### PR TITLE
feat: add the first LangChain parser slice for #11

### DIFF
--- a/driftshield/docs/supported-sources.md
+++ b/driftshield/docs/supported-sources.md
@@ -6,6 +6,7 @@
 | Claude Desktop | Yes | Yes | Best-effort | DriftShield now looks for local artefacts under `~/.claude-desktop/sessions/`. Format support is currently bounded to the representative message/tool-call JSON shape covered by fixtures. |
 | Codex CLI | Yes | Yes | Best-effort | DriftShield now looks for local artefacts under `~/.codex/sessions/`. JSONL sessions with message and tool-call records are supported in this slice. |
 | Codex Desktop | Yes | Yes | Best-effort | DriftShield now looks for local artefacts under `~/.codex-desktop/sessions/`. JSON sessions with message arrays are supported in this slice. |
+| LangChain / LangSmith export JSON | No | Yes | No | Manual ingest via `--parser langchain`. Supported scope is bounded to exported run JSON with `inputs.messages`, `outputs.messages`, and tool child runs. |
 | OpenClaw agents | Yes | Yes | Yes | Existing OpenClaw session connectors remain unchanged. |
 
 ## Provenance

--- a/driftshield/src/driftshield/cli/commands/ingest.py
+++ b/driftshield/src/driftshield/cli/commands/ingest.py
@@ -40,7 +40,7 @@ def ingest(
         "auto",
         "--parser",
         "-p",
-        help="Parser to use (auto, claude_code).",
+        help="Parser to use (auto, claude_code, claude_desktop, codex_cli, codex_desktop, langchain, openclaw).",
     ),
 ) -> None:
     """Upload a transcript to the DriftShield ingest API."""

--- a/driftshield/src/driftshield/cli/parsers.py
+++ b/driftshield/src/driftshield/cli/parsers.py
@@ -6,6 +6,7 @@ from driftshield.parsers.claude_code import ClaudeCodeParser
 from driftshield.parsers.claude_desktop import ClaudeDesktopParser
 from driftshield.parsers.codex_cli import CodexCliParser
 from driftshield.parsers.codex_desktop import CodexDesktopParser
+from driftshield.parsers.langchain import LangChainParser
 from driftshield.parsers.openclaw import OpenClawParser
 from driftshield.parsers.protocol import TranscriptParser
 
@@ -19,6 +20,7 @@ PARSERS: dict[str, type[TranscriptParser]] = {
     "claude_desktop": ClaudeDesktopParser,
     "codex_cli": CodexCliParser,
     "codex_desktop": CodexDesktopParser,
+    "langchain": LangChainParser,
     "openclaw": OpenClawParser,
 }
 

