### PR TITLE
feat: instrument Phase 2a metrics on ingest

### DIFF
--- a/driftshield/docs/telemetry.md
+++ b/driftshield/docs/telemetry.md
@@ -43,7 +43,7 @@ Fields:
 
 ### Analysis result
 
-Used as the Phase 2a smoke path for metric-shaped event fields before broader product instrumentation lands.
+Used as the Phase 2a smoke path for metric-shaped event fields before broader product instrumentation lands. When telemetry opt-in is enabled, the OSS ingest path now emits this event automatically for newly analysed runs.
 
 Fields:
 
@@ -59,6 +59,12 @@ Fields:
 - `payload.event_inventory_version = phase-2a-v1`
 
 These fields intentionally mirror the required Phase 2a run-level inventory for outcome status, classifiability, match count, family rollup, and not-classifiable reasons without adding broader product analytics.
+
+Current OSS emission path:
+
+- the `driftshield telemetry emit-analysis` command remains available for smoke testing
+- the `/api/ingest` flow now emits one `analysis_result` event for newly analysed runs when telemetry is enabled
+- deduplicated re-ingest responses do not emit a second `analysis_result` event
 
 ## CLI smoke path
 

--- a/driftshield/src/driftshield/api/routes/ingest.py
+++ b/driftshield/src/driftshield/api/routes/ingest.py
@@ -47,13 +47,16 @@ def ingest_transcript(
         db.commit()
         if not outcome.deduplicated and analysis_result is not None:
             metrics = metrics_payload_from_analysis_result(analysis_result)
-            TelemetryService().record_analysis_event(
-                outcome_status=metrics["outcome_status"],
-                match_count=metrics["match_count"],
-                primary_family_id=metrics["primary_family_id"],
-                mixed_family=metrics["mixed_family"],
-                not_classifiable_reason=metrics["not_classifiable_reason"],
-            )
+            try:
+                TelemetryService().record_analysis_event(
+                    outcome_status=metrics["outcome_status"],
+                    match_count=metrics["match_count"],
+                    primary_family_id=metrics["primary_family_id"],
+                    mixed_family=metrics["mixed_family"],
+                    not_classifiable_reason=metrics["not_classifiable_reason"],
+                )
+            except Exception:
+                pass
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except IntegrityError:

--- a/driftshield/src/driftshield/api/routes/ingest.py
+++ b/driftshield/src/driftshield/api/routes/ingest.py
@@ -10,8 +10,9 @@ from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
 from driftshield.api.schemas import IngestResponse
 from driftshield.cli.parsers import PARSERS
-from driftshield.db.ingest_service import TranscriptIngestService
+from driftshield.db.ingest_service import TranscriptIngestService, metrics_payload_from_analysis_result
 from driftshield.db.persistence import IngestProvenance, PersistenceService
+from driftshield.telemetry import TelemetryService
 
 router = APIRouter()
 
@@ -38,12 +39,21 @@ def ingest_transcript(
         raise HTTPException(status_code=413, detail=f"Request body exceeds {max_request_bytes} bytes")
     ingest_service = TranscriptIngestService(db)
     try:
-        outcome = ingest_service.ingest_bytes(
+        outcome, analysis_result = ingest_service.ingest_bytes(
             raw_bytes=raw_bytes,
             parser_name=normalised,
             source_path=file.filename,
         )
         db.commit()
+        if not outcome.deduplicated and analysis_result is not None:
+            metrics = metrics_payload_from_analysis_result(analysis_result)
+            TelemetryService().record_analysis_event(
+                outcome_status=metrics["outcome_status"],
+                match_count=metrics["match_count"],
+                primary_family_id=metrics["primary_family_id"],
+                mixed_family=metrics["mixed_family"],
+                not_classifiable_reason=metrics["not_classifiable_reason"],
+            )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except IntegrityError:

--- a/driftshield/src/driftshield/connectors/watcher.py
+++ b/driftshield/src/driftshield/connectors/watcher.py
@@ -141,7 +141,7 @@ class ConnectorWatchService:
 
             raw_bytes = session_info.path.read_bytes()
             transcript_hash = hashlib.sha256(raw_bytes).hexdigest()
-            outcome = ingest_service.ingest_bytes(
+            outcome, _analysis_result = ingest_service.ingest_bytes(
                 raw_bytes=raw_bytes,
                 parser_name=connector.parser_name,
                 source_path=str(session_info.path),

--- a/driftshield/src/driftshield/db/ingest_service.py
+++ b/driftshield/src/driftshield/db/ingest_service.py
@@ -9,7 +9,6 @@ from driftshield.cli.parsers import PARSERS, get_parser
 from driftshield.core.analysis.session import analyze_session
 from driftshield.core.models import CanonicalEvent, Session as DomainSession, SessionStatus
 from driftshield.db.persistence import IngestOutcome, IngestProvenance, PersistenceService
-from driftshield.telemetry import TelemetryService
 
 
 class TranscriptIngestService:
@@ -22,7 +21,7 @@ class TranscriptIngestService:
         file_path: Path,
         parser_name: str,
         existing_session_id: uuid.UUID | None = None,
-    ) -> IngestOutcome:
+    ) -> tuple[IngestOutcome, object]:
         raw_bytes = file_path.read_bytes()
         return self.ingest_bytes(
             raw_bytes=raw_bytes,
@@ -38,7 +37,7 @@ class TranscriptIngestService:
         parser_name: str,
         source_path: str | None,
         existing_session_id: uuid.UUID | None = None,
-    ) -> IngestOutcome:
+    ) -> tuple[IngestOutcome, object]:
         normalised = parser_name.replace("-", "_")
         if normalised not in PARSERS:
             raise ValueError(f"Unsupported format: {parser_name}")
@@ -76,21 +75,10 @@ class TranscriptIngestService:
                 provenance,
                 existing_session_id=existing_session_id,
             )
-
-        if not outcome.deduplicated:
-            metrics = _metrics_payload_from_analysis_result(result)
-            TelemetryService().record_analysis_event(
-                outcome_status=metrics["outcome_status"],
-                match_count=metrics["match_count"],
-                primary_family_id=metrics["primary_family_id"],
-                mixed_family=metrics["mixed_family"],
-                not_classifiable_reason=metrics["not_classifiable_reason"],
-            )
-
-        return outcome
+        return outcome, result
 
 
-def _metrics_payload_from_analysis_result(result) -> dict[str, object]:
+def metrics_payload_from_analysis_result(result) -> dict[str, object]:
     risk_summary = result.risk_summary
     matched_families = [family_id for family_id, count in risk_summary.items() if count > 0]
     primary_family_id = None

--- a/driftshield/src/driftshield/db/ingest_service.py
+++ b/driftshield/src/driftshield/db/ingest_service.py
@@ -9,6 +9,7 @@ from driftshield.cli.parsers import PARSERS, get_parser
 from driftshield.core.analysis.session import analyze_session
 from driftshield.core.models import CanonicalEvent, Session as DomainSession, SessionStatus
 from driftshield.db.persistence import IngestOutcome, IngestProvenance, PersistenceService
+from driftshield.telemetry import TelemetryService
 
 
 class TranscriptIngestService:
@@ -67,13 +68,45 @@ class TranscriptIngestService:
         )
         persistence = PersistenceService(self._db)
         if existing_session_id is None:
