### PR TITLE
feat: add CrewAI parser

### DIFF
--- a/driftshield/src/driftshield/cli/commands/ingest.py
+++ b/driftshield/src/driftshield/cli/commands/ingest.py
@@ -40,7 +40,7 @@ def ingest(
         "auto",
         "--parser",
         "-p",
-        help="Parser to use (auto, claude_code, claude_desktop, codex_cli, codex_desktop, langchain, openclaw).",
+        help="Parser to use (auto, claude_code, claude_desktop, codex_cli, codex_desktop, crewai, langchain, openclaw).",
     ),
 ) -> None:
     """Upload a transcript to the DriftShield ingest API."""

--- a/driftshield/src/driftshield/cli/parsers.py
+++ b/driftshield/src/driftshield/cli/parsers.py
@@ -6,6 +6,7 @@ from driftshield.parsers.claude_code import ClaudeCodeParser
 from driftshield.parsers.claude_desktop import ClaudeDesktopParser
 from driftshield.parsers.codex_cli import CodexCliParser
 from driftshield.parsers.codex_desktop import CodexDesktopParser
+from driftshield.parsers.crewai import CrewAIParser
 from driftshield.parsers.langchain import LangChainParser
 from driftshield.parsers.openclaw import OpenClawParser
 from driftshield.parsers.protocol import TranscriptParser
@@ -20,6 +21,7 @@ PARSERS: dict[str, type[TranscriptParser]] = {
     "claude_desktop": ClaudeDesktopParser,
     "codex_cli": CodexCliParser,
     "codex_desktop": CodexDesktopParser,
+    "crewai": CrewAIParser,
     "langchain": LangChainParser,
     "openclaw": OpenClawParser,
 }

