### PR TITLE
fix: keep runtime sources in sdist builds

### DIFF
--- a/driftshield/pyproject.toml
+++ b/driftshield/pyproject.toml
@@ -39,10 +39,14 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/driftshield"]
-
-[tool.hatch.build]
 include = [
     "src/driftshield/signatures/packs/*.json",
+]
+
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "src/driftshield",
+    "tests",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- scope the bundled community manifest include to the wheel target
- add an explicit sdist selection so source builds ship `src/driftshield` and `tests`
- avoid the broken sdist case where only the manifest and metadata were published

## Verification
- `cd /Users/tomasz.borys/github/driftshield/driftshield && uv run --extra dev pytest tests/test_community_signature_pack.py -q`
- `cd /Users/tomasz.borys/github/driftshield/driftshield && uv run --with build python -m build --sdist --wheel --outdir /tmp/driftshield-build-check`

## Context
- follow-up to the unresolved Codex packaging finding on PR #29
