### PR TITLE
Build the first community signature pack

### DIFF
--- a/driftshield/pyproject.toml
+++ b/driftshield/pyproject.toml
@@ -40,6 +40,11 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/driftshield"]
 
+[tool.hatch.build]
+include = [
+    "src/driftshield/signatures/packs/*.json",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/driftshield/src/driftshield/signatures/__init__.py
+++ b/driftshield/src/driftshield/signatures/__init__.py
@@ -108,9 +108,19 @@ def _as_tuple(values: Sequence[str]) -> tuple[str, ...]:
     return tuple(values)
 
 
+from driftshield.signatures.community import (
+    CommunityPack,
+    CommunityPackManifest,
+    load_builtin_community_pack,
+)
+
+
 __all__ = [
+    "CommunityPack",
+    "CommunityPackManifest",
     "SignatureDefinition",
     "SignaturePackMetadata",
     "SignatureProvider",
     "SignatureSeverity",
+    "load_builtin_community_pack",
 ]

--- a/driftshield/src/driftshield/signatures/community.py
+++ b/driftshield/src/driftshield/signatures/community.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from importlib import resources
+from importlib.abc import Traversable
 from pathlib import Path
 from typing import Any
 
@@ -50,26 +51,27 @@ def load_builtin_community_pack() -> CommunityPackManifest:
     return load_community_pack(package_file)
 
 
-def load_community_pack(path: str | Path) -> CommunityPackManifest:
+def load_community_pack(path: str | Path | Traversable) -> CommunityPackManifest:
     """Load and validate a Phase 2a community pack manifest from JSON."""
 
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    payload = json.loads(_read_manifest_text(path))
     return parse_community_pack(payload)
 
 
-def parse_community_pack(payload: Mapping[str, Any]) -> CommunityPackManifest:
+def parse_community_pack(payload: Any) -> CommunityPackManifest:
     """Validate a raw Phase 2a community pack manifest and project it to the OSS seam."""
 
+    manifest_payload = _require_mapping(payload, field_name="manifest")
     schema_version = _require_non_empty_string(
-        payload.get("schema_version"), field_name="schema_version"
+        manifest_payload.get("schema_version"), field_name="schema_version"
     )
     _validate_schema_version(schema_version)
 
     metadata_payload = _require_mapping(
-        payload.get("pack_metadata"), field_name="pack_metadata"
+        manifest_payload.get("pack_metadata"), field_name="pack_metadata"
     )
     signatures_payload = _require_sequence(
-        payload.get("signatures"), field_name="signatures"
+        manifest_payload.get("signatures"), field_name="signatures"
     )
 
     metadata = SignaturePackMetadata(
@@ -93,8 +95,14 @@ def parse_community_pack(payload: Mapping[str, Any]) -> CommunityPackManifest:
         )
     )
 
-    signatures = tuple(_parse_signature(item) for item in signatures_payload)
-    _validate_family_coverage(family_coverage=family_coverage, signatures=signatures)
+    parsed_signatures = tuple(_parse_signature(item) for item in signatures_payload)
+    family_ids = tuple(family_id for family_id, _ in parsed_signatures)
+    signatures = tuple(definition for _, definition in parsed_signatures)
+    _validate_family_coverage(
+        family_coverage=family_coverage,
+        signature_family_ids=family_ids,
+        signatures=signatures,
+    )
 
     return CommunityPackManifest(
         schema_version=schema_version,
@@ -105,16 +113,16 @@ def parse_community_pack(payload: Mapping[str, Any]) -> CommunityPackManifest:
     )
 
 
-def _parse_signature(payload: Any) -> SignatureDefinition:
+def _parse_signature(payload: Any) -> tuple[str, SignatureDefinition]:
     signature_payload = _require_mapping(payload, field_name="signatures[]")
