### PR TITLE
feat: add community signature distribution pull flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ follow-up.
 
 DriftShield uses a parser protocol. New sources can be added by implementing a single interface.
 
+## Community signature packs
+
+Phase 2a uses a deliberately simple pull flow for community-safe signature packs. Packs are versioned JSON manifests that follow the Phase 2a contract and can be fetched directly from a Git ref or tag.
+
+Example:
+
+```bash
+source .venv/bin/activate
+driftshield signatures pull community-general --ref <git-tag-or-commit>
+```
+
+By default this pulls from `tborys/driftshield` and stores the validated manifest under `~/.local/share/driftshield/signatures/<pack-name>/<pack-version>/`.
+
+If you need to test or mirror a pack source, override the source URL directly:
+
+```bash
+driftshield signatures pull community-general \
+  --ref local-smoke \
+  --url http://127.0.0.1:8000/community-general.json
+```
+
+Compatibility rules for the first rollout:
+
+- `schema_version` is the compatibility gate and is validated before installation
+- `pack_metadata.version` is the pack release version and determines the install path
+- only `pack_kind: community` is accepted by the OSS pull path
+- the pull flow is intentionally replaceable later without committing DriftShield to a marketplace design
+
 ## Quick Start
 
 ### Prerequisites

--- a/driftshield/src/driftshield/cli/commands/signatures.py
+++ b/driftshield/src/driftshield/cli/commands/signatures.py
@@ -22,8 +22,10 @@ app = typer.Typer(help="Manage community signature pack distribution.")
 @app.command("pull")
 def pull_signature_pack(
     pack_name: str = typer.Argument(..., help="Community pack name without the .json suffix."),
-    ref: str = typer.Option(
-        ..., "--ref", help="Git ref or tag to pull from when using the default GitHub source."
+    ref: str | None = typer.Option(
+        None,
+        "--ref",
+        help="Git ref or tag to pull from when using the default GitHub source.",
     ),
     repository: str = typer.Option(
         DEFAULT_COMMUNITY_REPOSITORY,
@@ -43,9 +45,13 @@ def pull_signature_pack(
     json_output: bool = typer.Option(False, "--json", help="Output JSON."),
 ) -> None:
     """Fetch, validate, and install a versioned community signature pack manifest."""
+    if source_url is None and ref is None:
+        console.print("[red]Error:[/red] --ref is required unless --url is provided.")
+        raise typer.Exit(1)
+
     resolved_source_url = source_url or build_github_raw_pack_url(
         repository=repository,
-        ref=ref,
+        ref=ref or "",
         pack_name=pack_name,
     )
 

--- a/driftshield/src/driftshield/cli/commands/signatures.py
+++ b/driftshield/src/driftshield/cli/commands/signatures.py
@@ -19,6 +19,13 @@ console = Console(force_terminal=True)
 app = typer.Typer(help="Manage community signature pack distribution.")
 
 
+def _validate_repository(repository: str) -> str:
+    parts = repository.split("/", maxsplit=1)
+    if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+        raise ValueError("--repository must use the format owner/repo")
+    return f"{parts[0].strip()}/{parts[1].strip()}"
+
+
 @app.command("pull")
 def pull_signature_pack(
     pack_name: str = typer.Argument(..., help="Community pack name without the .json suffix."),
@@ -49,13 +56,12 @@ def pull_signature_pack(
         console.print("[red]Error:[/red] --ref is required unless --url is provided.")
         raise typer.Exit(1)
 
-    resolved_source_url = source_url or build_github_raw_pack_url(
-        repository=repository,
-        ref=ref or "",
-        pack_name=pack_name,
-    )
-
     try:
+        resolved_source_url = source_url or build_github_raw_pack_url(
+            repository=_validate_repository(repository),
+            ref=ref or "",
+            pack_name=pack_name,
+        )
         pulled = install_community_pack(
             source_url=resolved_source_url,
             destination=output,

--- a/driftshield/src/driftshield/cli/commands/signatures.py
+++ b/driftshield/src/driftshield/cli/commands/signatures.py
@@ -20,10 +20,10 @@ app = typer.Typer(help="Manage community signature pack distribution.")
 
 
 def _validate_repository(repository: str) -> str:
-    parts = repository.split("/", maxsplit=1)
-    if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
-        raise ValueError("--repository must use the format owner/repo")
-    return f"{parts[0].strip()}/{parts[1].strip()}"
+    parts = [part.strip() for part in repository.split("/")]
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError("--repository must use the exact format owner/repo")
+    return f"{parts[0]}/{parts[1]}"
 
 
 @app.command("pull")

--- a/driftshield/src/driftshield/cli/commands/signatures.py
+++ b/driftshield/src/driftshield/cli/commands/signatures.py
@@ -1,0 +1,80 @@
+"""CLI commands for pulling community signature packs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from driftshield.signatures.distribution import (
+    DEFAULT_COMMUNITY_REPOSITORY,
+    build_github_raw_pack_url,
+    describe_pack_source,
+    install_community_pack,
+)
+
+console = Console(force_terminal=True)
+app = typer.Typer(help="Manage community signature pack distribution.")
+
+
+@app.command("pull")
+def pull_signature_pack(
+    pack_name: str = typer.Argument(..., help="Community pack name without the .json suffix."),
+    ref: str = typer.Option(
+        ..., "--ref", help="Git ref or tag to pull from when using the default GitHub source."
+    ),
+    repository: str = typer.Option(
+        DEFAULT_COMMUNITY_REPOSITORY,
+        "--repository",
+        help="GitHub repository that publishes the raw community pack manifest.",
+    ),
+    source_url: str | None = typer.Option(
+        None,
+        "--url",
+        help="Explicit manifest URL. Overrides --repository/--ref when supplied.",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Write the validated pack manifest to this exact path instead of the default install cache.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    """Fetch, validate, and install a versioned community signature pack manifest."""
+    resolved_source_url = source_url or build_github_raw_pack_url(
+        repository=repository,
+        ref=ref,
+        pack_name=pack_name,
+    )
+
+    try:
+        pulled = install_community_pack(
+            source_url=resolved_source_url,
+            destination=output,
+        )
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Could not pull pack: {exc}")
+        raise typer.Exit(1) from exc
+
+    payload = {
+        "pack_name": pulled.manifest.metadata.name,
+        "pack_version": pulled.manifest.metadata.version,
+        "schema_version": pulled.manifest.schema_version,
+        "source_url": describe_pack_source(pulled.source_url),
+        "installed_path": str(pulled.installed_path),
+        "signature_count": len(pulled.manifest.signatures),
+        "family_coverage": list(pulled.manifest.family_coverage),
+    }
+    if json_output:
+        typer.echo(json.dumps(payload))
+        return
+
+    console.print(
+        "[green]Pulled community pack[/green] "
+        f"{payload['pack_name']}@{payload['pack_version']} "
+        f"(schema {payload['schema_version']}, signatures={payload['signature_count']})."
+    )
+    console.print(f"Source: {payload['source_url']}")
+    console.print(f"Installed: {payload['installed_path']}")

--- a/driftshield/src/driftshield/cli/main.py
+++ b/driftshield/src/driftshield/cli/main.py
@@ -11,6 +11,7 @@ from driftshield.cli.commands.ingest import ingest
 from driftshield.cli.commands.inspect import inspect
 from driftshield.cli.commands.list import list_sessions
 from driftshield.cli.commands.report import report_command
+from driftshield.cli.commands.signatures import app as signatures_app
 from driftshield.cli.commands.telemetry import app as telemetry_app
 
 app = typer.Typer(
@@ -28,6 +29,7 @@ app.command(name="export-validations")(export_validations)
 app.command(name="generate-fixtures")(generate_fixtures)
 app.command()(ingest)
 app.add_typer(connectors_app, name="connectors")
+app.add_typer(signatures_app, name="signatures")
 app.add_typer(telemetry_app, name="telemetry")
 
 

--- a/driftshield/src/driftshield/signatures/distribution.py
+++ b/driftshield/src/driftshield/signatures/distribution.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote, urlparse
+from urllib.request import urlopen
+
+from driftshield.signatures.community import CommunityPackManifest, parse_community_pack
+
+DEFAULT_COMMUNITY_REPOSITORY = "tborys/driftshield"
+DEFAULT_COMMUNITY_PACK_PATH = "driftshield/src/driftshield/signatures/packs"
+
+
+@dataclass(frozen=True, slots=True)
+class PulledCommunityPack:
+    source_url: str
+    installed_path: Path
+    manifest: CommunityPackManifest
+
+
+def build_github_raw_pack_url(
+    *,
+    repository: str = DEFAULT_COMMUNITY_REPOSITORY,
+    ref: str,
+    pack_name: str,
+    pack_path: str = DEFAULT_COMMUNITY_PACK_PATH,
+) -> str:
+    owner, repo = repository.split("/", maxsplit=1)
+    encoded_ref = quote(ref, safe="")
+    relative_pack_path = "/".join(part.strip("/") for part in (pack_path, f"{pack_name}.json"))
+    return f"https://raw.githubusercontent.com/{owner}/{repo}/{encoded_ref}/{relative_pack_path}"
+
+
+def install_community_pack(
+    *,
+    source_url: str,
+    destination: Path | None = None,
+) -> PulledCommunityPack:
+    payload = _download_manifest_payload(source_url)
+    manifest = parse_community_pack(payload)
+    if manifest.pack_kind != "community":
+        raise ValueError(
+            f"unsupported pack_kind {manifest.pack_kind!r}; expected 'community' for OSS distribution"
+        )
+
+    target_path = destination or default_pack_install_path(
+        pack_name=manifest.metadata.name,
+        version=manifest.metadata.version,
+    )
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    return PulledCommunityPack(
+        source_url=source_url,
+        installed_path=target_path,
+        manifest=manifest,
+    )
+
+
+def default_pack_install_path(*, pack_name: str, version: str) -> Path:
+    return (
+        Path.home()
+        / ".local"
+        / "share"
+        / "driftshield"
+        / "signatures"
+        / pack_name
+        / version
+        / f"{pack_name}.json"
+    )
+
+
+def _download_manifest_payload(source_url: str) -> dict[str, object]:
+    with urlopen(source_url) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def describe_pack_source(source_url: str) -> str:
+    parsed = urlparse(source_url)
+    if parsed.scheme in {"http", "https", "file"}:
+        return source_url
+    return str(Path(source_url).expanduser().resolve())

--- a/driftshield/src/driftshield/signatures/distribution.py
+++ b/driftshield/src/driftshield/signatures/distribution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 from urllib.parse import quote, urlparse
 from urllib.request import urlopen
 
@@ -59,21 +59,39 @@ def install_community_pack(
 
 
 def default_pack_install_path(*, pack_name: str, version: str) -> Path:
+    safe_pack_name = _require_safe_path_component(pack_name, field_name="pack_metadata.name")
+    safe_version = _require_safe_path_component(version, field_name="pack_metadata.version")
     return (
         Path.home()
         / ".local"
         / "share"
         / "driftshield"
         / "signatures"
-        / pack_name
-        / version
-        / f"{pack_name}.json"
+        / safe_pack_name
+        / safe_version
+        / f"{safe_pack_name}.json"
     )
 
 
 def _download_manifest_payload(source_url: str) -> dict[str, object]:
     with urlopen(source_url) as response:
         return json.loads(response.read().decode("utf-8"))
+
+
+def _require_safe_path_component(value: str, *, field_name: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError(f"{field_name} is required")
+
+    pure_path = PurePath(candidate)
+    if (
+        pure_path.name != candidate
+        or len(pure_path.parts) != 1
+        or candidate in {".", ".."}
+        or candidate.startswith(("/", "\\"))
+    ):
+        raise ValueError(f"{field_name} must be a single safe path component")
+    return candidate
 
 
 def describe_pack_source(source_url: str) -> str:

--- a/driftshield/tests/cli/test_main.py
+++ b/driftshield/tests/cli/test_main.py
@@ -23,6 +23,7 @@ def test_cli_help_omits_private_commands():
     assert "evaluate-signatures" not in result.output
     assert "analyze" in result.output
     assert "report" in result.output
+    assert "signatures" in result.output
 
 
 def test_installed_console_script_starts_without_test_module_imports(tmp_path):

--- a/driftshield/tests/cli/test_signatures.py
+++ b/driftshield/tests/cli/test_signatures.py
@@ -145,22 +145,23 @@ def test_default_pack_install_path_rejects_unsafe_manifest_path_components() -> 
 
 
 def test_pull_signature_pack_rejects_invalid_repository_value() -> None:
-    result = runner.invoke(
-        app,
-        [
-            "signatures",
-            "pull",
-            "community-general",
-            "--ref",
-            "v1.2.3",
-            "--repository",
-            "tborys",
-        ],
-    )
+    for invalid_repository in ("tborys", "owner/repo/extra"):
+        result = runner.invoke(
+            app,
+            [
+                "signatures",
+                "pull",
+                "community-general",
+                "--ref",
+                "v1.2.3",
+                "--repository",
+                invalid_repository,
+            ],
+        )
 
-    assert result.exit_code == 1
-    assert "Could not pull pack" in result.output
-    assert "owner/repo" in result.output
+        assert result.exit_code == 1
+        assert "Could not pull pack" in result.output
+        assert "owner/repo" in result.output
 
 
 def test_pull_signature_pack_rejects_non_community_pack(monkeypatch) -> None:

--- a/driftshield/tests/cli/test_signatures.py
+++ b/driftshield/tests/cli/test_signatures.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from driftshield.cli.main import app
-from driftshield.signatures.distribution import build_github_raw_pack_url
+from driftshield.signatures.distribution import (
+    build_github_raw_pack_url,
+    default_pack_install_path,
+)
 
 
 runner = CliRunner()
@@ -95,6 +98,50 @@ def test_pull_signature_pack_writes_versioned_manifest(monkeypatch, tmp_path: Pa
     assert installed_payload["pack_metadata"]["version"] == "1.2.3"
     assert "community-general@" in result.output
     assert "schema" in result.output
+
+
+def test_pull_signature_pack_allows_url_without_ref(monkeypatch, tmp_path: Path) -> None:
+    payload = _community_pack_payload(version="1.2.3")
+
+    def fake_urlopen(source_url: str) -> DummyResponse:
+        assert source_url == "https://example.test/community-general.json"
+        return DummyResponse(payload)
+
+    monkeypatch.setattr("driftshield.signatures.distribution.urlopen", fake_urlopen)
+
+    output = tmp_path / "packs" / "community-general.json"
+    result = runner.invoke(
+        app,
+        [
+            "signatures",
+            "pull",
+            "community-general",
+            "--url",
+            "https://example.test/community-general.json",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert output.exists()
+
+
+def test_default_pack_install_path_rejects_unsafe_manifest_path_components() -> None:
+    for unsafe_value in ("../escape", "nested/path", "..", "/absolute"):
+        try:
+            default_pack_install_path(pack_name=unsafe_value, version="1.2.3")
+        except ValueError as exc:
+            assert "single safe path component" in str(exc)
+        else:
+            raise AssertionError("unsafe pack_name should be rejected")
+
+    try:
+        default_pack_install_path(pack_name="community-general", version="../1.2.3")
+    except ValueError as exc:
+        assert "single safe path component" in str(exc)
+    else:
+        raise AssertionError("unsafe version should be rejected")
 
 
 def test_pull_signature_pack_rejects_non_community_pack(monkeypatch) -> None:

--- a/driftshield/tests/cli/test_signatures.py
+++ b/driftshield/tests/cli/test_signatures.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from driftshield.cli.main import app
+from driftshield.signatures.distribution import build_github_raw_pack_url
+
+
+runner = CliRunner()
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, object]):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def _community_pack_payload(*, version: str = "1.2.3", pack_kind: str = "community") -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "pack_metadata": {
+            "name": "community-general",
+            "version": version,
+            "description": "General-purpose DriftShield community signatures.",
+            "pack_kind": pack_kind,
+            "family_coverage": ["coverage_gap"],
+        },
+        "signatures": [
+            {
+                "signature_id": "SIG-COMM-001",
+                "family_id": "coverage_gap",
+                "title": "Missing Retrieved Entities",
+                "signature_layer": {
+                    "surface": "output",
+                    "symptom": "missing key entities in response",
+                    "suspected_root_cause": "retrieval did not return full context",
+                    "pattern_hint": "coverage_gap",
+                },
+                "failure_shape": "retrieve->synthesise->respond",
+            }
+        ],
+    }
+
+
+def test_build_github_raw_pack_url_uses_repository_ref_and_pack_name() -> None:
+    assert build_github_raw_pack_url(
+        repository="tborys/driftshield",
+        ref="v1.2.3",
+        pack_name="community-general",
+    ) == (
+        "https://raw.githubusercontent.com/tborys/driftshield/"
+        "v1.2.3/driftshield/src/driftshield/signatures/packs/community-general.json"
+    )
+
+
+def test_pull_signature_pack_writes_versioned_manifest(monkeypatch, tmp_path: Path) -> None:
+    payload = _community_pack_payload(version="1.2.3")
+
+    def fake_urlopen(source_url: str) -> DummyResponse:
+        assert source_url == "https://example.test/community-general.json"
+        return DummyResponse(payload)
+
+    monkeypatch.setattr("driftshield.signatures.distribution.urlopen", fake_urlopen)
+
+    output = tmp_path / "packs" / "community-general.json"
+    result = runner.invoke(
+        app,
+        [
+            "signatures",
+            "pull",
+            "community-general",
+            "--ref",
+            "v1.2.3",
+            "--url",
+            "https://example.test/community-general.json",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert output.exists()
+    installed_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert installed_payload["pack_metadata"]["version"] == "1.2.3"
+    assert "community-general@" in result.output
+    assert "schema" in result.output
+
+
+def test_pull_signature_pack_rejects_non_community_pack(monkeypatch) -> None:
+    def fake_urlopen(source_url: str) -> DummyResponse:
+        return DummyResponse(_community_pack_payload(pack_kind="private"))
+
+    monkeypatch.setattr("driftshield.signatures.distribution.urlopen", fake_urlopen)
+
+    result = runner.invoke(
+        app,
+        [
+            "signatures",
+            "pull",
+            "community-general",
+            "--ref",
+            "v1.2.3",
+            "--url",
+            "https://example.test/private-pack.json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "unsupported pack_kind" in result.output
+    assert "community" in result.output

--- a/driftshield/tests/cli/test_signatures.py
+++ b/driftshield/tests/cli/test_signatures.py
@@ -144,6 +144,25 @@ def test_default_pack_install_path_rejects_unsafe_manifest_path_components() -> 
         raise AssertionError("unsafe version should be rejected")
 
 
+def test_pull_signature_pack_rejects_invalid_repository_value() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "signatures",
+            "pull",
+            "community-general",
+            "--ref",
+            "v1.2.3",
+            "--repository",
+            "tborys",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Could not pull pack" in result.output
+    assert "owner/repo" in result.output
+
+
 def test_pull_signature_pack_rejects_non_community_pack(monkeypatch) -> None:
     def fake_urlopen(source_url: str) -> DummyResponse:
         return DummyResponse(_community_pack_payload(pack_kind="private"))


### PR DESCRIPTION
$## Summary
- add a `driftshield signatures pull` CLI command for fetching versioned community pack manifests from a Git ref or explicit URL
- validate the raw manifest before install, reject non-community packs on the OSS path, and install under a versioned local cache path
- document the first Phase 2a pull/update flow and add targeted CLI coverage

## Testing
- `cd driftshield && PYTHONPATH=src pytest tests/cli/test_signatures.py tests/test_community_signature_pack.py`
- `cd driftshield && PYTHONPATH=src python3 -m compileall src/driftshield`

Closes #16