### PR TITLE
feat: add opt-in telemetry, registration, and heartbeat

### DIFF
--- a/driftshield/docs/telemetry.md
+++ b/driftshield/docs/telemetry.md
@@ -1,0 +1,87 @@
+# Phase 2a Telemetry
+
+DriftShield Phase 2a telemetry is explicitly opt-in and disabled by default.
+
+The current OSS transport is intentionally simple:
+
+- registration, heartbeat, and sample analysis-result events are written only after opt-in
+- events are appended to a local NDJSON stream under `DRIFTSHIELD_HOME/telemetry/` or `~/.driftshield/telemetry/`
+- this keeps the consent boundary, event inventory, and smoke path testable before broader instrumentation lands
+
+## Consent boundary
+
+- default state: disabled
+- enabling telemetry creates a local install id and records one `registration` event
+- disabling telemetry stops all further event emission but preserves the install id for later re-enablement
+- heartbeat and analysis-result emission return no-op behaviour when telemetry is disabled
+
+## Event inventory
+
+### Registration
+
+Emitted once on first opt-in.
+
+Fields:
+
+- `event_type = registration`
+- `occurred_at`
+- `install_id`
+- `payload.consent_state = opted_in`
+- `payload.event_inventory_version = phase-2a-v1`
+
+### Heartbeat
+
+Emitted only when telemetry is enabled and the operator explicitly triggers a heartbeat.
+
+Fields:
+
+- `event_type = heartbeat`
+- `occurred_at`
+- `install_id`
+- `payload.status = alive`
+- `payload.event_inventory_version = phase-2a-v1`
+
+### Analysis result
+
+Used as the Phase 2a smoke path for metric-shaped event fields before full instrumentation in `driftshield-meta#33`.
+
+Fields:
+
+- `event_type = analysis_result`
+- `occurred_at`
+- `install_id`
+- `payload.outcome_status`
+- `payload.classifiable`
+- `payload.match_count`
+- `payload.primary_family_id`
+- `payload.mixed_family`
+- `payload.not_classifiable_reason`
+- `payload.event_inventory_version = phase-2a-v1`
+
+These fields intentionally mirror the required run-level inventory from `driftshield-meta/docs/phases/phase-2a/metrics-semantics-v1.md` without adding broader product analytics.
+
+## CLI smoke path
+
+```bash
+# show current consent state
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry status
+
+# opt in and register this install
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry enable
+
+# emit one heartbeat
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry heartbeat
+
+# emit one sample analysis-result event
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry emit-analysis \
+  --outcome-status matched \
+  --match-count 1 \
+  --primary-family-id coverage_gap
+```
+
+## Out of scope for Phase 2a
+
+- background emission without explicit consent
+- remote collection transport
+- growth analytics, user analytics, or marketing telemetry
+- full product instrumentation beyond the minimum metrics semantics

--- a/driftshield/docs/telemetry.md
+++ b/driftshield/docs/telemetry.md
@@ -43,7 +43,7 @@ Fields:
 
 ### Analysis result
 
-Used as the Phase 2a smoke path for metric-shaped event fields before full instrumentation in `driftshield-meta#33`.
+Used as the Phase 2a smoke path for metric-shaped event fields before broader product instrumentation lands.
 
 Fields:
 
@@ -58,7 +58,7 @@ Fields:
 - `payload.not_classifiable_reason`
 - `payload.event_inventory_version = phase-2a-v1`
 
-These fields intentionally mirror the required run-level inventory from `driftshield-meta/docs/phases/phase-2a/metrics-semantics-v1.md` without adding broader product analytics.
+These fields intentionally mirror the required Phase 2a run-level inventory for outcome status, classifiability, match count, family rollup, and not-classifiable reasons without adding broader product analytics.
 
 ## CLI smoke path
 

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -7,7 +7,7 @@ import json
 import typer
 from rich.console import Console
 
-from driftshield.telemetry import TelemetryService
+from driftshield.telemetry import TelemetryService, validate_outcome_status
 
 console = Console(force_terminal=True)
 app = typer.Typer(help="Manage opt-in Phase 2a telemetry.")