-    _require_non_empty_string(
+    family_id = _require_non_empty_string(
         signature_payload.get("family_id"), field_name="signatures[].family_id"
     )
     _require_mapping(
         signature_payload.get("signature_layer"), field_name="signatures[].signature_layer"
     )
 
-    return SignatureDefinition(
+    return family_id, SignatureDefinition(
         signature_id=_require_non_empty_string(
             signature_payload.get("signature_id"), field_name="signatures[].signature_id"
         ),
@@ -159,7 +167,10 @@ def _validate_schema_version(schema_version: str) -> None:
 
 
 def _validate_family_coverage(
-    *, family_coverage: Sequence[str], signatures: Sequence[SignatureDefinition]
+    *,
+    family_coverage: Sequence[str],
+    signature_family_ids: Sequence[str],
+    signatures: Sequence[SignatureDefinition],
 ) -> None:
     if len(set(family_coverage)) != len(family_coverage):
         raise ValueError("pack_metadata.family_coverage must not contain duplicates")
@@ -170,6 +181,17 @@ def _validate_family_coverage(
     signature_count = len(signatures)
     if signature_count and not family_coverage:
         raise ValueError("pack_metadata.family_coverage is required when signatures are present")
+
+    if signature_count and set(family_coverage) != set(signature_family_ids):
+        raise ValueError(
+            "pack_metadata.family_coverage must match the family_id values declared by signatures"
+        )
+
+
+def _read_manifest_text(path: str | Path | Traversable) -> str:
+    if hasattr(path, "read_text"):
+        return path.read_text(encoding="utf-8")
+    return Path(path).read_text(encoding="utf-8")
 
 
 def _require_mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:

--- a/driftshield/src/driftshield/signatures/community.py
+++ b/driftshield/src/driftshield/signatures/community.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from driftshield.signatures import (
+    SignatureDefinition,
+    SignaturePackMetadata,
+    SignatureProvider,
+    SignatureSeverity,
+)
+
+SUPPORTED_SCHEMA_MAJOR = 1
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityPackManifest:
+    """Validated Phase 2a community pack manifest."""
+
+    schema_version: str
+    metadata: SignaturePackMetadata
+    family_coverage: tuple[str, ...]
+    pack_kind: str
+    signatures: tuple[SignatureDefinition, ...]
+
+
+class CommunityPack(SignatureProvider):
+    """Provider wrapper over a validated Phase 2a community pack manifest."""
+
+    def __init__(self, manifest: CommunityPackManifest) -> None:
+        self.manifest = manifest
+
+    def describe(self) -> SignaturePackMetadata:
+        return self.manifest.metadata
+
+    def iter_signatures(self) -> Iterable[SignatureDefinition]:
+        return iter(self.manifest.signatures)
+
+
+def load_builtin_community_pack() -> CommunityPackManifest:
+    """Load the bundled community pack manifest shipped with the OSS package."""
+
+    package_file = (
+        resources.files("driftshield.signatures") / "packs" / "community-general.json"
+    )
+    return load_community_pack(package_file)
+
+
+def load_community_pack(path: str | Path) -> CommunityPackManifest:
+    """Load and validate a Phase 2a community pack manifest from JSON."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return parse_community_pack(payload)
+
+
+def parse_community_pack(payload: Mapping[str, Any]) -> CommunityPackManifest:
+    """Validate a raw Phase 2a community pack manifest and project it to the OSS seam."""
+
+    schema_version = _require_non_empty_string(
+        payload.get("schema_version"), field_name="schema_version"
+    )
+    _validate_schema_version(schema_version)
+
+    metadata_payload = _require_mapping(
+        payload.get("pack_metadata"), field_name="pack_metadata"
+    )
+    signatures_payload = _require_sequence(
+        payload.get("signatures"), field_name="signatures"
+    )
+
+    metadata = SignaturePackMetadata(
+        name=_require_non_empty_string(metadata_payload.get("name"), field_name="pack_metadata.name"),
+        version=_require_non_empty_string(
+            metadata_payload.get("version"), field_name="pack_metadata.version"
+        ),
+        description=_require_non_empty_string(
+            metadata_payload.get("description"), field_name="pack_metadata.description"
+        ),
+        homepage_url=_optional_non_empty_string(metadata_payload.get("homepage_url")),
+        documentation_url=_optional_non_empty_string(metadata_payload.get("documentation_url")),
+    )
+    pack_kind = _require_non_empty_string(
+        metadata_payload.get("pack_kind"), field_name="pack_metadata.pack_kind"
+    )
+    family_coverage = tuple(
+        _require_non_empty_string(family_id, field_name="pack_metadata.family_coverage[]")
+        for family_id in _require_sequence(
+            metadata_payload.get("family_coverage"), field_name="pack_metadata.family_coverage"
+        )
+    )
+
+    signatures = tuple(_parse_signature(item) for item in signatures_payload)
+    _validate_family_coverage(family_coverage=family_coverage, signatures=signatures)
+
+    return CommunityPackManifest(
+        schema_version=schema_version,
+        metadata=metadata,
+        family_coverage=family_coverage,
+        pack_kind=pack_kind,
+        signatures=signatures,
+    )
+
+
+def _parse_signature(payload: Any) -> SignatureDefinition:
+    signature_payload = _require_mapping(payload, field_name="signatures[]")
+    _require_non_empty_string(
+        signature_payload.get("family_id"), field_name="signatures[].family_id"
+    )
+    _require_mapping(
+        signature_payload.get("signature_layer"), field_name="signatures[].signature_layer"
+    )
+
+    return SignatureDefinition(
+        signature_id=_require_non_empty_string(
+            signature_payload.get("signature_id"), field_name="signatures[].signature_id"
+        ),
+        title=_require_non_empty_string(
+            signature_payload.get("title"), field_name="signatures[].title"
+        ),
+        summary=_derive_summary(signature_payload),
+        failure_shape=_require_non_empty_string(
+            signature_payload.get("failure_shape"), field_name="signatures[].failure_shape"
+        ),
+        severity=_parse_severity(signature_payload.get("severity")),
+        lexical_markers=_parse_string_sequence(
+            signature_payload.get("lexical_markers", ()), field_name="signatures[].lexical_markers"
+        ),
+        temporal_constraints=_parse_string_sequence(
+            signature_payload.get("temporal_constraints", ()),
+            field_name="signatures[].temporal_constraints",
+        ),
+        tags=_parse_string_sequence(signature_payload.get("tags", ()), field_name="signatures[].tags"),
+    )
+
+
+def _derive_summary(payload: Mapping[str, Any]) -> str:
+    summary = _optional_non_empty_string(payload.get("summary"))
+    if summary is not None:
+        return summary
+
+    signature_layer = _require_mapping(
+        payload.get("signature_layer"), field_name="signatures[].signature_layer"
+    )
+    return _require_non_empty_string(
+        signature_layer.get("symptom"), field_name="signatures[].signature_layer.symptom"
+    )
+
+
+def _validate_schema_version(schema_version: str) -> None:
+    major_token = schema_version.split(".", maxsplit=1)[0]
+    if not major_token.isdigit() or int(major_token) != SUPPORTED_SCHEMA_MAJOR:
+        raise ValueError(
+            f"unsupported schema_version {schema_version!r}; expected major version {SUPPORTED_SCHEMA_MAJOR}"
+        )
+
+
+def _validate_family_coverage(
+    *, family_coverage: Sequence[str], signatures: Sequence[SignatureDefinition]
+) -> None:
+    if len(set(family_coverage)) != len(family_coverage):
+        raise ValueError("pack_metadata.family_coverage must not contain duplicates")
+
+    if not signatures and family_coverage:
+        raise ValueError("pack_metadata.family_coverage must be empty when signatures is empty")
+
+    signature_count = len(signatures)
+    if signature_count and not family_coverage:
+        raise ValueError("pack_metadata.family_coverage is required when signatures are present")
+
+
+def _require_mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be an object")
+    return value
+
+
+def _require_sequence(value: Any, *, field_name: str) -> Sequence[Any]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{field_name} must be an array")
+    return value
+
+
+def _require_non_empty_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_non_empty_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("optional string fields must be non-empty when provided")
+    return value.strip()
+
+
+def _parse_string_sequence(value: Any, *, field_name: str) -> tuple[str, ...]:
+    return tuple(
+        _require_non_empty_string(item, field_name=f"{field_name}[]")
+        for item in _require_sequence(value, field_name=field_name)
+    )
+
+
+def _parse_severity(value: Any) -> SignatureSeverity:
+    if value is None:
+        return SignatureSeverity.MEDIUM
+    severity = _require_non_empty_string(value, field_name="signatures[].severity")
+    try:
+        return SignatureSeverity(severity)
+    except ValueError as exc:
+        raise ValueError(f"unsupported severity {severity!r}") from exc

--- a/driftshield/src/driftshield/signatures/packs/community-general.json
+++ b/driftshield/src/driftshield/signatures/packs/community-general.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": "1.0.0",
+  "pack_metadata": {
+    "name": "community-general",
+    "version": "1.0.0",
+    "description": "General-purpose DriftShield community signatures.",
+    "pack_kind": "community",
+    "family_coverage": [
+      "coverage_gap",
+      "verification_failure",
+      "assumption_mutation"
+    ],
+    "homepage_url": "https://github.com/tborys/driftshield",
+    "documentation_url": "https://github.com/tborys/driftshield/tree/main/docs"
+  },
+  "signatures": [
+    {
+      "signature_id": "SIG-COMM-001",
+      "family_id": "coverage_gap",
+      "title": "Missing Retrieved Entities",
+      "signature_layer": {
+        "surface": "output",
+        "symptom": "missing key entities in response",
+        "suspected_root_cause": "retrieval did not return full context",
+        "pattern_hint": "coverage_gap"
+      },
+      "failure_shape": "retrieve->synthesise->respond",
+      "severity": "medium",
+      "lexical_markers": [
+        "summarise",
+        "key points",
+        "final answer"
+      ],
+      "temporal_constraints": [
+        "retrieval coverage drops before response synthesis"
+      ],
+      "tags": [
+        "community",
+        "retrieval",
+        "coverage"
+      ],
+      "summary": "missing key entities in response"
+    },
+    {
+      "signature_id": "SIG-COMM-002",
+      "family_id": "verification_failure",
+      "title": "Completion Claim Without Verification",
+      "signature_layer": {
+        "surface": "planning",
+        "symptom": "task is marked done before checks run",
+        "suspected_root_cause": "verification step was skipped under time pressure",
+        "pattern_hint": "verification_failure"
+      },
+      "failure_shape": "plan->implement->claim_done",
+      "severity": "high",
+      "lexical_markers": [
+        "done",
+        "looks good",
+        "should be fine"
+      ],
+      "temporal_constraints": [
+        "completion is asserted before validation evidence appears"
+      ],
+      "tags": [
+        "community",
+        "verification",
+        "planning"
+      ],
+      "summary": "task is marked done before checks run"
+    },
+    {
+      "signature_id": "SIG-COMM-003",
+      "family_id": "assumption_mutation",
+      "title": "Silent Assumption Reversal",
+      "signature_layer": {
+        "surface": "planning",
+        "symptom": "agent switches key assumption without fresh evidence",
+        "suspected_root_cause": "working hypothesis drifted during planning",
+        "pattern_hint": "assumption_mutation"
+      },
+      "failure_shape": "assume->act->reverse",
+      "severity": "medium",
+      "lexical_markers": [
+        "I assumed",
+        "actually",
+        "let me reconsider"
+      ],
+      "temporal_constraints": [
+        "new conclusion appears without intervening evidence"
+      ],
+      "tags": [
+        "community",
+        "assumption",
+        "planning"
+      ],
+      "summary": "agent switches key assumption without fresh evidence"
+    }
+  ]
+}

--- a/driftshield/tests/test_community_signature_pack.py
+++ b/driftshield/tests/test_community_signature_pack.py
@@ -11,7 +11,7 @@ from driftshield.signatures import (
     SignatureSeverity,
     load_builtin_community_pack,
 )
-from driftshield.signatures.community import parse_community_pack
+from driftshield.signatures.community import load_community_pack, parse_community_pack
 
 
 def test_builtin_community_pack_validates_and_projects_to_public_provider() -> None:
@@ -32,6 +32,43 @@ def test_builtin_community_pack_validates_and_projects_to_public_provider() -> N
     assert len(signatures) == 3
     assert signatures[0].signature_id == "SIG-COMM-001"
     assert signatures[1].severity == SignatureSeverity.HIGH
+
+
+def test_load_community_pack_accepts_traversable_resources() -> None:
+    class InlineTraversable:
+        def read_text(self, encoding: str = "utf-8") -> str:
+            assert encoding == "utf-8"
+            return json.dumps(
+                {
+                    "schema_version": "1.0.0",
+                    "pack_metadata": {
+                        "name": "community-general",
+                        "version": "1.0.0",
+                        "description": "General-purpose DriftShield community signatures.",
+                        "pack_kind": "community",
+                        "family_coverage": ["coverage_gap"],
+                    },
+                    "signatures": [
+                        {
+                            "signature_id": "SIG-COMM-001",
+                            "family_id": "coverage_gap",
+                            "title": "Missing Retrieved Entities",
+                            "signature_layer": {
+                                "surface": "output",
+                                "symptom": "missing key entities in response",
+                                "suspected_root_cause": "retrieval did not return full context",
+                                "pattern_hint": "coverage_gap",
+                            },
+                            "failure_shape": "retrieve->synthesise->respond",
+                        }
+                    ],
+                }
+            )
+
+    manifest = load_community_pack(InlineTraversable())
+
+    assert manifest.schema_version == "1.0.0"
+    assert manifest.family_coverage == ("coverage_gap",)
 
 
 def test_builtin_pack_json_looks_like_phase_2a_contract() -> None:
@@ -58,6 +95,10 @@ def test_builtin_pack_json_looks_like_phase_2a_contract() -> None:
 @pytest.mark.parametrize(
     "payload, expected_message",
     [
+        (
+            [],
+            "manifest must be an object",
+        ),
         (
             {
                 "schema_version": "2.0.0",
@@ -112,6 +153,33 @@ def test_builtin_pack_json_looks_like_phase_2a_contract() -> None:
                 ],
             },
             "family_coverage is required when signatures are present",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "pack_metadata": {
+                    "name": "community-general",
+                    "version": "1.0.0",
+                    "description": "General-purpose DriftShield community signatures.",
+                    "pack_kind": "community",
+                    "family_coverage": ["verification_failure"],
+                },
+                "signatures": [
+                    {
+                        "signature_id": "SIG-COMM-001",
+                        "family_id": "coverage_gap",
+                        "title": "Missing Retrieved Entities",
+                        "signature_layer": {
+                            "surface": "output",
+                            "symptom": "missing key entities in response",
+                            "suspected_root_cause": "retrieval did not return full context",
+                            "pattern_hint": "coverage_gap",
+                        },
+                        "failure_shape": "retrieve->synthesise->respond",
+                    }
+                ],
+            },
+            "family_coverage must match the family_id values declared by signatures",
         ),
     ],
 )

--- a/driftshield/tests/test_community_signature_pack.py
+++ b/driftshield/tests/test_community_signature_pack.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from driftshield.signatures import (
+    CommunityPack,
+    SignatureProvider,
+    SignatureSeverity,
+    load_builtin_community_pack,
+)
+from driftshield.signatures.community import parse_community_pack
+
+
+def test_builtin_community_pack_validates_and_projects_to_public_provider() -> None:
+    manifest = load_builtin_community_pack()
+    provider = CommunityPack(manifest)
+
+    signatures = list(provider.iter_signatures())
+
+    assert isinstance(provider, SignatureProvider)
+    assert manifest.schema_version == "1.0.0"
+    assert manifest.metadata.name == "community-general"
+    assert manifest.pack_kind == "community"
+    assert manifest.family_coverage == (
+        "coverage_gap",
+        "verification_failure",
+        "assumption_mutation",
+    )
+    assert len(signatures) == 3
+    assert signatures[0].signature_id == "SIG-COMM-001"
+    assert signatures[1].severity == SignatureSeverity.HIGH
+
+
+def test_builtin_pack_json_looks_like_phase_2a_contract() -> None:
+    pack_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "driftshield"
+        / "signatures"
+        / "packs"
+        / "community-general.json"
+    )
+    payload = json.loads(pack_path.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["pack_metadata"]["pack_kind"] == "community"
+    assert payload["pack_metadata"]["family_coverage"] == [
+        "coverage_gap",
+        "verification_failure",
+        "assumption_mutation",
+    ]
+    assert payload["signatures"][0]["signature_layer"]["pattern_hint"] == "coverage_gap"
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message",
+    [
+        (
+            {
+                "schema_version": "2.0.0",
+                "pack_metadata": {
+                    "name": "community-general",
+                    "version": "1.0.0",
+                    "description": "General-purpose DriftShield community signatures.",
+                    "pack_kind": "community",
+                    "family_coverage": [],
+                },
+                "signatures": [],
+            },
+            "unsupported schema_version",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "pack_metadata": {
+                    "name": "community-general",
+                    "version": "1.0.0",
+                    "description": "General-purpose DriftShield community signatures.",
+                    "pack_kind": "community",
+                    "family_coverage": ["coverage_gap", "coverage_gap"],
+                },
+                "signatures": [],
+            },
+            "must not contain duplicates",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "pack_metadata": {
+                    "name": "community-general",
+                    "version": "1.0.0",
+                    "description": "General-purpose DriftShield community signatures.",
+                    "pack_kind": "community",
+                    "family_coverage": [],
+                },
+                "signatures": [
+                    {
+                        "signature_id": "SIG-COMM-001",
+                        "family_id": "coverage_gap",
+                        "title": "Missing Retrieved Entities",
+                        "signature_layer": {
+                            "surface": "output",
+                            "symptom": "missing key entities in response",
+                            "suspected_root_cause": "retrieval did not return full context",
+                            "pattern_hint": "coverage_gap",
+                        },
+                        "failure_shape": "retrieve->synthesise->respond",
+                    }
+                ],
+            },
+            "family_coverage is required when signatures are present",
+        ),
+    ],
+)
+def test_parse_community_pack_rejects_incompatible_or_inconsistent_manifests(
+    payload: dict[str, object], expected_message: str
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        parse_community_pack(payload)

--- a/driftshield/tests/test_signatures_public_api.py
+++ b/driftshield/tests/test_signatures_public_api.py
@@ -153,10 +153,13 @@ def test_public_signatures_surface_imports_without_private_modules() -> None:
     payload = json.loads(result.stdout)
 
     assert payload["exports"] == [
+        "CommunityPack",
+        "CommunityPackManifest",
         "SignatureDefinition",
         "SignaturePackMetadata",
         "SignatureProvider",
         "SignatureSeverity",
+        "load_builtin_community_pack",
     ]
     assert payload["private_signature_module_loaded"] is False
     assert payload["recurrence_module_loaded"] is False


### PR DESCRIPTION
## Summary

- add the first bundled Phase 2a community signature pack manifest in the OSS repo
- add a small validation/projection loader so the raw pack can be checked and consumed through the public signature seam
- add targeted tests covering the bundled pack, contract-shaped JSON, and invalid-manifest rejection

## Verification

- [x] `PYTHONPATH=src python3 -m pytest tests/test_signatures_public_api.py tests/test_community_signature_pack.py -q`

## Notes

- Closes #14
- Refs tborys/driftshield-meta#27
- Raw pack manifest stays canonical for future distribution and matching work; the OSS loader projects it into the current `driftshield.signatures` seam
