### PR TITLE
Improve CI and Dependabot workflow handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend-tests:
     runs-on: ubuntu-latest
@@ -13,12 +20,14 @@ jobs:
         working-directory: driftshield
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: driftshield/pyproject.toml
 
       - name: Install backend dependencies
         run: |
@@ -35,7 +44,7 @@ jobs:
         working-directory: driftshield/frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -53,18 +62,35 @@ jobs:
   frontend-e2e:
     runs-on: ubuntu-latest
     needs: frontend-build
-    if: >
-      github.event_name == 'push' ||
-      contains(join(github.event.pull_request.labels.*.name, ','), 'frontend') ||
-      true
     defaults:
       run:
         working-directory: driftshield/frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect whether e2e should run
+        id: should-run
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags origin "${{ github.base_ref }}"
+
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q '^driftshield/frontend/'; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
+        if: steps.should-run.outputs.run_e2e == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -72,12 +98,19 @@ jobs:
           cache-dependency-path: driftshield/frontend/package-lock.json
 
       - name: Install dependencies
+        if: steps.should-run.outputs.run_e2e == 'true'
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.should-run.outputs.run_e2e == 'true'
         run: npx playwright install chromium --with-deps
 
+      - name: Skip e2e when frontend is untouched
+        if: steps.should-run.outputs.run_e2e != 'true'
+        run: echo "No frontend changes in this PR; skipping Playwright run"
+
       - name: Check for e2e tests
+        if: steps.should-run.outputs.run_e2e == 'true'
         id: check-tests
         run: |
           if ls tests/e2e/*.spec.ts 2>/dev/null | grep -q .; then
@@ -88,13 +121,13 @@ jobs:
           fi
 
       - name: Run Playwright tests
-        if: steps.check-tests.outputs.has_tests == 'true'
+        if: steps.should-run.outputs.run_e2e == 'true' && steps.check-tests.outputs.has_tests == 'true'
         run: npx playwright test --reporter=list
         env:
           BASE_URL: http://localhost:5173
 
       - name: Upload Playwright report
-        if: failure()
+        if: failure() && steps.should-run.outputs.run_e2e == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -15,11 +15,12 @@ jobs:
   review:
     if: |
       (github.event_name == 'pull_request' &&
-       github.actor != 'dependabot[bot]' &&
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
        github.event.pull_request.user.type != 'Bot') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       github.actor != 'dependabot[bot]' &&
+       github.event.issue.user.login != 'dependabot[bot]' &&
+       github.event.issue.user.type != 'Bot' &&
        github.event.comment.user.type != 'Bot' &&
        contains(github.event.comment.body, '@codex-actions'))
     concurrency:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -15,9 +15,11 @@ jobs:
   review:
     if: |
       (github.event_name == 'pull_request' &&
+       github.actor != 'dependabot[bot]' &&
        github.event.pull_request.user.type != 'Bot') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       github.actor != 'dependabot[bot]' &&
        github.event.comment.user.type != 'Bot' &&
        contains(github.event.comment.body, '@codex-actions'))
     concurrency:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,72 @@
+name: Dependabot Automerge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-automerge:
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether this Dependabot PR is eligible
+        id: eligibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          pr_json=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title,files)
+          printf '%s\n' "$pr_json" > "$RUNNER_TEMP/pr.json"
+
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          allowed_files = {
+              "driftshield/frontend/package.json",
+              "driftshield/frontend/package-lock.json",
+              "driftshield/pyproject.toml",
+          }
+
+          pr = json.loads((Path(os.environ["RUNNER_TEMP"]) / "pr.json").read_text())
+          files = [entry["path"] for entry in pr["files"]]
+          files_ok = bool(files) and all(path in allowed_files for path in files)
+
+          match = re.search(r"from\s+([0-9]+(?:\.[0-9]+){0,2})\s+to\s+([0-9]+(?:\.[0-9]+){0,2})", pr["title"])
+          version_ok = False
+          if match:
+              before = tuple(int(part) for part in match.group(1).split("."))
+              after = tuple(int(part) for part in match.group(2).split("."))
+              version_ok = before and after and before[0] == after[0]
+
+          print(f"eligible={'true' if files_ok and version_ok else 'false'}")
+          PY
+
+      - name: Enable PR auto-merge
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if ! gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge; then
+            echo "Auto-merge is not available yet; leaving the PR open for manual merge"
+          fi


### PR DESCRIPTION
## Summary
- add concurrency and dependency caching to CI
- skip frontend e2e when a PR does not touch the frontend
- harden Codex review gating for bot-authored PRs
- add a conservative Dependabot auto-merge workflow for safe dependency bumps

## Verification
- ruby YAML parse for all workflow files
- git diff --check
- manual review of repo settings after enabling auto-merge, update-branch, and delete-branch-on-merge

## Notes
- the new Dependabot auto-merge workflow only targets non-major Dependabot PRs into `main` with a narrow allowed file set
- repo settings were updated to enable GitHub auto-merge and branch updates so the workflow can take effect