@@ -70,8 +70,14 @@ def telemetry_emit_analysis(
     not_classifiable_reason: str | None = typer.Option(None, "--not-classifiable-reason"),
 ) -> None:
     """Emit one sample analysis-result telemetry event for smoke testing."""
+    try:
+        validated_outcome_status = validate_outcome_status(outcome_status)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
     emitted = TelemetryService().record_analysis_event(
-        outcome_status=outcome_status,
+        outcome_status=validated_outcome_status,
         match_count=match_count,
         primary_family_id=primary_family_id,
         mixed_family=mixed_family,

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -1,0 +1,83 @@
+"""CLI commands for consent-gated Phase 2a telemetry."""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from rich.console import Console
+
+from driftshield.telemetry import TelemetryService
+
+console = Console(force_terminal=True)
+app = typer.Typer(help="Manage opt-in Phase 2a telemetry.")
+
+
+@app.command("status")
+def telemetry_status(
+    json_output: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    """Show telemetry consent and heartbeat status."""
+    config = TelemetryService().load_config()
+    payload = {
+        "enabled": config.enabled,
+        "install_id": config.install_id,
+        "registered_at": config.registered_at,
+        "last_heartbeat_at": config.last_heartbeat_at,
+        "event_stream_path": config.event_stream_path,
+    }
+    if json_output:
+        typer.echo(json.dumps(payload))
+        return
+
+    console.print(json.dumps(payload, indent=2))
+
+
+@app.command("enable")
+def telemetry_enable() -> None:
+    """Enable telemetry and register this local installation."""
+    config = TelemetryService().enable()
+    console.print(
+        f"Telemetry enabled for install {config.install_id}. Event stream: {config.event_stream_path}"
+    )
+
+
+@app.command("disable")
+def telemetry_disable() -> None:
+    """Disable telemetry emission."""
+    config = TelemetryService().disable()
+    console.print(
+        f"Telemetry disabled. Existing install id remains {config.install_id or 'unset'}."
+    )
+
+
+@app.command("heartbeat")
+def telemetry_heartbeat() -> None:
+    """Emit one heartbeat event when telemetry opt-in is enabled."""
+    emitted = TelemetryService().heartbeat()
+    if not emitted:
+        console.print("Telemetry is disabled; heartbeat not emitted.")
+        raise typer.Exit(1)
+    console.print("Heartbeat emitted.")
+
+
+@app.command("emit-analysis")
+def telemetry_emit_analysis(
+    outcome_status: str = typer.Option(..., "--outcome-status", help="matched, unclassified, or not_classifiable"),
+    match_count: int = typer.Option(0, "--match-count", min=0),
+    primary_family_id: str | None = typer.Option(None, "--primary-family-id"),
+    mixed_family: bool = typer.Option(False, "--mixed-family"),
+    not_classifiable_reason: str | None = typer.Option(None, "--not-classifiable-reason"),
+) -> None:
+    """Emit one sample analysis-result telemetry event for smoke testing."""
+    emitted = TelemetryService().record_analysis_event(
+        outcome_status=outcome_status,
+        match_count=match_count,
+        primary_family_id=primary_family_id,
+        mixed_family=mixed_family,
+        not_classifiable_reason=not_classifiable_reason,
+    )
+    if not emitted:
+        console.print("Telemetry is disabled; analysis event not emitted.")
+        raise typer.Exit(1)
+    console.print("Analysis event emitted.")

--- a/driftshield/src/driftshield/cli/main.py
+++ b/driftshield/src/driftshield/cli/main.py
@@ -11,6 +11,7 @@ from driftshield.cli.commands.ingest import ingest
 from driftshield.cli.commands.inspect import inspect
 from driftshield.cli.commands.list import list_sessions
 from driftshield.cli.commands.report import report_command
+from driftshield.cli.commands.telemetry import app as telemetry_app
 
 app = typer.Typer(
     name="driftshield",
@@ -27,6 +28,7 @@ app.command(name="export-validations")(export_validations)
 app.command(name="generate-fixtures")(generate_fixtures)
 app.command()(ingest)
 app.add_typer(connectors_app, name="connectors")
+app.add_typer(telemetry_app, name="telemetry")
 
 
 def version_callback(value: bool) -> None:

--- a/driftshield/src/driftshield/telemetry/__init__.py
+++ b/driftshield/src/driftshield/telemetry/__init__.py
@@ -1,0 +1,9 @@
+"""Phase 2a telemetry primitives."""
+
+from driftshield.telemetry.service import (
+    TelemetryConfig,
+    TelemetryEvent,
+    TelemetryService,
+)
+
+__all__ = ["TelemetryConfig", "TelemetryEvent", "TelemetryService"]

--- a/driftshield/src/driftshield/telemetry/__init__.py
+++ b/driftshield/src/driftshield/telemetry/__init__.py
@@ -4,6 +4,7 @@ from driftshield.telemetry.service import (
     TelemetryConfig,
     TelemetryEvent,
     TelemetryService,
+    validate_outcome_status,
 )
 
-__all__ = ["TelemetryConfig", "TelemetryEvent", "TelemetryService"]
+__all__ = ["TelemetryConfig", "TelemetryEvent", "TelemetryService", "validate_outcome_status"]

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -1,0 +1,178 @@
+"""Consent-gated local telemetry transport for the Phase 2a evidence loop."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import uuid
+from typing import Any
+
+
+@dataclass(slots=True)
+class TelemetryConfig:
+    enabled: bool = False
+    install_id: str | None = None
+    registered_at: str | None = None
+    last_heartbeat_at: str | None = None
+    event_stream_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TelemetryEvent:
+    event_type: str
+    occurred_at: str
+    install_id: str
+    payload: dict[str, Any]
+
+
+class TelemetryService:
+    """Persist opt-in telemetry events to a local event stream."""
+
+    def __init__(self, home: Path | None = None) -> None:
+        self._home = home or _telemetry_home()
+        self._config_path = self._home / "config.json"
+        self._default_stream_path = self._home / "events.ndjson"
+
+    def load_config(self) -> TelemetryConfig:
+        if not self._config_path.exists():
+            return TelemetryConfig(event_stream_path=str(self._default_stream_path))
+
+        data = json.loads(self._config_path.read_text(encoding="utf-8"))
+        return TelemetryConfig(
+            enabled=bool(data.get("enabled", False)),
+            install_id=_optional_string(data.get("install_id")),
+            registered_at=_optional_string(data.get("registered_at")),
+            last_heartbeat_at=_optional_string(data.get("last_heartbeat_at")),
+            event_stream_path=_optional_string(data.get("event_stream_path"))
+            or str(self._default_stream_path),
+        )
+
+    def enable(self) -> TelemetryConfig:
+        config = self.load_config()
+        changed = False
+        if not config.install_id:
+            config.install_id = str(uuid.uuid4())
+            changed = True
+        if not config.event_stream_path:
+            config.event_stream_path = str(self._default_stream_path)
+            changed = True
+        if not config.enabled:
+            config.enabled = True
+            changed = True
+        if not config.registered_at:
+            timestamp = _utc_now().isoformat()
+            config.registered_at = timestamp
+            changed = True
+            self._write_event(
+                TelemetryEvent(
+                    event_type="registration",
+                    occurred_at=timestamp,
+                    install_id=config.install_id,
+                    payload={
+                        "consent_state": "opted_in",
+                        "event_inventory_version": "phase-2a-v1",
+                    },
+                ),
+                config=config,
+            )
+        if changed:
+            self._save_config(config)
+        return config
+
+    def disable(self) -> TelemetryConfig:
+        config = self.load_config()
+        config.enabled = False
+        if not config.event_stream_path:
+            config.event_stream_path = str(self._default_stream_path)
+        self._save_config(config)
+        return config
+
+    def heartbeat(self) -> bool:
+        config = self.load_config()
+        if not config.enabled or not config.install_id:
+            return False
+        timestamp = _utc_now().isoformat()
+        config.last_heartbeat_at = timestamp
+        self._write_event(
+            TelemetryEvent(
+                event_type="heartbeat",
+                occurred_at=timestamp,
+                install_id=config.install_id,
+                payload={"status": "alive", "event_inventory_version": "phase-2a-v1"},
+            ),
+            config=config,
+        )
+        self._save_config(config)
+        return True
+
+    def record_analysis_event(
+        self,
+        *,
+        outcome_status: str,
+        match_count: int,
+        primary_family_id: str | None = None,
+        mixed_family: bool = False,
+        not_classifiable_reason: str | None = None,
+    ) -> bool:
+        config = self.load_config()
+        if not config.enabled or not config.install_id:
+            return False
+        self._write_event(
+            TelemetryEvent(
+                event_type="analysis_result",
+                occurred_at=_utc_now().isoformat(),
+                install_id=config.install_id,
+                payload={
+                    "outcome_status": outcome_status,
+                    "classifiable": outcome_status in {"matched", "unclassified"},
+                    "match_count": match_count,
+                    "primary_family_id": primary_family_id,
+                    "mixed_family": mixed_family,
+                    "not_classifiable_reason": not_classifiable_reason,
+                    "event_inventory_version": "phase-2a-v1",
+                },
+            ),
+            config=config,
+        )
+        return True
+
+    def read_events(self) -> list[dict[str, Any]]:
+        config = self.load_config()
+        stream_path = Path(config.event_stream_path or self._default_stream_path)
+        if not stream_path.exists():
+            return []
+        return [json.loads(line) for line in stream_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    def _save_config(self, config: TelemetryConfig) -> None:
+        self._home.mkdir(parents=True, exist_ok=True)
+        self._config_path.write_text(json.dumps(asdict(config), indent=2) + "\n", encoding="utf-8")
+
+    def _write_event(self, event: TelemetryEvent, *, config: TelemetryConfig) -> None:
+        self._home.mkdir(parents=True, exist_ok=True)
+        stream_path = Path(config.event_stream_path or self._default_stream_path)
+        stream_path.parent.mkdir(parents=True, exist_ok=True)
+        with stream_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(event), sort_keys=True) + "\n")
+
+
+def _telemetry_home() -> Path:
+    configured = os.environ.get("DRIFTSHIELD_HOME")
+    if configured:
+        return Path(configured).expanduser() / "telemetry"
+    return Path.home() / ".driftshield" / "telemetry"
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("expected string value")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -11,6 +11,9 @@ import uuid
 from typing import Any
 
 
+_VALID_OUTCOME_STATUSES = {"matched", "unclassified", "not_classifiable"}
+
+
 @dataclass(slots=True)
 class TelemetryConfig:
     enabled: bool = False
@@ -117,6 +120,7 @@ class TelemetryService:
         mixed_family: bool = False,
         not_classifiable_reason: str | None = None,
     ) -> bool:
+        validated_outcome_status = validate_outcome_status(outcome_status)
         config = self.load_config()
         if not config.enabled or not config.install_id:
             return False
@@ -126,7 +130,7 @@ class TelemetryService:
                 occurred_at=_utc_now().isoformat(),
                 install_id=config.install_id,
                 payload={
-                    "outcome_status": outcome_status,
+                    "outcome_status": validated_outcome_status,
                     "classifiable": outcome_status in {"matched", "unclassified"},
                     "match_count": match_count,
                     "primary_family_id": primary_family_id,
@@ -163,6 +167,14 @@ def _telemetry_home() -> Path:
     if configured:
         return Path(configured).expanduser() / "telemetry"
     return Path.home() / ".driftshield" / "telemetry"
+
+
+def validate_outcome_status(value: str) -> str:
+    normalized = value.strip()
+    if normalized not in _VALID_OUTCOME_STATUSES:
+        valid = ", ".join(sorted(_VALID_OUTCOME_STATUSES))
+        raise ValueError(f"outcome_status must be one of: {valid}")
+    return normalized
 
 
 def _optional_string(value: object) -> str | None:

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -131,7 +131,7 @@ class TelemetryService:
                 install_id=config.install_id,
                 payload={
                     "outcome_status": validated_outcome_status,
-                    "classifiable": outcome_status in {"matched", "unclassified"},
+                    "classifiable": validated_outcome_status in {"matched", "unclassified"},
                     "match_count": match_count,
                     "primary_family_id": primary_family_id,
                     "mixed_family": mixed_family,

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -113,3 +113,25 @@ def test_emit_analysis_rejects_invalid_outcome_status(tmp_path, monkeypatch):
 
     events = TelemetryService().read_events()
     assert [event["event_type"] for event in events] == ["registration"]
+
+
+def test_emit_analysis_normalizes_outcome_status_before_classifiable_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "enable"])
+
+    emitted = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "emit-analysis",
+            "--outcome-status",
+            " matched ",
+            "--match-count",
+            "1",
+        ],
+    )
+
+    assert emitted.exit_code == 0
+    analysis_event = TelemetryService().read_events()[-1]
+    assert analysis_event["payload"]["outcome_status"] == "matched"
+    assert analysis_event["payload"]["classifiable"] is True

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -92,3 +92,24 @@ def test_disable_stops_further_emission(tmp_path, monkeypatch):
 
     events = TelemetryService().read_events()
     assert [event["event_type"] for event in events] == ["registration"]
+
+
+def test_emit_analysis_rejects_invalid_outcome_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "enable"])
+
+    invalid = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "emit-analysis",
+            "--outcome-status",
+            "matchd",
+        ],
+    )
+
+    assert invalid.exit_code == 1
+    assert "outcome_status must be one of" in invalid.stdout
+
+    events = TelemetryService().read_events()
+    assert [event["event_type"] for event in events] == ["registration"]

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from driftshield.cli.main import app
+from driftshield.telemetry import TelemetryService
+
+
+runner = CliRunner()
+
+
+def test_telemetry_is_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    status = runner.invoke(app, ["telemetry", "status", "--json"])
+
+    assert status.exit_code == 0
+    payload = json.loads(status.stdout)
+    assert payload["enabled"] is False
+    assert payload["install_id"] is None
+
+    heartbeat = runner.invoke(app, ["telemetry", "heartbeat"])
+    assert heartbeat.exit_code == 1
+    assert "disabled" in heartbeat.stdout.lower()
+    assert TelemetryService().read_events() == []
+
+
+def test_telemetry_enable_registers_install_and_emits_heartbeat(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    enabled = runner.invoke(app, ["telemetry", "enable"])
+    assert enabled.exit_code == 0
+
+    service = TelemetryService()
+    config = service.load_config()
+    assert config.enabled is True
+    assert config.install_id is not None
+    assert config.registered_at is not None
+
+    heartbeat = runner.invoke(app, ["telemetry", "heartbeat"])
+    assert heartbeat.exit_code == 0
+
+    events = service.read_events()
+    assert [event["event_type"] for event in events] == ["registration", "heartbeat"]
+    assert events[0]["payload"]["consent_state"] == "opted_in"
+    assert events[1]["payload"]["status"] == "alive"
+
+
+def test_emit_analysis_uses_phase_2a_metric_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "enable"])
+
+    emitted = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "emit-analysis",
+            "--outcome-status",
+            "matched",
+            "--match-count",
+            "2",
+            "--primary-family-id",
+            "verification_failure",
+        ],
+    )
+    assert emitted.exit_code == 0
+
+    events = TelemetryService().read_events()
+    analysis_event = events[-1]
+    assert analysis_event["event_type"] == "analysis_result"
+    assert analysis_event["payload"] == {
+        "classifiable": True,
+        "event_inventory_version": "phase-2a-v1",
+        "match_count": 2,
+        "mixed_family": False,
+        "not_classifiable_reason": None,
+        "outcome_status": "matched",
+        "primary_family_id": "verification_failure",
+    }
+
+
+def test_disable_stops_further_emission(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "enable"])
+    runner.invoke(app, ["telemetry", "disable"])
+
+    heartbeat = runner.invoke(app, ["telemetry", "heartbeat"])
+    assert heartbeat.exit_code == 1
+
+    events = TelemetryService().read_events()
+    assert [event["event_type"] for event in events] == ["registration"]


### PR DESCRIPTION
## Summary
- add an explicitly opt-in Phase 2a telemetry service with local registration, heartbeat, and analysis-result emission
- add a `driftshield telemetry` CLI surface for consent status, opt-in, heartbeat, and smoke testing
- document the minimal Phase 2a event inventory and add targeted CLI tests for disabled and enabled behaviour

## Testing
- `PYTHONPATH=src pytest tests/cli/test_telemetry.py tests/cli/test_ingest.py tests/cli/test_connectors.py -q`
- `./scripts/check-public-scope.sh`

Closes #15
