### PR TITLE
Phase 2a: surface signature and recurrence status in investigation UI

### DIFF
--- a/driftshield/frontend/package-lock.json
+++ b/driftshield/frontend/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -1721,6 +1722,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",

--- a/driftshield/frontend/package.json
+++ b/driftshield/frontend/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@playwright/test": "^1.59.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/driftshield/frontend/src/pages/InvestigationPage.tsx
+++ b/driftshield/frontend/src/pages/InvestigationPage.tsx
@@ -7,6 +7,100 @@ import { useSessionReports } from '../api/reports'
 import { InvestigationView } from '../components/investigation/InvestigationView'
 import { ReportTrigger } from '../components/reports/ReportTrigger'
 import { ReportPreview } from '../components/reports/ReportPreview'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+
+function labelFromValue(value: string | null | undefined) {
+  if (!value) {
+    return null
+  }
+
+  return value.replace(/[_-]/g, ' ')
+}
+
+function SignatureAndRecurrenceCard({
+  loading,
+  session,
+}: {
+  loading: boolean
+  session: ReturnType<typeof useSession>['data']
+}) {
+  const signatureMatch = session?.signature_match ?? null
+  const recurrenceStatus = session?.recurrence_status ?? null
+  const matchedFamilies = signatureMatch?.matched_family_ids ?? []
+  const matchStatus = signatureMatch?.status ?? null
+  const recurrenceLabel = labelFromValue(recurrenceStatus?.status)
+  const signatureLabel = labelFromValue(matchStatus)
+  const hasSignatureData = signatureMatch !== null
+  const hasRecurrenceData = recurrenceStatus !== null
+  const showUnavailable = !loading && !hasSignatureData && !hasRecurrenceData
+  const showUnmatched = !loading && hasSignatureData && matchStatus === 'unmatched'
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Signature and recurrence</CardTitle>
+        <CardDescription>
+          Phase 2a classification output from the backend, with explicit unavailable states.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {loading ? (
+          <div className="text-muted-foreground">Loading classification summary...</div>
+        ) : showUnavailable ? (
+          <div className="rounded-md border bg-muted/30 p-3 text-muted-foreground">
+            This session does not expose signature or recurrence data yet.
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant={matchStatus === 'matched' ? 'destructive' : 'outline'}>
+                Signature: {signatureLabel ?? 'unavailable'}
+              </Badge>
+              <Badge variant={recurrenceStatus?.status === 'recurring' ? 'destructive' : 'outline'}>
+                Recurrence: {recurrenceLabel ?? 'unavailable'}
+              </Badge>
+              {signatureMatch?.match_count !== null && signatureMatch?.match_count !== undefined && (
+                <Badge variant="outline">{signatureMatch.match_count} match{signatureMatch.match_count === 1 ? '' : 'es'}</Badge>
+              )}
+              {recurrenceStatus?.recurrence_count !== null && recurrenceStatus?.recurrence_count !== undefined && (
+                <Badge variant="outline">{recurrenceStatus.recurrence_count} related run{recurrenceStatus.recurrence_count === 1 ? '' : 's'}</Badge>
+              )}
+            </div>
+
+            {signatureMatch?.summary && <p>{signatureMatch.summary}</p>}
+            {!signatureMatch?.summary && showUnmatched && (
+              <p className="text-muted-foreground">No signature matches were returned for this session.</p>
+            )}
+            {recurrenceStatus?.summary && <p>{recurrenceStatus.summary}</p>}
+
+            {matchedFamilies.length > 0 && (
+              <div className="space-y-2">
+                <div className="text-xs font-medium text-muted-foreground">Matched families</div>
+                <div className="flex flex-wrap gap-2">
+                  {matchedFamilies.map((familyId) => (
+                    <Badge key={familyId} variant="secondary">{labelFromValue(familyId) ?? familyId}</Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {signatureMatch?.primary_family_id && (
+              <div className="text-muted-foreground">
+                Primary family: <span className="font-medium text-foreground">{labelFromValue(signatureMatch.primary_family_id)}</span>
+              </div>
+            )}
+
+            {recurrenceStatus?.cluster_id && (
+              <div className="text-muted-foreground">
+                Cluster: <span className="font-mono text-foreground">{recurrenceStatus.cluster_id}</span>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
 
 export function InvestigationPage() {
   const { id } = useParams<{ id: string }>()
@@ -69,15 +163,16 @@ export function InvestigationPage() {
         <ReportTrigger sessionId={id!} onReportGenerated={setPreviewReportId} />
       </div>
 
-      <div className="px-6 py-3 border-b">
-        <div className="flex items-center justify-between mb-2">
-          <div className="text-sm font-medium">Session reports</div>
-          {reports && reports.length > 0 && (
-            <Button variant="ghost" size="sm" onClick={() => setPreviewReportId(reports[0].id)}>
-              Open latest
-            </Button>
-          )}
-        </div>
+      <div className="px-6 py-3 border-b grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-sm font-medium">Session reports</div>
+            {reports && reports.length > 0 && (
+              <Button variant="ghost" size="sm" onClick={() => setPreviewReportId(reports[0].id)}>
+                Open latest
+              </Button>
+            )}
+          </div>
 
         {reportsLoading && (
           <div className="text-sm text-muted-foreground">Loading report history...</div>
@@ -107,6 +202,9 @@ export function InvestigationPage() {
             </div>
           </div>
         )}
+        </div>
+
+        <SignatureAndRecurrenceCard loading={sessionLoading} session={session} />
       </div>
 
       <InvestigationView graph={graph} />

--- a/driftshield/frontend/src/types/session.ts
+++ b/driftshield/frontend/src/types/session.ts
@@ -17,10 +17,29 @@ export interface SessionSummary {
   provenance: SessionProvenance | null
 }
 
+export interface SignatureMatchSummary {
+  status: string | null
+  primary_family_id: string | null
+  matched_family_ids: string[]
+  match_count: number | null
+  summary: string | null
+  raw: Record<string, unknown> | null
+}
+
+export interface RecurrenceStatus {
+  status: string | null
+  cluster_id: string | null
+  recurrence_count: number | null
+  summary: string | null
+  raw: Record<string, unknown> | null
+}
+
 export interface SessionDetail extends SessionSummary {
   total_events: number
   flagged_events: number
   risk_summary: Record<string, number>
+  signature_match?: SignatureMatchSummary | null
+  recurrence_status?: RecurrenceStatus | null
 }
 
 export interface PaginatedResponse<T> {

--- a/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
+++ b/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test'
+
+const sessionId = '11111111-1111-1111-1111-111111111111'
+
+test('shows matched signature and recurrence states from backend metadata', async ({ page }) => {
+  await page.route(`**/api/sessions/${sessionId}`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: sessionId,
+        agent_id: 'claude-code',
+        external_id: null,
+        status: 'completed',
+        started_at: '2026-04-21T10:00:00Z',
+        ended_at: '2026-04-21T10:05:00Z',
+        risk_flag_count: 2,
+        has_inflection: true,
+        provenance: {
+          source_session_id: 'src-1',
+          source_path: 'uploads/test.jsonl',
+          parser_version: 'claude_code@1',
+          ingested_at: '2026-04-21T10:06:00Z',
+        },
+        total_events: 4,
+        flagged_events: 2,
+        risk_summary: { coverage_gap: 2 },
+        explanations: { risk_explanations: {}, inflection_explanation: null },
+        signature_match: {
+          status: 'matched',
+          primary_family_id: 'coverage_gap',
+          matched_family_ids: ['coverage_gap', 'verification_failure'],
+          match_count: 2,
+          summary: 'Matched two known failure families.',
+          raw: null,
+        },
+        recurrence_status: {
+          status: 'recurring',
+          cluster_id: 'cluster-42',
+          recurrence_count: 3,
+          summary: 'Seen in three related runs.',
+          raw: null,
+        },
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/graph`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session_id: sessionId,
+        provenance: null,
+        nodes: [
+          {
+            id: '22222222-2222-2222-2222-222222222222',
+            event_type: 'TOOL_CALL',
+            action: 'review_sections',
+            sequence_num: 1,
+            risk_flags: ['coverage_gap'],
+            risk_explanations: {},
+            is_inflection: true,
+            inflection_explanation: null,
+            inputs: null,
+            outputs: null,
+            metadata: null,
+            parent_node_id: null,
+          },
+        ],
+        edges: [],
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/reports`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+
+  await page.goto(`/sessions/${sessionId}`)
+
+  await expect(page.getByText('Signature: matched')).toBeVisible()
+  await expect(page.getByText('Recurrence: recurring')).toBeVisible()
+  await expect(page.getByText('Matched two known failure families.')).toBeVisible()
+  await expect(page.getByText('Seen in three related runs.')).toBeVisible()
+  await expect(page.getByText('Primary family:')).toBeVisible()
+  await expect(page.getByText('Cluster:')).toBeVisible()
+})
+
+test('shows unavailable state when backend omits signature and recurrence fields', async ({ page }) => {
+  await page.route(`**/api/sessions/${sessionId}`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: sessionId,
+        agent_id: 'claude-code',
+        external_id: null,
+        status: 'completed',
+        started_at: '2026-04-21T10:00:00Z',
+        ended_at: '2026-04-21T10:05:00Z',
+        risk_flag_count: 0,
+        has_inflection: false,
+        provenance: null,
+        total_events: 1,
+        flagged_events: 0,
+        risk_summary: {},
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/graph`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session_id: sessionId,
+        provenance: null,
+        nodes: [
+          {
+            id: '22222222-2222-2222-2222-222222222222',
+            event_type: 'OUTPUT',
+            action: 'respond',
+            sequence_num: 1,
+            risk_flags: [],
+            risk_explanations: {},
+            is_inflection: false,
+            inflection_explanation: null,
+            inputs: null,
+            outputs: null,
+            metadata: null,
+            parent_node_id: null,
+          },
+        ],
+        edges: [],
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/reports`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+
+  await page.goto(`/sessions/${sessionId}`)
+
+  await expect(page.getByText('This session does not expose signature or recurrence data yet.')).toBeVisible()
+})

--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -12,11 +12,13 @@ from driftshield.api.schemas import (
     GraphNodeResponse,
     GraphResponse,
     PaginatedResponse,
+    RecurrenceStatusResponse,
     SessionDetail,
     SessionExplanationItemResponse,
     SessionExplanationsResponse,
     SessionProvenanceResponse,
     SessionSummary,
+    SignatureMatchSummaryResponse,
     ValidationCreateRequest,
     ValidationResponse,
 )
@@ -128,6 +130,57 @@ def _session_explanations(nodes: list[DecisionNodeModel]) -> SessionExplanations
     )
 
 
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _extract_signature_match(session: SessionModel) -> SignatureMatchSummaryResponse | None:
+    metadata = session.metadata_json or {}
+    payload = metadata.get("signature_match") or metadata.get("signature_summary")
+    if not isinstance(payload, dict):
+        return None
+
+    matched_family_ids = payload.get("matched_family_ids")
+    if not isinstance(matched_family_ids, list):
+        matched_family_ids = []
+
+    status = payload.get("status")
+    if not isinstance(status, str):
+        status = payload.get("outcome_status") if isinstance(payload.get("outcome_status"), str) else None
+
+    return SignatureMatchSummaryResponse(
+        status=status,
+        primary_family_id=(
+            payload.get("primary_family_id")
+            if isinstance(payload.get("primary_family_id"), str)
+            else None
+        ),
+        matched_family_ids=[item for item in matched_family_ids if isinstance(item, str)],
+        match_count=_optional_int(payload.get("match_count")),
+        summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
+        raw=payload,
+    )
+
+
+def _extract_recurrence_status(session: SessionModel) -> RecurrenceStatusResponse | None:
+    metadata = session.metadata_json or {}
+    payload = metadata.get("recurrence_status")
+    if not isinstance(payload, dict):
+        return None
+
+    return RecurrenceStatusResponse(
+        status=payload.get("status") if isinstance(payload.get("status"), str) else None,
+        cluster_id=payload.get("cluster_id") if isinstance(payload.get("cluster_id"), str) else None,
+        recurrence_count=_optional_int(payload.get("recurrence_count")),
+        summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
+        raw=payload,
+    )
+
+
 @router.get("/api/sessions")
 def list_sessions(
     page: int = Query(default=1, ge=1),
@@ -212,6 +265,8 @@ def get_session(
         flagged_events=risk_count,
         risk_summary=_risk_summary(nodes),
         explanations=_session_explanations(nodes),
+        signature_match=_extract_signature_match(session),
+        recurrence_status=_extract_recurrence_status(session),
     )
 
 

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -41,11 +41,30 @@ class SessionSummary(BaseModel):
     provenance: SessionProvenanceResponse | None = None
 
 
+class SignatureMatchSummaryResponse(BaseModel):
+    status: str | None = None
+    primary_family_id: str | None = None
+    matched_family_ids: list[str] = Field(default_factory=list)
+    match_count: int | None = None
+    summary: str | None = None
+    raw: dict[str, Any] | None = None
+
+
+class RecurrenceStatusResponse(BaseModel):
+    status: str | None = None
+    cluster_id: str | None = None
+    recurrence_count: int | None = None
+    summary: str | None = None
+    raw: dict[str, Any] | None = None
+
+
 class SessionDetail(SessionSummary):
     total_events: int = 0
     flagged_events: int = 0
     risk_summary: dict[str, int] = Field(default_factory=dict)
     explanations: SessionExplanationsResponse | None = None
+    signature_match: SignatureMatchSummaryResponse | None = None
+    recurrence_status: RecurrenceStatusResponse | None = None
 
 
 class GraphNodeResponse(BaseModel):

--- a/driftshield/tests/api/test_sessions.py
+++ b/driftshield/tests/api/test_sessions.py
@@ -54,6 +54,21 @@ def seeded_session(db_session):
         source_path="uploads/daily/test-agent.jsonl",
         parser_version="claude_code@1",
         ingested_at=datetime.now(timezone.utc),
+        metadata_json={
+            "signature_match": {
+                "status": "matched",
+                "primary_family_id": "coverage_gap",
+                "matched_family_ids": ["coverage_gap", "verification_failure"],
+                "match_count": 2,
+                "summary": "Matched two known failure families.",
+            },
+            "recurrence_status": {
+                "status": "recurring",
+                "cluster_id": "cluster-42",
+                "recurrence_count": 3,
+                "summary": "Seen in three related runs.",
+            },
+        },
     )
     node = DecisionNodeModel(
         id=uuid.uuid4(),
@@ -142,7 +157,70 @@ def test_get_session_detail(client, auth_headers, seeded_session):
             "evidence_refs": ["risk:coverage_gap"],
         },
     }
-    assert "recurrence_level" not in data
+    assert data["signature_match"] == {
+        "status": "matched",
+        "primary_family_id": "coverage_gap",
+        "matched_family_ids": ["coverage_gap", "verification_failure"],
+        "match_count": 2,
+        "summary": "Matched two known failure families.",
+        "raw": {
+            "status": "matched",
+            "primary_family_id": "coverage_gap",
+            "matched_family_ids": ["coverage_gap", "verification_failure"],
+            "match_count": 2,
+            "summary": "Matched two known failure families.",
+        },
+    }
+    assert data["recurrence_status"] == {
+        "status": "recurring",
+        "cluster_id": "cluster-42",
+        "recurrence_count": 3,
+        "summary": "Seen in three related runs.",
+        "raw": {
+            "status": "recurring",
+            "cluster_id": "cluster-42",
+            "recurrence_count": 3,
+            "summary": "Seen in three related runs.",
+        },
+    }
+
+
+def test_get_session_detail_falls_back_to_legacy_outcome_status(client, auth_headers, db_session):
+    session_id = uuid.uuid4()
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            agent_id="legacy-agent",
+            started_at=datetime.now(timezone.utc),
+            status="completed",
+            metadata_json={
+                "signature_summary": {
+                    "outcome_status": "matched",
+                    "primary_family_id": "coverage_gap",
+                    "matched_family_ids": ["coverage_gap"],
+                    "match_count": 1,
+                }
+            },
+        )
+    )
+    db_session.add(
+        DecisionNodeModel(
+            id=uuid.uuid4(),
+            session_id=session_id,
+            sequence_num=1,
+            event_type="TOOL_CALL",
+            action="legacy-review",
+            coverage_gap=True,
+        )
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/sessions/{session_id}", headers=auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["signature_match"]["status"] == "matched"
+    assert payload["signature_match"]["primary_family_id"] == "coverage_gap"
 
 
 def test_get_session_detail_orders_explanations_by_sequence(client, auth_headers, db_session):


### PR DESCRIPTION
## Summary
- expose optional signature-match and recurrence-status payloads from the session detail API
- render a compact investigation summary card with explicit matched, unmatched, and unavailable states
- add API coverage plus Playwright coverage for the new frontend surface
- refs tborys/driftshield-meta#35
- refs https://github.com/tborys/driftshield-meta/issues/35

## Verification
- `PYTHONPATH=src pytest tests/api/test_sessions.py`
- `npm run build`
- `npx playwright test tests/e2e/investigation-signature-summary.spec.ts`

Closes #18
