### PR TITLE
Phase 2a: formalise CrewAI as the additional parser

### DIFF
--- a/driftshield/docs/supported-sources.md
+++ b/driftshield/docs/supported-sources.md
@@ -7,6 +7,7 @@
 | Codex CLI | Yes | Yes | Best-effort | DriftShield now looks for local artefacts under `~/.codex/sessions/`. JSONL sessions with message and tool-call records are supported in this slice. |
 | Codex Desktop | Yes | Yes | Best-effort | DriftShield now looks for local artefacts under `~/.codex-desktop/sessions/`. JSON sessions with message arrays are supported in this slice. |
 | LangChain / LangSmith export JSON | No | Yes | No | Manual ingest via `--parser langchain`. Supported scope is bounded to exported run JSON with `inputs.messages`, `outputs.messages`, and tool child runs. |
+| CrewAI exported run JSON | No | Yes | No | Manual ingest via `--parser crewai`. Supported scope is bounded to representative run exports with top-level prompt/input, task entries, tool calls, and final task output. |
 | OpenClaw agents | Yes | Yes | Yes | Existing OpenClaw session connectors remain unchanged. |
 
 ## Provenance
@@ -16,4 +17,5 @@ Session APIs expose a `provenance.source_type` field derived from the persisted 
 ## Current limits
 
 - Desktop/Codex watchability is best-effort because upstream tools do not yet provide a formally versioned transcript contract.
+- CrewAI support is manual-ingest only in this slice; DriftShield does not claim generic discovery or watch support for arbitrary CrewAI local artefacts.
 - If a source emits a different local schema, ingestion falls back to manual fixture-driven parser extension rather than claiming generic support.

--- a/driftshield/src/driftshield/cli/commands/analyze.py
+++ b/driftshield/src/driftshield/cli/commands/analyze.py
@@ -30,7 +30,7 @@ def analyze(
         "auto",
         "--parser",
         "-p",
-        help="Parser to use (auto, claude_code).",
+        help="Parser to use (auto, claude_code, claude_desktop, codex_cli, codex_desktop, crewai, langchain, openclaw).",
     ),
     verbose: bool = typer.Option(
         False,

--- a/driftshield/tests/cli/test_analyze.py
+++ b/driftshield/tests/cli/test_analyze.py
@@ -1,5 +1,7 @@
 """Tests for analyze command."""
 
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -11,6 +13,7 @@ from driftshield.cli.main import app
 runner = CliRunner()
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "transcripts"
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class TestAnalyzeCommand:
@@ -81,6 +84,21 @@ class TestAnalyzeCommand:
 
         assert result.exit_code != 0
         assert "claude_code" in result.output  # Lists available
+
+
+    def test_analyze_with_explicit_crewai_parser_outputs_json_summary(self):
+        """CrewAI fixture can be analysed end to end through the CLI."""
+        result = runner.invoke(
+            app,
+            ["analyze", str(FIXTURES_DIR / "sample_crewai_session.json"), "--parser", "crewai", "--json"],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(ANSI_RE.sub("", result.output))
+        assert payload["session_id"] == "crewai-run-001"
+        assert payload["total_events"] == 3
+        assert "flagged_events" in payload
+        assert "risks" in payload
 
 
 class TestAnalyzeProject:


### PR DESCRIPTION
## Summary
- make CrewAI the explicit framework choice for `#13` and record that choice on the linked issues
- document CrewAI in supported sources as a manual-ingest parser with bounded scope
- add an end-to-end CLI analyse test proving the representative CrewAI fixture works through `--parser crewai`

## Verification
- `PYTHONPATH=src pytest tests/parsers/test_crewai.py tests/cli/test_ingest.py tests/cli/test_analyze.py -q`

Closes #13
Refs tborys/driftshield-meta#24