--- a/driftshield/src/driftshield/parsers/langchain.py
+++ b/driftshield/src/driftshield/parsers/langchain.py
@@ -1,0 +1,264 @@
+"""Parser for LangSmith / LangChain exported run JSON."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from driftshield.core.models import CanonicalEvent, EventType
+
+
+class LangChainParser:
+    """Parse bounded LangSmith / LangChain exported run JSON into canonical events."""
+
+    def __init__(self) -> None:
+        self._default_agent_id = "langchain"
+
+    @property
+    def source_type(self) -> str:
+        return "langchain"
+
+    def parse_file(self, file_path: str) -> list[CanonicalEvent]:
+        return self.parse(Path(file_path).read_text())
+
+    def parse(self, content: str) -> list[CanonicalEvent]:
+        payload = json.loads(content)
+        runs = self._normalise_runs(payload)
+        if not runs:
+            return []
+
+        root_run = self._select_root_run(runs)
+        session_id = str(root_run.get("trace_id") or root_run.get("id") or "unknown")
+
+        ordered_runs = sorted(runs, key=self._run_sort_key)
+
+        events: list[CanonicalEvent] = []
+        previous_event_id: UUID | None = None
+
+        for message in self._extract_messages(root_run.get("inputs"), role="user"):
+            event = self._build_output_event(
+                session_id=session_id,
+                timestamp=self._parse_timestamp(root_run.get("start_time")),
+                parent_event_id=previous_event_id,
+                agent_id="user",
+                action="user_message",
+                text=message,
+                metadata={
+                    "source_type": self.source_type,
+                    "root_run_id": root_run.get("id"),
+                    "semantic_action_category": "user_input",
+                    "raw_action": "user_message",
+                },
+            )
+            events.append(event)
+            previous_event_id = event.id
+
+        for run in ordered_runs:
+            if str(run.get("run_type", "")).lower() != "tool":
+                continue
+            event = self._build_tool_event(
+                run=run,
+                session_id=session_id,
+                parent_event_id=previous_event_id,
+            )
+            events.append(event)
+            previous_event_id = event.id
+
+        for message in self._extract_messages(root_run.get("outputs"), role="assistant"):
+            event = self._build_output_event(
+                session_id=session_id,
+                timestamp=self._parse_timestamp(root_run.get("end_time") or root_run.get("start_time")),
+                parent_event_id=previous_event_id,
+                agent_id=self._default_agent_id,
+                action="assistant_narrative",
+                text=message,
+                metadata={
+                    "source_type": self.source_type,
+                    "root_run_id": root_run.get("id"),
+                    "semantic_action_category": "reasoning",
+                    "raw_action": "assistant_narrative",
+                },
+            )
+            events.append(event)
+            previous_event_id = event.id
+
+        return events
+
+    def _normalise_runs(self, payload: dict | list) -> list[dict]:
+        if isinstance(payload, list):
+            runs = [run for run in payload if isinstance(run, dict)]
+            nested_runs: list[dict] = []
+            for run in runs:
+                nested_runs.extend(self._flatten_child_runs(run))
+            return self._deduplicate_runs([*runs, *nested_runs])
+
+        if not isinstance(payload, dict):
+            return []
+
+        runs = [payload]
+        runs.extend(self._flatten_child_runs(payload))
+        return self._deduplicate_runs(runs)
+
+    def _flatten_child_runs(self, run: dict) -> list[dict]:
+        flattened: list[dict] = []
+        for child in run.get("child_runs") or []:
+            if not isinstance(child, dict):
+                continue
+            flattened.append(child)
+            flattened.extend(self._flatten_child_runs(child))
+        return flattened
+
+    def _deduplicate_runs(self, runs: list[dict]) -> list[dict]:
+        deduped: dict[str, dict] = {}
+        anonymous: list[dict] = []
+        for run in runs:
+            run_id = run.get("id")
+            if run_id is None:
+                anonymous.append(run)
+                continue
+            deduped[str(run_id)] = run
+        return [*deduped.values(), *anonymous]
+
+    def _select_root_run(self, runs: list[dict]) -> dict:
+        roots = [run for run in runs if not run.get("parent_run_id")]
+        if not roots:
+            roots = runs
+        return sorted(roots, key=self._run_sort_key)[0]
+
+    def _run_sort_key(self, run: dict) -> tuple[int, float, str]:
+        execution_order = run.get("dotted_order") or run.get("execution_order")
+        if isinstance(execution_order, str):
+            parts = []
+            for piece in execution_order.replace(":", ".").split("."):
+                if piece.isdigit():
+                    parts.append(int(piece))
+            if parts:
+                return (0, float(parts[-1]), str(run.get("id") or ""))
+        if isinstance(execution_order, (int, float)):
+            return (0, float(execution_order), str(run.get("id") or ""))
+
+        timestamp = self._parse_timestamp(run.get("start_time"))
+        return (1, timestamp.timestamp(), str(run.get("id") or ""))
+
+    def _build_output_event(
+        self,
+        *,
+        session_id: str,
+        timestamp: datetime,
+        parent_event_id: UUID | None,
+        agent_id: str,
+        action: str,
+        text: str,
+        metadata: dict,
+    ) -> CanonicalEvent:
+        return CanonicalEvent(
+            id=uuid4(),
+            session_id=session_id,
+            timestamp=timestamp,
+            event_type=EventType.OUTPUT,
+            agent_id=agent_id,
+            action=action,
+            parent_event_id=parent_event_id,
+            inputs={},
+            outputs={"text": text},
+            metadata=metadata,
+        )
+
+    def _build_tool_event(
+        self,
+        *,
+        run: dict,
+        session_id: str,
+        parent_event_id: UUID | None,
+    ) -> CanonicalEvent:
+        outputs = {"result": run.get("outputs")}
+        if run.get("error"):
+            outputs["error"] = run.get("error")
+
+        metadata = {
+            "source_type": self.source_type,
+            "run_id": run.get("id"),
+            "parent_run_id": run.get("parent_run_id"),
+            "trace_id": run.get("trace_id"),
+            "run_type": run.get("run_type"),
+            "raw_action": run.get("name"),
+            "semantic_action_category": "other",
+        }
+        if run.get("error"):
+            metadata["error"] = run.get("error")
+
+        return CanonicalEvent(
+            id=uuid4(),
+            session_id=session_id,
+            timestamp=self._parse_timestamp(run.get("start_time")),
+            event_type=EventType.TOOL_CALL,
+            agent_id=self._default_agent_id,
+            action=str(run.get("name") or "tool"),
+            parent_event_id=parent_event_id,
+            inputs=self._coerce_dict(run.get("inputs")),
+            outputs=outputs,
+            metadata=metadata,
+        )
+
+    def _extract_messages(self, payload: object, *, role: str) -> list[str]:
+        if not isinstance(payload, dict):
+            return []
+
+        messages = payload.get("messages")
+        if not isinstance(messages, list):
+            return []
+
+        extracted: list[str] = []
+        for message in messages:
+            text = self._message_text(message, role=role)
+            if text:
+                extracted.append(text)
+        return extracted
+
+    def _message_text(self, message: object, *, role: str) -> str:
+        if not isinstance(message, dict):
+            return ""
+
+        message_role = str(message.get("role") or message.get("type") or "").lower()
+        if role == "user" and message_role not in {"human", "user"}:
+            return ""
+        if role == "assistant" and message_role not in {"ai", "assistant"}:
+            return ""
+
+        content = message.get("content")
+        return self._content_to_text(content)
+
+    def _content_to_text(self, content: object) -> str:
+        if isinstance(content, str):
+            return content.strip()
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str) and item.strip():
+                    parts.append(item.strip())
+                elif isinstance(item, dict):
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        parts.append(text.strip())
+                    elif item.get("type") == "text":
+                        value = item.get("value")
+                        if isinstance(value, str) and value.strip():
+                            parts.append(value.strip())
+            return "\n".join(parts)
+        if isinstance(content, dict):
+            text = content.get("text") or content.get("value")
+            if isinstance(text, str):
+                return text.strip()
+        return ""
+
+    def _coerce_dict(self, value: object) -> dict:
+        return value if isinstance(value, dict) else {}
+
+    def _parse_timestamp(self, value: str | int | float | None) -> datetime:
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/driftshield/src/driftshield/parsers/langchain.py
+++ b/driftshield/src/driftshield/parsers/langchain.py
@@ -309,5 +309,5 @@ class LangChainParser:
         if value is None:
             return datetime.now(timezone.utc)
         if isinstance(value, (int, float)):
-            return datetime.fromtimestamp(value, tz=timezone.utc)
+            return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
         return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/driftshield/src/driftshield/parsers/langchain.py
+++ b/driftshield/src/driftshield/parsers/langchain.py
@@ -31,8 +31,8 @@ class LangChainParser:
 
         root_run = self._select_root_run(runs)
         session_id = str(root_run.get("trace_id") or root_run.get("id") or "unknown")
-
-        ordered_runs = sorted(runs, key=self._run_sort_key)
+        scoped_runs = self._runs_for_root(runs, root_run)
+        ordered_runs = sorted(scoped_runs, key=self._run_sort_key)
 
         events: list[CanonicalEvent] = []
         previous_event_id: UUID | None = None
@@ -127,20 +127,71 @@ class LangChainParser:
             roots = runs
         return sorted(roots, key=self._run_sort_key)[0]
 
-    def _run_sort_key(self, run: dict) -> tuple[int, float, str]:
+    def _runs_for_root(self, runs: list[dict], root_run: dict) -> list[dict]:
+        root_id = root_run.get("id")
+        root_trace_id = root_run.get("trace_id")
+        descendant_ids = self._collect_descendant_ids(runs, root_id)
+
+        scoped_runs: list[dict] = []
+        for run in runs:
+            run_id = run.get("id")
+            if run is root_run:
+                scoped_runs.append(run)
+                continue
+            if run_id is not None and str(run_id) in descendant_ids:
+                scoped_runs.append(run)
+                continue
+            if root_id is None and root_trace_id is not None and run.get("trace_id") == root_trace_id:
+                scoped_runs.append(run)
+        return scoped_runs
+
+    def _collect_descendant_ids(self, runs: list[dict], root_id: object) -> set[str]:
+        if root_id is None:
+            return set()
+
+        children_by_parent: dict[str, list[str]] = {}
+        for run in runs:
+            run_id = run.get("id")
+            parent_id = run.get("parent_run_id")
+            if run_id is None or parent_id is None:
+                continue
+            children_by_parent.setdefault(str(parent_id), []).append(str(run_id))
+
+        descendants: set[str] = set()
+        stack = [str(root_id)]
+        while stack:
+            current = stack.pop()
+            for child_id in children_by_parent.get(current, []):
+                if child_id in descendants:
+                    continue
+                descendants.add(child_id)
+                stack.append(child_id)
+        return descendants
+
+    def _run_sort_key(self, run: dict) -> tuple[int, tuple[int, ...], float, str]:
         execution_order = run.get("dotted_order") or run.get("execution_order")
-        if isinstance(execution_order, str):
-            parts = []
-            for piece in execution_order.replace(":", ".").split("."):
-                if piece.isdigit():
-                    parts.append(int(piece))
-            if parts:
-                return (0, float(parts[-1]), str(run.get("id") or ""))
-        if isinstance(execution_order, (int, float)):
-            return (0, float(execution_order), str(run.get("id") or ""))
+        order_parts = self._execution_order_parts(execution_order)
+        if order_parts is not None:
+            return (0, order_parts, 0.0, str(run.get("id") or ""))
 
         timestamp = self._parse_timestamp(run.get("start_time"))
-        return (1, timestamp.timestamp(), str(run.get("id") or ""))
+        return (1, (), timestamp.timestamp(), str(run.get("id") or ""))
+
+    def _execution_order_parts(self, value: object) -> tuple[int, ...] | None:
+        if isinstance(value, int):
+            return (value,)
+        if isinstance(value, float):
+            return (int(value),)
+        if isinstance(value, str):
+            parts: list[int] = []
+            for piece in value.replace(":", ".").split("."):
+                if not piece:
+                    continue
+                if not piece.isdigit():
+                    return None
+                parts.append(int(piece))
+            return tuple(parts) if parts else None
+        return None
 
     def _build_output_event(
         self,

--- a/driftshield/src/driftshield/parsers/langchain.py
+++ b/driftshield/src/driftshield/parsers/langchain.py
@@ -168,7 +168,7 @@ class LangChainParser:
                 stack.append(child_id)
         return descendants
 
-    def _run_sort_key(self, run: dict) -> tuple[int, tuple[int, ...], float, str]:
+    def _run_sort_key(self, run: dict) -> tuple[int, tuple[tuple[int, int | str], ...], float, str]:
         execution_order = run.get("dotted_order") or run.get("execution_order")
         order_parts = self._execution_order_parts(execution_order)
         if order_parts is not None:
@@ -177,20 +177,18 @@ class LangChainParser:
         timestamp = self._parse_timestamp(run.get("start_time"))
         return (1, (), timestamp.timestamp(), str(run.get("id") or ""))
 
-    def _execution_order_parts(self, value: object) -> tuple[int, ...] | None:
+    def _execution_order_parts(self, value: object) -> tuple[tuple[int, int | str], ...] | None:
         if isinstance(value, int):
-            return (value,)
+            return ((0, value),)
         if isinstance(value, float):
-            return (int(value),)
+            return ((0, int(value)),)
         if isinstance(value, str):
-            parts: list[int] = []
-            for piece in value.replace(":", ".").split("."):
-                if not piece:
-                    continue
-                if not piece.isdigit():
-                    return None
-                parts.append(int(piece))
-            return tuple(parts) if parts else None
+            pieces = [piece for piece in value.split(".") if piece]
+            if not pieces:
+                return None
+            if all(piece.isdigit() for piece in pieces):
+                return tuple((0, int(piece)) for piece in pieces)
+            return tuple((1, piece) for piece in pieces)
         return None
 
     def _build_output_event(

--- a/driftshield/tests/cli/test_parsers.py
+++ b/driftshield/tests/cli/test_parsers.py
@@ -8,6 +8,7 @@ from driftshield.cli.parsers import ParserNotFoundError, detect_parser, get_pars
 from driftshield.parsers.claude_desktop import ClaudeDesktopParser
 from driftshield.parsers.codex_cli import CodexCliParser
 from driftshield.parsers.codex_desktop import CodexDesktopParser
+from driftshield.parsers.langchain import LangChainParser
 
 
 class TestGetParser:
@@ -34,6 +35,10 @@ class TestGetParser:
     def test_get_codex_desktop_parser(self):
         parser = get_parser("codex_desktop")
         assert isinstance(parser, CodexDesktopParser)
+
+    def test_get_langchain_parser(self):
+        parser = get_parser("langchain")
+        assert isinstance(parser, LangChainParser)
 
     def test_unknown_parser_raises(self):
         with pytest.raises(ParserNotFoundError) as exc_info:

--- a/driftshield/tests/fixtures/transcripts/sample_langchain_session.json
+++ b/driftshield/tests/fixtures/transcripts/sample_langchain_session.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "run-root-1",
+    "trace_id": "trace-issue-11",
+    "name": "AgentExecutor",
+    "run_type": "chain",
+    "start_time": "2026-04-19T08:00:00Z",
+    "end_time": "2026-04-19T08:00:07Z",
+    "inputs": {
+      "messages": [
+        {
+          "role": "human",
+          "content": "Please inspect the README and summarise the risks."
+        }
+      ]
+    },
+    "outputs": {
+      "messages": [
+        {
+          "role": "ai",
+          "content": "I inspected the README and found no immediate risks."
+        }
+      ]
+    },
+    "error": null
+  },
+  {
+    "id": "run-tool-1",
+    "trace_id": "trace-issue-11",
+    "parent_run_id": "run-root-1",
+    "name": "read_file",
+    "run_type": "tool",
+    "start_time": "2026-04-19T08:00:03Z",
+    "end_time": "2026-04-19T08:00:04Z",
+    "execution_order": 2,
+    "inputs": {
+      "file_path": "README.md"
+    },
+    "outputs": {
+      "content": "# DriftShield"
+    },
+    "error": "permission warning preserved for analysis"
+  }
+]

--- a/driftshield/tests/parsers/test_langchain.py
+++ b/driftshield/tests/parsers/test_langchain.py
@@ -260,6 +260,38 @@ class TestLangChainParser:
             "assistant_narrative",
         ]
 
+    def test_parses_epoch_millisecond_timestamps(self):
+        parser = LangChainParser()
+        payload = {
+            "id": "root-ms",
+            "trace_id": "trace-ms",
+            "name": "root",
+            "run_type": "chain",
+            "start_time": 1713513600000,
+            "end_time": 1713513603000,
+            "inputs": {"messages": [{"role": "human", "content": "Run tools"}]},
+            "outputs": {"messages": [{"role": "ai", "content": "Done"}]},
+            "child_runs": [
+                {
+                    "id": "tool-ms",
+                    "trace_id": "trace-ms",
+                    "parent_run_id": "root-ms",
+                    "name": "tool_ms",
+                    "run_type": "tool",
+                    "start_time": 1713513601000,
+                    "inputs": {},
+                    "outputs": {"status": "ok"},
+                }
+            ],
+        }
+
+        events = parser.parse(json.dumps(payload))
+
+        assert len(events) == 3
+        assert events[0].timestamp.isoformat() == "2024-04-19T08:00:00+00:00"
+        assert events[1].timestamp.isoformat() == "2024-04-19T08:00:01+00:00"
+        assert events[2].timestamp.isoformat() == "2024-04-19T08:00:03+00:00"
+
     def test_source_type_is_langchain(self):
         parser = LangChainParser()
         assert parser.source_type == "langchain"

--- a/driftshield/tests/parsers/test_langchain.py
+++ b/driftshield/tests/parsers/test_langchain.py
@@ -214,6 +214,52 @@ class TestLangChainParser:
             "assistant_narrative",
         ]
 
+    def test_orders_native_langsmith_dotted_order_safely(self):
+        parser = LangChainParser()
+        payload = [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "trace_id": "trace-native-dotted",
+                "name": "root",
+                "run_type": "chain",
+                "start_time": "2026-04-19T12:00:00Z",
+                "inputs": {"messages": [{"role": "human", "content": "Run tools"}]},
+                "outputs": {"messages": [{"role": "ai", "content": "Done"}]},
+                "dotted_order": "20260419T120000000000Z00000000-0000-0000-0000-000000000001",
+            },
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "trace_id": "trace-native-dotted",
+                "parent_run_id": "00000000-0000-0000-0000-000000000001",
+                "name": "second_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T12:00:01Z",
+                "inputs": {},
+                "outputs": {"status": "second"},
+                "dotted_order": "20260419T120000000000Z00000000-0000-0000-0000-000000000001.20260419T120002000000Z00000000-0000-0000-0000-000000000002",
+            },
+            {
+                "id": "00000000-0000-0000-0000-000000000010",
+                "trace_id": "trace-native-dotted",
+                "parent_run_id": "00000000-0000-0000-0000-000000000001",
+                "name": "first_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T12:00:01Z",
+                "inputs": {},
+                "outputs": {"status": "first"},
+                "dotted_order": "20260419T120000000000Z00000000-0000-0000-0000-000000000001.20260419T120001000000Z00000000-0000-0000-0000-000000000010",
+            },
+        ]
+
+        events = parser.parse(json.dumps(payload))
+
+        assert [event.action for event in events] == [
+            "user_message",
+            "first_tool",
+            "second_tool",
+            "assistant_narrative",
+        ]
+
     def test_source_type_is_langchain(self):
         parser = LangChainParser()
         assert parser.source_type == "langchain"

--- a/driftshield/tests/parsers/test_langchain.py
+++ b/driftshield/tests/parsers/test_langchain.py
@@ -116,6 +116,104 @@ class TestLangChainParser:
             "assistant_narrative",
         ]
 
+    def test_filters_out_other_roots_and_traces_from_same_export(self):
+        parser = LangChainParser()
+        payload = [
+            {
+                "id": "root-a",
+                "trace_id": "trace-a",
+                "name": "AgentExecutor",
+                "run_type": "chain",
+                "start_time": "2026-04-19T11:00:00Z",
+                "inputs": {"messages": [{"role": "human", "content": "Inspect README."}]},
+                "outputs": {"messages": [{"role": "ai", "content": "README inspected."}]},
+            },
+            {
+                "id": "tool-a",
+                "trace_id": "trace-a",
+                "parent_run_id": "root-a",
+                "name": "read_file",
+                "run_type": "tool",
+                "start_time": "2026-04-19T11:00:01Z",
+                "inputs": {"file_path": "README.md"},
+                "outputs": {"status": "ok"},
+            },
+            {
+                "id": "root-b",
+                "trace_id": "trace-b",
+                "name": "OtherRoot",
+                "run_type": "chain",
+                "start_time": "2026-04-19T11:00:02Z",
+                "inputs": {"messages": [{"role": "human", "content": "Ignore this trace."}]},
+                "outputs": {"messages": [{"role": "ai", "content": "Ignored."}]},
+            },
+            {
+                "id": "tool-b",
+                "trace_id": "trace-b",
+                "parent_run_id": "root-b",
+                "name": "foreign_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T11:00:03Z",
+                "inputs": {"file_path": "OTHER.md"},
+                "outputs": {"status": "foreign"},
+            },
+        ]
+
+        events = parser.parse(json.dumps(payload))
+
+        assert [event.action for event in events] == [
+            "user_message",
+            "read_file",
+            "assistant_narrative",
+        ]
+        assert all(event.session_id == "trace-a" for event in events)
+        assert all(event.metadata.get("trace_id") != "trace-b" for event in events if event.event_type == EventType.TOOL_CALL)
+
+    def test_orders_hierarchical_dotted_order_safely(self):
+        parser = LangChainParser()
+        payload = [
+            {
+                "id": "root",
+                "trace_id": "trace-dotted-order",
+                "name": "AgentExecutor",
+                "run_type": "chain",
+                "start_time": "2026-04-19T12:00:00Z",
+                "inputs": {"messages": [{"role": "human", "content": "Run nested tools."}]},
+                "outputs": {"messages": [{"role": "ai", "content": "Nested tools done."}]},
+            },
+            {
+                "id": "tool-2-1",
+                "trace_id": "trace-dotted-order",
+                "parent_run_id": "root",
+                "name": "later_branch_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T12:00:03Z",
+                "dotted_order": "2.1",
+                "inputs": {},
+                "outputs": {"status": "later"},
+            },
+            {
+                "id": "tool-1-10",
+                "trace_id": "trace-dotted-order",
+                "parent_run_id": "root",
+                "name": "earlier_branch_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T12:00:04Z",
+                "dotted_order": "1.10",
+                "inputs": {},
+                "outputs": {"status": "earlier"},
+            },
+        ]
+
+        events = parser.parse(json.dumps(payload))
+
+        assert [event.action for event in events] == [
+            "user_message",
+            "earlier_branch_tool",
+            "later_branch_tool",
+            "assistant_narrative",
+        ]
+
     def test_source_type_is_langchain(self):
         parser = LangChainParser()
         assert parser.source_type == "langchain"

--- a/driftshield/tests/parsers/test_langchain.py
+++ b/driftshield/tests/parsers/test_langchain.py
@@ -1,0 +1,121 @@
+"""Tests for the LangChain transcript parser."""
+
+import json
+from pathlib import Path
+
+from driftshield.core.models import EventType
+from driftshield.parsers.langchain import LangChainParser
+
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "transcripts"
+
+
+class TestLangChainParser:
+    def test_parses_representative_langsmith_export_fixture(self):
+        parser = LangChainParser()
+        events = parser.parse_file(str(FIXTURES_DIR / "sample_langchain_session.json"))
+
+        assert [event.event_type for event in events] == [
+            EventType.OUTPUT,
+            EventType.TOOL_CALL,
+            EventType.OUTPUT,
+        ]
+        assert [event.action for event in events] == [
+            "user_message",
+            "read_file",
+            "assistant_narrative",
+        ]
+        assert all(event.session_id == "trace-issue-11" for event in events)
+        assert events[0].outputs["text"] == "Please inspect the README and summarise the risks."
+        assert events[1].inputs == {"file_path": "README.md"}
+        assert events[1].outputs["result"] == {"content": "# DriftShield"}
+        assert events[1].outputs["error"] == "permission warning preserved for analysis"
+        assert events[1].metadata["semantic_action_category"] == "other"
+        assert events[2].outputs["text"] == "I inspected the README and found no immediate risks."
+
+    def test_parse_accepts_single_root_object_with_child_runs(self):
+        parser = LangChainParser()
+        payload = {
+            "id": "root-run",
+            "trace_id": "trace-single-object",
+            "name": "AgentExecutor",
+            "run_type": "chain",
+            "start_time": "2026-04-19T09:00:00Z",
+            "end_time": "2026-04-19T09:00:03Z",
+            "inputs": {
+                "messages": [{"role": "human", "content": "Check parser wiring."}]
+            },
+            "outputs": {
+                "messages": [{"role": "ai", "content": "Parser wiring looks good."}]
+            },
+            "child_runs": [
+                {
+                    "id": "tool-run",
+                    "trace_id": "trace-single-object",
+                    "parent_run_id": "root-run",
+                    "name": "lookup_fixture",
+                    "run_type": "tool",
+                    "start_time": "2026-04-19T09:00:01Z",
+                    "inputs": {"path": "tests/fixtures/transcripts/sample_langchain_session.json"},
+                    "outputs": {"status": "ok"},
+                    "error": None,
+                }
+            ],
+        }
+
+        events = parser.parse(json.dumps(payload))
+
+        assert len(events) == 3
+        assert events[0].session_id == "trace-single-object"
+        assert events[1].action == "lookup_fixture"
+        assert events[1].outputs["result"] == {"status": "ok"}
+        assert events[2].outputs["text"] == "Parser wiring looks good."
+
+    def test_orders_tool_runs_by_execution_order_when_available(self):
+        parser = LangChainParser()
+        payload = [
+            {
+                "id": "root",
+                "trace_id": "trace-ordering",
+                "name": "AgentExecutor",
+                "run_type": "chain",
+                "start_time": "2026-04-19T10:00:00Z",
+                "inputs": {"messages": [{"role": "human", "content": "Do two tool calls."}]},
+                "outputs": {"messages": [{"role": "ai", "content": "Done."}]},
+            },
+            {
+                "id": "tool-late",
+                "trace_id": "trace-ordering",
+                "parent_run_id": "root",
+                "name": "second_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T10:00:03Z",
+                "execution_order": 20,
+                "inputs": {},
+                "outputs": {"status": "second"},
+            },
+            {
+                "id": "tool-early",
+                "trace_id": "trace-ordering",
+                "parent_run_id": "root",
+                "name": "first_tool",
+                "run_type": "tool",
+                "start_time": "2026-04-19T10:00:04Z",
+                "execution_order": 10,
+                "inputs": {},
+                "outputs": {"status": "first"},
+            },
+        ]
+
+        events = parser.parse(json.dumps(payload))
+
+        assert [event.action for event in events] == [
+            "user_message",
+            "first_tool",
+            "second_tool",
+            "assistant_narrative",
+        ]
+
+    def test_source_type_is_langchain(self):
+        parser = LangChainParser()
+        assert parser.source_type == "langchain"


### PR DESCRIPTION
## Summary
- add a bounded `langchain` parser for LangSmith / LangChain exported run JSON
- wire the parser into the registry and cover it with parser registry tests
- add one representative fixture, parser tests, and a small supported-sources note

## Validation
- `PYTHONPATH=src pytest tests/parsers/test_langchain.py tests/cli/test_parsers.py tests/parsers/test_local_sources.py -q`
- `PYTHONPATH=src python3 -m driftshield.cli.main analyze tests/fixtures/transcripts/sample_langchain_session.json --parser langchain --json`

## Notes
This stays within the accepted first slice: root input/output messages, tool child runs, sensible ordering, and preserved error context.

Closes #11
Refs tborys/driftshield-meta#22
