### PR TITLE
fix: isolate repo-owned Codex review workflow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -11,18 +11,18 @@ permissions:
   pull-requests: write
   issues: write
 
-concurrency:
-  group: codex-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   review:
     if: |
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.type != 'Bot') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        github.event.comment.user.type != 'Bot' &&
-       contains(github.event.comment.body, '@codex'))
+       contains(github.event.comment.body, '@codex-actions'))
+    concurrency:
+      group: codex-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Key variables (see `driftshield/.env.example`):
 
 ## Automated PR Review
 
-Codex reviews every PR via `.github/workflows/codex-review.yml`. The review runs on `opened`, `synchronize` and `reopened` events. You can also tag `@codex` in a PR comment to trigger a review.
+Codex reviews every non-bot PR via `.github/workflows/codex-review.yml`. The review runs on `opened`, `synchronize` and `reopened` events. You can also tag `@codex-actions` in a PR comment to trigger the repo-owned review workflow.
 
 ### Review Priorities (ordered)
 


### PR DESCRIPTION
## Summary
- move Codex review concurrency to the review job so skipped bot-triggered workflows no longer cancel active runs
- switch the manual review trigger to `@codex-actions` so it does not collide with the external Codex connector
- skip bot-authored PRs and update the repo review guidance to match

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codex-review.yml"); puts "ok"'
- git diff --check