--- a/driftshield/src/driftshield/parsers/crewai.py
+++ b/driftshield/src/driftshield/parsers/crewai.py
@@ -1,0 +1,142 @@
+"""Parser for bounded CrewAI exported run JSON."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from driftshield.core.models import CanonicalEvent, EventType
+
+
+class CrewAIParser:
+    """Parse a representative CrewAI run export into canonical events."""
+
+    @property
+    def source_type(self) -> str:
+        return "crewai"
+
+    def parse_file(self, file_path: str) -> list[CanonicalEvent]:
+        return self.parse(Path(file_path).read_text())
+
+    def parse(self, content: str) -> list[CanonicalEvent]:
+        payload = json.loads(content)
+        if not isinstance(payload, dict):
+            return []
+
+        session_id = str(payload.get("run_id") or payload.get("id") or "unknown")
+        started_at = self._parse_timestamp(payload.get("started_at"))
+        events: list[CanonicalEvent] = []
+        previous_event_id: UUID | None = None
+
+        prompt = str(payload.get("input") or payload.get("goal") or "").strip()
+        if prompt:
+            user_event = CanonicalEvent(
+                id=uuid4(),
+                session_id=session_id,
+                timestamp=started_at,
+                event_type=EventType.OUTPUT,
+                agent_id="user",
+                action="user_message",
+                parent_event_id=previous_event_id,
+                inputs={},
+                outputs={"text": prompt},
+                metadata={
+                    "source_type": self.source_type,
+                    "semantic_action_category": "user_input",
+                    "raw_action": "user_message",
+                },
+            )
+            events.append(user_event)
+            previous_event_id = user_event.id
+
+        for task in payload.get("tasks") or []:
+            if not isinstance(task, dict):
+                continue
+            tool_event = self._build_task_event(
+                session_id=session_id,
+                task=task,
+                parent_event_id=previous_event_id,
+            )
+            events.append(tool_event)
+            previous_event_id = tool_event.id
+
+            final_output = str(task.get("output") or "").strip()
+            if final_output:
+                output_event = CanonicalEvent(
+                    id=uuid4(),
+                    session_id=session_id,
+                    timestamp=self._parse_timestamp(task.get("completed_at") or task.get("started_at")),
+                    event_type=EventType.OUTPUT,
+                    agent_id=str((task.get("agent") or {}).get("role") or payload.get("crew_name") or "crewai"),
+                    action="assistant_narrative",
+                    parent_event_id=previous_event_id,
+                    inputs={},
+                    outputs={"text": final_output},
+                    metadata={
+                        "source_type": self.source_type,
+                        "task_id": task.get("id"),
+                        "semantic_action_category": "reasoning",
+                        "raw_action": "task_output",
+                    },
+                )
+                events.append(output_event)
+                previous_event_id = output_event.id
+
+        return events
+
+    def _build_task_event(
+        self,
+        *,
+        session_id: str,
+        task: dict,
+        parent_event_id: UUID | None,
+    ) -> CanonicalEvent:
+        agent = task.get("agent") or {}
+        tool_calls = [tool for tool in task.get("tool_calls") or [] if isinstance(tool, dict)]
+        primary_tool = tool_calls[0] if tool_calls else None
+        action = str(
+            (primary_tool or {}).get("tool_name")
+            or task.get("name")
+            or task.get("description")
+            or "task"
+        )
+        outputs: dict[str, object] = {}
+        if primary_tool is not None:
+            outputs["result"] = primary_tool.get("output")
+            if primary_tool.get("error"):
+                outputs["error"] = primary_tool.get("error")
+
+        return CanonicalEvent(
+            id=uuid4(),
+            session_id=session_id,
+            timestamp=self._parse_timestamp(task.get("started_at")),
+            event_type=EventType.TOOL_CALL,
+            agent_id=str(agent.get("role") or "crewai"),
+            action=action,
+            parent_event_id=parent_event_id,
+            inputs={
+                "description": task.get("description"),
+                "expected_output": task.get("expected_output"),
+                "tool_input": (primary_tool or {}).get("input"),
+            },
+            outputs=outputs,
+            metadata={
+                "source_type": self.source_type,
+                "task_id": task.get("id"),
+                "task_status": task.get("status"),
+                "agent_goal": agent.get("goal"),
+                "tool_name": (primary_tool or {}).get("tool_name"),
+                "semantic_action_category": "other",
+                "raw_action": action,
+            },
+        )
+
+    def _parse_timestamp(self, value: object) -> datetime:
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        if isinstance(value, str) and value:
+            normalized = value.replace("Z", "+00:00")
+            return datetime.fromisoformat(normalized)
+        return datetime.now(timezone.utc)

--- a/driftshield/src/driftshield/parsers/crewai.py
+++ b/driftshield/src/driftshield/parsers/crewai.py
@@ -54,13 +54,28 @@ class CrewAIParser:
         for task in payload.get("tasks") or []:
             if not isinstance(task, dict):
                 continue
-            tool_event = self._build_task_event(
-                session_id=session_id,
-                task=task,
-                parent_event_id=previous_event_id,
-            )
-            events.append(tool_event)
-            previous_event_id = tool_event.id
+            tool_calls = [tool for tool in task.get("tool_calls") or [] if isinstance(tool, dict)]
+            if tool_calls:
+                for index, tool_call in enumerate(tool_calls):
+                    tool_event = self._build_task_event(
+                        session_id=session_id,
+                        task=task,
+                        tool_call=tool_call,
+                        tool_call_index=index,
+                        parent_event_id=previous_event_id,
+                    )
+                    events.append(tool_event)
+                    previous_event_id = tool_event.id
+            else:
+                task_event = self._build_task_event(
+                    session_id=session_id,
+                    task=task,
+                    tool_call=None,
+                    tool_call_index=None,
+                    parent_event_id=previous_event_id,
+                )
+                events.append(task_event)
+                previous_event_id = task_event.id
 
             final_output = str(task.get("output") or "").strip()
             if final_output:
@@ -91,22 +106,22 @@ class CrewAIParser:
         *,
         session_id: str,
         task: dict,
+        tool_call: dict | None,
+        tool_call_index: int | None,
         parent_event_id: UUID | None,
     ) -> CanonicalEvent:
         agent = task.get("agent") or {}
-        tool_calls = [tool for tool in task.get("tool_calls") or [] if isinstance(tool, dict)]
-        primary_tool = tool_calls[0] if tool_calls else None
         action = str(
-            (primary_tool or {}).get("tool_name")
+            (tool_call or {}).get("tool_name")
             or task.get("name")
             or task.get("description")
             or "task"
         )
         outputs: dict[str, object] = {}
-        if primary_tool is not None:
-            outputs["result"] = primary_tool.get("output")
-            if primary_tool.get("error"):
-                outputs["error"] = primary_tool.get("error")
+        if tool_call is not None:
+            outputs["result"] = tool_call.get("output")
+            if tool_call.get("error"):
+                outputs["error"] = tool_call.get("error")
 
         return CanonicalEvent(
             id=uuid4(),
@@ -119,7 +134,7 @@ class CrewAIParser:
             inputs={
                 "description": task.get("description"),
                 "expected_output": task.get("expected_output"),
-                "tool_input": (primary_tool or {}).get("input"),
+                "tool_input": (tool_call or {}).get("input"),
             },
             outputs=outputs,
             metadata={
@@ -127,7 +142,8 @@ class CrewAIParser:
                 "task_id": task.get("id"),
                 "task_status": task.get("status"),
                 "agent_goal": agent.get("goal"),
-                "tool_name": (primary_tool or {}).get("tool_name"),
+                "tool_name": (tool_call or {}).get("tool_name"),
+                "tool_call_index": tool_call_index,
                 "semantic_action_category": "other",
                 "raw_action": action,
             },

--- a/driftshield/src/driftshield/parsers/crewai.py
+++ b/driftshield/src/driftshield/parsers/crewai.py
@@ -66,16 +66,6 @@ class CrewAIParser:
                     )
                     events.append(tool_event)
                     previous_event_id = tool_event.id
-            else:
-                task_event = self._build_task_event(
-                    session_id=session_id,
-                    task=task,
-                    tool_call=None,
-                    tool_call_index=None,
-                    parent_event_id=previous_event_id,
-                )
-                events.append(task_event)
-                previous_event_id = task_event.id
 
             final_output = str(task.get("output") or "").strip()
             if final_output:

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -2,6 +2,7 @@ import io
 import json
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -219,6 +220,23 @@ def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample
         "deduplicated": True,
     }
     assert emit_calls == []
+
+
+def test_ingest_crewai_transcript_with_explicit_parser(client, auth_headers):
+    fixture = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "transcripts" / "sample_crewai_session.json"
+    )
+    response = client.post(
+        "/api/ingest",
+        headers=auth_headers,
+        files={"file": ("sample_crewai_session.json", io.BytesIO(fixture.read_bytes()), "application/json")},
+        data={"format": "crewai"},
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["total_events"] == 3
+    assert data["status"] == "created"
 
 
 def test_ingest_without_auth(client, sample_transcript):

--- a/driftshield/tests/cli/test_ingest.py
+++ b/driftshield/tests/cli/test_ingest.py
@@ -162,6 +162,24 @@ def test_ingest_surfaces_deduplicated_response(monkeypatch):
     assert "duplicate" in result.output.lower() or "already" in result.output.lower()
 
 
+def test_ingest_with_explicit_crewai_parser(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_post_ingest(*, target_url: str, api_key: str, file_path: Path, parser: str):
+        captured["parser"] = parser
+        return DummyResponse()._payload
+
+    monkeypatch.setenv("DRIFTSHIELD_API_URL", "http://localhost:8000")
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "test-key")
+    monkeypatch.setattr("driftshield.cli.commands.ingest.post_ingest", fake_post_ingest)
+
+    transcript = FIXTURES_DIR / "sample_crewai_session.json"
+    result = runner.invoke(app, ["ingest", "--path", str(transcript), "--parser", "crewai"])
+
+    assert result.exit_code == 0
+    assert captured["parser"] == "crewai"
+
+
 def test_build_multipart_body_uses_basename_for_uploaded_filename():
     transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
 

--- a/driftshield/tests/cli/test_parsers.py
+++ b/driftshield/tests/cli/test_parsers.py
@@ -8,6 +8,7 @@ from driftshield.cli.parsers import ParserNotFoundError, detect_parser, get_pars
 from driftshield.parsers.claude_desktop import ClaudeDesktopParser
 from driftshield.parsers.codex_cli import CodexCliParser
 from driftshield.parsers.codex_desktop import CodexDesktopParser
+from driftshield.parsers.crewai import CrewAIParser
 from driftshield.parsers.langchain import LangChainParser
 
 
@@ -35,6 +36,10 @@ class TestGetParser:
     def test_get_codex_desktop_parser(self):
         parser = get_parser("codex_desktop")
         assert isinstance(parser, CodexDesktopParser)
+
+    def test_get_crewai_parser(self):
+        parser = get_parser("crewai")
+        assert isinstance(parser, CrewAIParser)
 
     def test_get_langchain_parser(self):
         parser = get_parser("langchain")

--- a/driftshield/tests/fixtures/transcripts/sample_crewai_session.json
+++ b/driftshield/tests/fixtures/transcripts/sample_crewai_session.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "crewai-run-001",
+  "crew_name": "Repo Investigation Crew",
+  "input": "Inspect the README and identify obvious risks.",
+  "started_at": "2026-04-21T02:20:00Z",
+  "tasks": [
+    {
+      "id": "task-1",
+      "name": "inspect_readme",
+      "description": "Read the README and identify obvious risks.",
+      "expected_output": "A short list of concrete risks.",
+      "status": "completed",
+      "started_at": "2026-04-21T02:20:01Z",
+      "completed_at": "2026-04-21T02:20:04Z",
+      "agent": {
+        "role": "researcher",
+        "goal": "Inspect repository documents"
+      },
+      "tool_calls": [
+        {
+          "tool_name": "read_file",
+          "input": {
+            "file_path": "README.md"
+          },
+          "output": {
+            "content": "# DriftShield\nA decision forensics platform."
+          },
+          "error": null
+        }
+      ],
+      "output": "The README is present and the main risk is missing setup detail."
+    }
+  ]
+}

--- a/driftshield/tests/parsers/test_crewai.py
+++ b/driftshield/tests/parsers/test_crewai.py
@@ -1,0 +1,74 @@
+"""Tests for the CrewAI transcript parser."""
+
+import json
+from pathlib import Path
+
+from driftshield.core.models import EventType
+from driftshield.parsers.crewai import CrewAIParser
+
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "transcripts"
+
+
+class TestCrewAIParser:
+    def test_parses_representative_crewai_export_fixture(self):
+        parser = CrewAIParser()
+        events = parser.parse_file(str(FIXTURES_DIR / "sample_crewai_session.json"))
+
+        assert [event.event_type for event in events] == [
+            EventType.OUTPUT,
+            EventType.TOOL_CALL,
+            EventType.OUTPUT,
+        ]
+        assert [event.action for event in events] == [
+            "user_message",
+            "read_file",
+            "assistant_narrative",
+        ]
+        assert all(event.session_id == "crewai-run-001" for event in events)
+        assert events[0].outputs["text"] == "Inspect the README and identify obvious risks."
+        assert events[1].inputs["tool_input"] == {"file_path": "README.md"}
+        assert events[1].outputs["result"] == {
+            "content": "# DriftShield\nA decision forensics platform."
+        }
+        assert events[2].outputs["text"] == "The README is present and the main risk is missing setup detail."
+
+    def test_parse_accepts_direct_payload_string(self):
+        parser = CrewAIParser()
+        payload = {
+            "run_id": "crewai-inline",
+            "input": "Check parser support.",
+            "started_at": "2026-04-21T02:25:00Z",
+            "tasks": [
+                {
+                    "id": "task-inline",
+                    "name": "lookup_notes",
+                    "description": "Lookup parser notes",
+                    "status": "completed",
+                    "started_at": "2026-04-21T02:25:01Z",
+                    "completed_at": "2026-04-21T02:25:03Z",
+                    "agent": {"role": "analyst", "goal": "Check notes"},
+                    "tool_calls": [
+                        {
+                            "tool_name": "search_notes",
+                            "input": {"query": "parser support"},
+                            "output": {"status": "ok"},
+                            "error": None,
+                        }
+                    ],
+                    "output": "Parser notes found.",
+                }
+            ],
+        }
+
+        events = parser.parse(json.dumps(payload))
+
+        assert len(events) == 3
+        assert events[0].session_id == "crewai-inline"
+        assert events[1].action == "search_notes"
+        assert events[1].outputs["result"] == {"status": "ok"}
+        assert events[2].outputs["text"] == "Parser notes found."
+
+    def test_source_type_is_crewai(self):
+        parser = CrewAIParser()
+        assert parser.source_type == "crewai"

--- a/driftshield/tests/parsers/test_crewai.py
+++ b/driftshield/tests/parsers/test_crewai.py
@@ -69,6 +69,55 @@ class TestCrewAIParser:
         assert events[1].outputs["result"] == {"status": "ok"}
         assert events[2].outputs["text"] == "Parser notes found."
 
+    def test_emits_one_event_per_tool_call_within_task(self):
+        parser = CrewAIParser()
+        payload = {
+            "run_id": "crewai-multi-tool",
+            "input": "Inspect docs and config.",
+            "started_at": "2026-04-21T02:30:00Z",
+            "tasks": [
+                {
+                    "id": "task-multi",
+                    "name": "inspect_repo",
+                    "description": "Inspect docs and config",
+                    "status": "completed",
+                    "started_at": "2026-04-21T02:30:01Z",
+                    "completed_at": "2026-04-21T02:30:04Z",
+                    "agent": {"role": "researcher", "goal": "Inspect files"},
+                    "tool_calls": [
+                        {
+                            "tool_name": "read_file",
+                            "input": {"file_path": "README.md"},
+                            "output": {"content": "# README"},
+                            "error": None,
+                        },
+                        {
+                            "tool_name": "read_file",
+                            "input": {"file_path": "pyproject.toml"},
+                            "output": {"content": "[project]"},
+                            "error": None,
+                        },
+                    ],
+                    "output": "Repo inspection completed.",
+                }
+            ],
+        }
+
+        events = parser.parse(json.dumps(payload))
+
+        assert [event.action for event in events] == [
+            "user_message",
+            "read_file",
+            "read_file",
+            "assistant_narrative",
+        ]
+        assert events[1].inputs["tool_input"] == {"file_path": "README.md"}
+        assert events[1].outputs["result"] == {"content": "# README"}
+        assert events[1].metadata["tool_call_index"] == 0
+        assert events[2].inputs["tool_input"] == {"file_path": "pyproject.toml"}
+        assert events[2].outputs["result"] == {"content": "[project]"}
+        assert events[2].metadata["tool_call_index"] == 1
+
     def test_source_type_is_crewai(self):
         parser = CrewAIParser()
         assert parser.source_type == "crewai"

--- a/driftshield/tests/parsers/test_crewai.py
+++ b/driftshield/tests/parsers/test_crewai.py
@@ -118,6 +118,40 @@ class TestCrewAIParser:
         assert events[2].outputs["result"] == {"content": "[project]"}
         assert events[2].metadata["tool_call_index"] == 1
 
+    def test_skips_tool_call_event_when_task_has_no_tool_calls(self):
+        parser = CrewAIParser()
+        payload = {
+            "run_id": "crewai-no-tool",
+            "input": "Summarise the incident.",
+            "started_at": "2026-04-21T02:35:00Z",
+            "tasks": [
+                {
+                    "id": "task-no-tool",
+                    "name": "summarise_incident",
+                    "description": "Summarise the incident without tools",
+                    "status": "completed",
+                    "started_at": "2026-04-21T02:35:01Z",
+                    "completed_at": "2026-04-21T02:35:04Z",
+                    "agent": {"role": "analyst", "goal": "Summarise incident"},
+                    "tool_calls": [],
+                    "output": "Incident summarised from existing context.",
+                }
+            ],
+        }
+
+        events = parser.parse(json.dumps(payload))
+
+        assert [event.event_type for event in events] == [
+            EventType.OUTPUT,
+            EventType.OUTPUT,
+        ]
+        assert [event.action for event in events] == [
+            "user_message",
+            "assistant_narrative",
+        ]
+        assert events[1].parent_event_id == events[0].id
+        assert events[1].outputs["text"] == "Incident summarised from existing context."
+
     def test_source_type_is_crewai(self):
         parser = CrewAIParser()
         assert parser.source_type == "crewai"


### PR DESCRIPTION
## Summary
- add a bounded `crewai` parser for representative CrewAI exported run JSON
- add a representative CrewAI fixture and targeted parser coverage
- wire the parser into CLI ingest/registry paths and add ingest smoke coverage
- emit one canonical event per CrewAI tool call within a task

## Testing
- `PYTHONPATH=src pytest tests/parsers/test_crewai.py tests/cli/test_parsers.py tests/cli/test_ingest.py tests/api/test_ingest.py -q`
- `./scripts/check-public-scope.sh`

Closes #12
Refs tborys/driftshield-meta#23