-            return persistence.ingest(domain_session, result, provenance)
-        return persistence.ingest(
-            domain_session,
-            result,
-            provenance,
-            existing_session_id=existing_session_id,
+            outcome = persistence.ingest(domain_session, result, provenance)
+        else:
+            outcome = persistence.ingest(
+                domain_session,
+                result,
+                provenance,
+                existing_session_id=existing_session_id,
+            )
+
+        if not outcome.deduplicated:
+            metrics = _metrics_payload_from_analysis_result(result)
+            TelemetryService().record_analysis_event(
+                outcome_status=metrics["outcome_status"],
+                match_count=metrics["match_count"],
+                primary_family_id=metrics["primary_family_id"],
+                mixed_family=metrics["mixed_family"],
+                not_classifiable_reason=metrics["not_classifiable_reason"],
+            )
+
+        return outcome
+
+
+def _metrics_payload_from_analysis_result(result) -> dict[str, object]:
+    risk_summary = result.risk_summary
+    matched_families = [family_id for family_id, count in risk_summary.items() if count > 0]
+    primary_family_id = None
+    if matched_families:
+        primary_family_id = max(
+            matched_families,
+            key=lambda family_id: (risk_summary[family_id], family_id),
         )
+
+    return {
+        "outcome_status": "matched" if result.flagged_events > 0 else "unclassified",
+        "match_count": result.flagged_events,
+        "primary_family_id": primary_family_id,
+        "mixed_family": len(matched_families) > 1,
+        "not_classifiable_reason": None,
+    }
 
 
 def _stabilize_event_ids(events: list[CanonicalEvent], session_id: uuid.UUID) -> None:

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -13,6 +13,7 @@ from sqlalchemy.pool import StaticPool
 from driftshield.api.app import create_app
 from driftshield.db.models import Base, DecisionNodeModel, SessionModel
 from driftshield.db.persistence import IngestOutcome, PersistenceService
+from driftshield.telemetry import TelemetryService
 
 
 @pytest.fixture
@@ -252,3 +253,82 @@ def test_ingest_rejects_invalid_content_length_header(client, auth_headers, samp
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid Content-Length header"
+
+
+def test_ingest_emits_unclassified_phase_2a_metrics_when_telemetry_is_enabled(client, auth_headers, sample_transcript, monkeypatch, tmp_path):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    TelemetryService().enable()
+
+    response = _post_ingest(client, auth_headers, sample_transcript)
+
+    assert response.status_code == 201
+    events = TelemetryService().read_events()
+    analysis_event = events[-1]
+    assert analysis_event["event_type"] == "analysis_result"
+    assert analysis_event["payload"] == {
+        "classifiable": True,
+        "event_inventory_version": "phase-2a-v1",
+        "match_count": 0,
+        "mixed_family": False,
+        "not_classifiable_reason": None,
+        "outcome_status": "unclassified",
+        "primary_family_id": None,
+    }
+
+
+def test_ingest_emits_matched_phase_2a_metrics_when_analysis_flags_risk(client, auth_headers, sample_transcript, monkeypatch, tmp_path):
+    from driftshield.core.analysis.session import AnalysisResult
+    from driftshield.core.graph.models import LineageGraph
+    from driftshield.core.models import ExplanationPayload, RiskClassification
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    TelemetryService().enable()
+
+    original_events = []
+
+    def fake_analyze_session(events, session_id=None):
+        original_events.extend(events)
+        events[0].risk_classification = RiskClassification(
+            coverage_gap=True,
+            explanations={"coverage_gap": ExplanationPayload(reason="missing context")},
+        )
+        return AnalysisResult(
+            events=events,
+            graph=LineageGraph(session_id=session_id or events[0].session_id),
+            inflection_node=None,
+            total_events=len(events),
+            flagged_events=1,
+            inflection_explanation=None,
+        )
+
+    monkeypatch.setattr("driftshield.db.ingest_service.analyze_session", fake_analyze_session)
+
+    response = _post_ingest(client, auth_headers, sample_transcript)
+
+    assert response.status_code == 201
+    analysis_event = TelemetryService().read_events()[-1]
+    assert analysis_event["event_type"] == "analysis_result"
+    assert analysis_event["payload"] == {
+        "classifiable": True,
+        "event_inventory_version": "phase-2a-v1",
+        "match_count": 1,
+        "mixed_family": False,
+        "not_classifiable_reason": None,
+        "outcome_status": "matched",
+        "primary_family_id": "coverage_gap",
+    }
+
+
+def test_deduped_ingest_does_not_emit_duplicate_metrics(client, auth_headers, sample_transcript, monkeypatch, tmp_path):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    TelemetryService().enable()
+
+    first = _post_ingest(client, auth_headers, sample_transcript)
+    second = _post_ingest(client, auth_headers, sample_transcript)
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    analysis_events = [
+        event for event in TelemetryService().read_events() if event["event_type"] == "analysis_result"
+    ]
+    assert len(analysis_events) == 1

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -145,6 +145,8 @@ def test_reingest_is_explicit_dedupe_no_op(client, auth_headers, sample_transcri
 
 def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample_transcript, monkeypatch):
     from driftshield.api.dependencies import get_db
+    from driftshield.core.analysis.session import AnalysisResult
+    from driftshield.core.graph.models import LineageGraph
 
     class FakeDB:
         def __init__(self):
@@ -161,14 +163,25 @@ def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample
 
     session_id = uuid.uuid4()
 
-    def fake_ingest(self, session, result, provenance):
-        return IngestOutcome(
-            session_id=session_id,
+    def fake_ingest_bytes(self, *, raw_bytes, parser_name, source_path, existing_session_id=None):
+        analysis_result = AnalysisResult(
+            events=[],
+            graph=LineageGraph(session_id=str(session_id)),
+            inflection_node=None,
             total_events=1,
             flagged_events=0,
-            has_inflection=False,
-            status="created",
-            deduplicated=False,
+            inflection_explanation=None,
+        )
+        return (
+            IngestOutcome(
+                session_id=session_id,
+                total_events=1,
+                flagged_events=0,
+                has_inflection=False,
+                status="created",
+                deduplicated=False,
+            ),
+            analysis_result,
         )
 
     def fake_get_ingest_outcome(self, provenance):
@@ -182,8 +195,15 @@ def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample
             deduplicated=True,
         )
 
-    monkeypatch.setattr(PersistenceService, "ingest", fake_ingest)
+    emit_calls = []
+
+    def fake_record_analysis_event(self, **kwargs):
+        emit_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr("driftshield.api.routes.ingest.TranscriptIngestService.ingest_bytes", fake_ingest_bytes)
     monkeypatch.setattr(PersistenceService, "get_ingest_outcome", fake_get_ingest_outcome)
+    monkeypatch.setattr("driftshield.api.routes.ingest.TelemetryService.record_analysis_event", fake_record_analysis_event)
 
     response = _post_ingest(client, auth_headers, sample_transcript)
 
@@ -198,6 +218,7 @@ def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample
         "status": "deduped",
         "deduplicated": True,
     }
+    assert emit_calls == []
 
 
 def test_ingest_without_auth(client, sample_transcript):

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -353,3 +353,18 @@ def test_deduped_ingest_does_not_emit_duplicate_metrics(client, auth_headers, sa
         event for event in TelemetryService().read_events() if event["event_type"] == "analysis_result"
     ]
     assert len(analysis_events) == 1
+
+
+def test_ingest_succeeds_even_when_post_commit_telemetry_emit_fails(client, auth_headers, sample_transcript, monkeypatch):
+    def fail_record_analysis_event(self, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "driftshield.api.routes.ingest.TelemetryService.record_analysis_event",
+        fail_record_analysis_event,
+    )
+
+    response = _post_ingest(client, auth_headers, sample_transcript)
+
+    assert response.status_code == 201
+    assert response.json()["status"] == "created"


### PR DESCRIPTION
## Summary
- instrument the OSS ingest flow to emit Phase 2a `analysis_result` telemetry events for newly analysed runs when telemetry opt-in is enabled
- derive the run-level telemetry fields from the analysed session result using the agreed minimal metric semantics
- document the real emission path and add regression tests for unclassified, matched, and deduped ingest behaviour

## Testing
- `PYTHONPATH=src pytest tests/api/test_ingest.py tests/cli/test_telemetry.py tests/cli/test_ingest.py tests/cli/test_connectors.py -q`
- `./scripts/check-public-scope.sh`

Closes #17
