### PR TITLE
feat: add canonical normalized event pipeline

### DIFF
--- a/driftshield/src/driftshield/core/analysis/session.py
+++ b/driftshield/src/driftshield/core/analysis/session.py
@@ -15,6 +15,7 @@ from driftshield.core.analysis.risk import RiskAnalyzer
 from driftshield.core.graph.builder import build_graph
 from driftshield.core.graph.models import DecisionNode, LineageGraph
 from driftshield.core.models import CanonicalEvent, ExplanationPayload
+from driftshield.core.normalization import normalize_events
 
 
 @dataclass
@@ -68,6 +69,8 @@ def analyze_session(
     if session_id is None:
         session_id = events[0].session_id
 
+    normalized_events = normalize_events(events)
+
     analyzer = RiskAnalyzer(
         heuristics=[
             CoverageGapHeuristic(),
@@ -78,7 +81,7 @@ def analyze_session(
         ],
         context_builders=[load_analysis_context],
     )
-    analyzed_events = analyzer.analyze(events)
+    analyzed_events = analyzer.analyze(normalized_events)
     graph = build_graph(analyzed_events, session_id=session_id)
 
     inflection_node = None

--- a/driftshield/src/driftshield/core/graph/builder.py
+++ b/driftshield/src/driftshield/core/graph/builder.py
@@ -12,8 +12,14 @@ def build_graph(events: list[CanonicalEvent], session_id: str) -> LineageGraph:
     """
     graph = LineageGraph(session_id=session_id)
 
-    # Sort events by timestamp
-    sorted_events = sorted(events, key=lambda e: e.timestamp)
+    sorted_events = sorted(
+        events,
+        key=lambda e: (
+            e.ordinal is None,
+            e.ordinal if e.ordinal is not None else 0,
+            e.timestamp,
+        ),
+    )
 
     # Create nodes with sequence numbers
     for seq_num, event in enumerate(sorted_events):

--- a/driftshield/src/driftshield/core/models.py
+++ b/driftshield/src/driftshield/core/models.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from typing import Any
 from uuid import UUID
 
 
@@ -113,6 +114,16 @@ class CanonicalEvent:
     outputs: dict = None
     metadata: dict = None
     risk_classification: RiskClassification | None = None
+    ordinal: int | None = None
+    actor: dict[str, str] | None = None
+    summary: str | None = None
+    parent_event_refs: list[UUID] = field(default_factory=list)
+    source_refs: list[dict[str, str]] = field(default_factory=list)
+    artifact_refs: list[dict[str, str]] = field(default_factory=list)
+    constraints: list[dict[str, str]] = field(default_factory=list)
+    tool_activity: dict[str, Any] | None = None
+    failure_context: dict[str, Any] | None = None
+    ambiguities: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         if self.inputs is None:
@@ -121,12 +132,52 @@ class CanonicalEvent:
             self.outputs = {}
         if self.metadata is None:
             self.metadata = {}
+        if self.actor is None:
+            self.actor = {
+                "id": self.agent_id or "unknown",
+                "role": self._default_actor_role(),
+            }
+        if self.parent_event_id is not None and not self.parent_event_refs:
+            self.parent_event_refs = [self.parent_event_id]
 
     def has_risk_flags(self) -> bool:
         """Return True if this event has any risk flags set."""
         if self.risk_classification is None:
             return False
         return self.risk_classification.has_any_flag()
+
+    @property
+    def event_id(self) -> UUID:
+        return self.id
+
+    @property
+    def event_kind(self) -> str:
+        return self.event_type.value.lower()
+
+    def to_normalized_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": str(self.id),
+            "session_id": self.session_id,
+            "ordinal": self.ordinal,
+            "timestamp": self.timestamp.isoformat(),
+            "event_kind": self.event_kind,
+            "actor": dict(self.actor or {}),
+            "summary": self.summary,
+            "parent_event_refs": [str(ref) for ref in self.parent_event_refs],
+            "source_refs": [dict(ref) for ref in self.source_refs],
+            "artifact_refs": [dict(ref) for ref in self.artifact_refs],
+            "constraints": [dict(ref) for ref in self.constraints],
+            "tool_activity": dict(self.tool_activity or {}) if self.tool_activity else None,
+            "failure_context": dict(self.failure_context or {}) if self.failure_context else None,
+            "ambiguities": list(self.ambiguities),
+        }
+
+    def _default_actor_role(self) -> str:
+        if self.agent_id == "user":
+            return "user"
+        if self.agent_id == "system":
+            return "system"
+        return "assistant"
 
 
 class SessionStatus(str, Enum):

--- a/driftshield/src/driftshield/core/normalization.py
+++ b/driftshield/src/driftshield/core/normalization.py
@@ -214,7 +214,7 @@ def _tool_activity(event: CanonicalEvent) -> dict[str, Any] | None:
         "category": event.metadata.get("semantic_action_category"),
         "raw_name": event.metadata.get("raw_action") or event.action,
         "status": status,
-        "input_keys": sorted(str(key) for key in event.inputs.keys()),
+        "input_keys": _mapping_keys(event.inputs),
         "has_outputs": bool(event.outputs),
     }
 
@@ -367,3 +367,9 @@ def _first_non_empty(*values: object) -> str | None:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+def _mapping_keys(value: object) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    return sorted(str(key) for key in value.keys())

--- a/driftshield/src/driftshield/core/normalization.py
+++ b/driftshield/src/driftshield/core/normalization.py
@@ -99,10 +99,9 @@ def _actor_role(event: CanonicalEvent) -> str:
 
 
 def _parent_refs(event: CanonicalEvent) -> list[Any]:
-    refs = list(event.parent_event_refs or [])
-    if event.parent_event_id is not None and event.parent_event_id not in refs:
-        refs.insert(0, event.parent_event_id)
-    return refs
+    if event.parent_event_id is not None:
+        return [event.parent_event_id]
+    return list(event.parent_event_refs or [])
 
 
 def _source_refs(
@@ -270,8 +269,15 @@ def _extract_keyed_refs(
     refs: list[dict[str, str]] = []
     if isinstance(payload, dict):
         for key, value in payload.items():
-            if key in keys and isinstance(value, (str, int, float)):
-                refs.append({key_name: key, "value": str(value), "source": payload_name})
+            if key in keys:
+                refs.extend(
+                    _extract_matched_key_values(
+                        value,
+                        matched_key=key,
+                        payload_name=payload_name,
+                        key_name=key_name,
+                    )
+                )
             elif isinstance(value, dict):
                 refs.extend(_extract_keyed_refs(value, f"{payload_name}.{key}", keys, key_name=key_name))
             elif isinstance(value, list):
@@ -287,6 +293,42 @@ def _extract_keyed_refs(
     elif isinstance(payload, list):
         for index, item in enumerate(payload):
             refs.extend(_extract_keyed_refs(item, f"{payload_name}[{index}]", keys, key_name=key_name))
+    return refs
+
+
+def _extract_matched_key_values(
+    value: object,
+    *,
+    matched_key: str,
+    payload_name: str,
+    key_name: str,
+) -> list[dict[str, str]]:
+    if isinstance(value, (str, int, float)):
+        return [{key_name: matched_key, "value": str(value), "source": payload_name}]
+
+    refs: list[dict[str, str]] = []
+    if isinstance(value, list):
+        for item in value:
+            refs.extend(
+                _extract_matched_key_values(
+                    item,
+                    matched_key=matched_key,
+                    payload_name=payload_name,
+                    key_name=key_name,
+                )
+            )
+        return refs
+
+    if isinstance(value, dict):
+        for nested_value in value.values():
+            refs.extend(
+                _extract_matched_key_values(
+                    nested_value,
+                    matched_key=matched_key,
+                    payload_name=payload_name,
+                    key_name=key_name,
+                )
+            )
     return refs
 
 

--- a/driftshield/src/driftshield/core/normalization.py
+++ b/driftshield/src/driftshield/core/normalization.py
@@ -1,0 +1,327 @@
+"""Canonical normalized event pipeline for parser output."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from driftshield.core.models import CanonicalEvent, EventType
+
+
+NORMALIZED_EVENT_VERSION = "phase-2b-v1"
+
+_SOURCE_REF_KEYS = (
+    "tool_use_id",
+    "tool_call_id",
+    "run_id",
+    "parent_run_id",
+    "trace_id",
+    "task_id",
+    "root_run_id",
+    "source_message_index",
+    "hook_event",
+    "hook_name",
+)
+_ARTIFACT_KEYS = {
+    "file_path",
+    "path",
+    "source_path",
+    "output_path",
+    "target_path",
+    "cwd",
+}
+_CONSTRAINT_KEYS = {
+    "expected_output",
+    "constraint",
+    "constraints",
+    "policy",
+    "policies",
+    "requirement",
+    "requirements",
+}
+_CONSTRAINT_PATTERN = re.compile(
+    r"\b(must|should|do not|don't|without|only|exactly|required|before)\b",
+    re.IGNORECASE,
+)
+_FAILURE_PATTERN = re.compile(
+    r"\b(error|failed|failure|exception|timed out|timeout|permission denied|not found)\b",
+    re.IGNORECASE,
+)
+_TOOL_EVENT_TYPES = {EventType.TOOL_CALL, EventType.HANDOFF}
+
+
+def normalize_events(
+    events: list[CanonicalEvent],
+    *,
+    source_type: str | None = None,
+    source_path: str | None = None,
+) -> list[CanonicalEvent]:
+    """Populate the Phase 2b normalized-event fields on parser output."""
+
+    for ordinal, event in enumerate(events):
+        metadata = dict(event.metadata or {})
+        if source_type and not metadata.get("source_type"):
+            metadata["source_type"] = source_type
+        if source_path and not metadata.get("source_path"):
+            metadata["source_path"] = source_path
+        metadata["normalized_event_version"] = NORMALIZED_EVENT_VERSION
+        event.metadata = metadata
+
+        event.ordinal = ordinal
+        event.actor = _actor(event)
+        event.parent_event_refs = _parent_refs(event)
+        event.source_refs = _source_refs(event, source_type=source_type, source_path=source_path)
+        event.artifact_refs = _artifact_refs(event)
+        event.constraints = _constraints(event)
+        event.failure_context = _failure_context(event)
+        event.tool_activity = _tool_activity(event)
+        event.summary = _summary(event)
+        event.ambiguities = _ambiguities(event)
+
+    return events
+
+
+def _actor(event: CanonicalEvent) -> dict[str, str]:
+    actor = dict(event.actor or {})
+    actor.setdefault("id", event.agent_id or "unknown")
+    actor.setdefault("role", _actor_role(event))
+    return actor
+
+
+def _actor_role(event: CanonicalEvent) -> str:
+    if event.agent_id == "user":
+        return "user"
+    if event.agent_id == "system":
+        return "system"
+    if event.event_type in _TOOL_EVENT_TYPES:
+        return "assistant"
+    return (event.actor or {}).get("role") or "assistant"
+
+
+def _parent_refs(event: CanonicalEvent) -> list[Any]:
+    refs = list(event.parent_event_refs or [])
+    if event.parent_event_id is not None and event.parent_event_id not in refs:
+        refs.insert(0, event.parent_event_id)
+    return refs
+
+
+def _source_refs(
+    event: CanonicalEvent,
+    *,
+    source_type: str | None,
+    source_path: str | None,
+) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+
+    parser_name = (
+        source_type
+        or str(event.metadata.get("source_type", "")).strip()
+        or None
+    )
+    if parser_name:
+        refs.append({"kind": "parser", "value": parser_name})
+
+    path_value = source_path or event.metadata.get("source_path")
+    if path_value:
+        refs.append({"kind": "source_path", "value": str(path_value)})
+
+    for key in _SOURCE_REF_KEYS:
+        value = event.metadata.get(key)
+        if value is None or value == "":
+            continue
+        refs.append({"kind": key, "value": str(value)})
+
+    return _dedupe_refs(refs)
+
+
+def _artifact_refs(event: CanonicalEvent) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    for payload_name, payload in (
+        ("inputs", event.inputs),
+        ("outputs", event.outputs),
+        ("metadata", event.metadata),
+    ):
+        refs.extend(_extract_keyed_refs(payload, payload_name, _ARTIFACT_KEYS))
+    return _dedupe_refs(refs)
+
+
+def _constraints(event: CanonicalEvent) -> list[dict[str, str]]:
+    constraints: list[dict[str, str]] = []
+
+    for payload_name, payload in (
+        ("inputs", event.inputs),
+        ("outputs", event.outputs),
+        ("metadata", event.metadata),
+    ):
+        constraints.extend(_extract_keyed_refs(payload, payload_name, _CONSTRAINT_KEYS, key_name="kind"))
+
+    for text in _text_fragments(event):
+        if not _CONSTRAINT_PATTERN.search(text):
+            continue
+        constraints.append(
+            {
+                "kind": "message_constraint",
+                "value": text,
+                "source": "outputs.text",
+            }
+        )
+
+    return _dedupe_refs(constraints)
+
+
+def _failure_context(event: CanonicalEvent) -> dict[str, Any] | None:
+    signals: list[str] = []
+    error = _first_non_empty(
+        event.outputs.get("error"),
+        event.metadata.get("error"),
+    )
+    is_error = bool(event.outputs.get("is_error"))
+
+    if error:
+        signals.append("explicit_error")
+    if is_error:
+        signals.append("tool_marked_error")
+
+    failure_language = any(_FAILURE_PATTERN.search(text) for text in _text_fragments(event))
+    if failure_language:
+        signals.append("failure_language")
+
+    if not signals:
+        return None
+
+    status = "error" if error or is_error else "warning"
+    return {
+        "status": status,
+        "error": str(error) if error else None,
+        "signals": sorted(set(signals)),
+        "declared_failure": bool(error or is_error or failure_language),
+    }
+
+
+def _tool_activity(event: CanonicalEvent) -> dict[str, Any] | None:
+    if event.event_type not in _TOOL_EVENT_TYPES:
+        return None
+
+    failure = event.failure_context or {}
+    if failure.get("status") == "error":
+        status = "error"
+    elif event.outputs:
+        status = "completed"
+    else:
+        status = "pending"
+
+    return {
+        "name": event.action,
+        "category": event.metadata.get("semantic_action_category"),
+        "raw_name": event.metadata.get("raw_action") or event.action,
+        "status": status,
+        "input_keys": sorted(str(key) for key in event.inputs.keys()),
+        "has_outputs": bool(event.outputs),
+    }
+
+
+def _summary(event: CanonicalEvent) -> str:
+    if event.summary:
+        return event.summary
+
+    if event.event_type in _TOOL_EVENT_TYPES:
+        artifact = next((ref["value"] for ref in event.artifact_refs), None)
+        suffix = f" on {artifact}" if artifact else ""
+        if event.failure_context and event.failure_context.get("status") == "error":
+            return f"{event.action} reported an error{suffix}"
+        if event.outputs:
+            return f"{event.action} completed{suffix}"
+        return f"{event.action} invoked{suffix}"
+
+    for text in _text_fragments(event):
+        cleaned = " ".join(text.split())
+        if cleaned:
+            return cleaned[:160]
+
+    return event.action or event.event_type.value.lower()
+
+
+def _ambiguities(event: CanonicalEvent) -> list[str]:
+    ambiguities: list[str] = []
+
+    if not event.source_refs:
+        ambiguities.append("missing_source_ref")
+    if event.ordinal not in (None, 0) and not event.parent_event_refs:
+        ambiguities.append("missing_parent_ref")
+    if event.actor is None or event.actor.get("id") in {None, "", "unknown"}:
+        ambiguities.append("missing_actor")
+    if event.event_type in _TOOL_EVENT_TYPES and not event.inputs:
+        ambiguities.append("missing_tool_inputs")
+    if event.event_type in _TOOL_EVENT_TYPES and not event.outputs:
+        ambiguities.append("missing_tool_outputs")
+    if event.failure_context and event.failure_context.get("status") == "warning":
+        ambiguities.append("failure_inferred_from_text")
+
+    return sorted(set(ambiguities))
+
+
+def _extract_keyed_refs(
+    payload: object,
+    payload_name: str,
+    keys: set[str],
+    *,
+    key_name: str = "kind",
+) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key in keys and isinstance(value, (str, int, float)):
+                refs.append({key_name: key, "value": str(value), "source": payload_name})
+            elif isinstance(value, dict):
+                refs.extend(_extract_keyed_refs(value, f"{payload_name}.{key}", keys, key_name=key_name))
+            elif isinstance(value, list):
+                for index, item in enumerate(value):
+                    refs.extend(
+                        _extract_keyed_refs(
+                            item,
+                            f"{payload_name}.{key}[{index}]",
+                            keys,
+                            key_name=key_name,
+                        )
+                    )
+    elif isinstance(payload, list):
+        for index, item in enumerate(payload):
+            refs.extend(_extract_keyed_refs(item, f"{payload_name}[{index}]", keys, key_name=key_name))
+    return refs
+
+
+def _text_fragments(event: CanonicalEvent) -> list[str]:
+    texts: list[str] = []
+
+    output_text = event.outputs.get("text")
+    if isinstance(output_text, str) and output_text.strip():
+        texts.append(output_text.strip())
+
+    result = event.outputs.get("result")
+    if isinstance(result, str) and result.strip():
+        texts.append(result.strip())
+
+    error = event.outputs.get("error")
+    if isinstance(error, str) and error.strip():
+        texts.append(error.strip())
+
+    return texts
+
+
+def _dedupe_refs(refs: list[dict[str, str]]) -> list[dict[str, str]]:
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    deduped: list[dict[str, str]] = []
+    for ref in refs:
+        key = tuple(sorted((str(name), str(value)) for name, value in ref.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(ref)
+    return deduped
+
+
+def _first_non_empty(*values: object) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/driftshield/src/driftshield/db/ingest_service.py
+++ b/driftshield/src/driftshield/db/ingest_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from driftshield.cli.parsers import PARSERS, get_parser
 from driftshield.core.analysis.session import analyze_session
 from driftshield.core.models import CanonicalEvent, Session as DomainSession, SessionStatus
+from driftshield.core.normalization import normalize_events
 from driftshield.db.persistence import IngestOutcome, IngestProvenance, PersistenceService
 
 
@@ -47,6 +48,7 @@ class TranscriptIngestService:
         events = parser.parse(content)
         if not events:
             raise ValueError("No events parsed from transcript")
+        normalize_events(events, source_type=parser.source_type, source_path=source_path)
 
         target_session_id = existing_session_id or uuid.uuid4()
         _stabilize_event_ids(events, target_session_id)

--- a/driftshield/src/driftshield/db/ingest_service.py
+++ b/driftshield/src/driftshield/db/ingest_service.py
@@ -48,10 +48,10 @@ class TranscriptIngestService:
         events = parser.parse(content)
         if not events:
             raise ValueError("No events parsed from transcript")
-        normalize_events(events, source_type=parser.source_type, source_path=source_path)
 
         target_session_id = existing_session_id or uuid.uuid4()
         _stabilize_event_ids(events, target_session_id)
+        normalize_events(events, source_type=parser.source_type, source_path=source_path)
         result = analyze_session(events, session_id=str(target_session_id))
         domain_session = DomainSession(
             id=target_session_id,

--- a/driftshield/src/driftshield/parsers/claude_code.py
+++ b/driftshield/src/driftshield/parsers/claude_code.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.normalization import normalize_events
 
 
 class ClaudeCodeParser:
@@ -45,7 +46,11 @@ class ClaudeCodeParser:
     def parse_file(self, file_path: str) -> list[CanonicalEvent]:
         """Parse transcript from file path."""
         content = Path(file_path).read_text()
-        return self.parse(content)
+        return normalize_events(
+            self.parse(content),
+            source_type=self.source_type,
+            source_path=file_path,
+        )
 
     def parse(self, content: str) -> list[CanonicalEvent]:
         """Parse raw JSONL content into canonical events."""
@@ -151,7 +156,7 @@ class ClaudeCodeParser:
                             events.append(text_event)
                             prev_event_id = text_event.id
 
-        return events
+        return normalize_events(events, source_type=self.source_type)
 
     def _create_tool_call_event(
         self,

--- a/driftshield/src/driftshield/parsers/crewai.py
+++ b/driftshield/src/driftshield/parsers/crewai.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.normalization import normalize_events
 
 
 class CrewAIParser:
@@ -18,7 +19,11 @@ class CrewAIParser:
         return "crewai"
 
     def parse_file(self, file_path: str) -> list[CanonicalEvent]:
-        return self.parse(Path(file_path).read_text())
+        return normalize_events(
+            self.parse(Path(file_path).read_text()),
+            source_type=self.source_type,
+            source_path=file_path,
+        )
 
     def parse(self, content: str) -> list[CanonicalEvent]:
         payload = json.loads(content)
@@ -89,7 +94,7 @@ class CrewAIParser:
                 events.append(output_event)
                 previous_event_id = output_event.id
 
-        return events
+        return normalize_events(events, source_type=self.source_type)
 
     def _build_task_event(
         self,

--- a/driftshield/src/driftshield/parsers/langchain.py
+++ b/driftshield/src/driftshield/parsers/langchain.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.normalization import normalize_events
 
 
 class LangChainParser:
@@ -21,7 +22,11 @@ class LangChainParser:
         return "langchain"
 
     def parse_file(self, file_path: str) -> list[CanonicalEvent]:
-        return self.parse(Path(file_path).read_text())
+        return normalize_events(
+            self.parse(Path(file_path).read_text()),
+            source_type=self.source_type,
+            source_path=file_path,
+        )
 
     def parse(self, content: str) -> list[CanonicalEvent]:
         payload = json.loads(content)
@@ -84,7 +89,7 @@ class LangChainParser:
             events.append(event)
             previous_event_id = event.id
 
-        return events
+        return normalize_events(events, source_type=self.source_type)
 
     def _normalise_runs(self, payload: dict | list) -> list[dict]:
         if isinstance(payload, list):

--- a/driftshield/src/driftshield/parsers/local_chat.py
+++ b/driftshield/src/driftshield/parsers/local_chat.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.normalization import normalize_events
 
 
 class LocalChatTranscriptParser:
@@ -32,18 +33,29 @@ class LocalChatTranscriptParser:
         path = Path(file_path)
         content = path.read_text()
         if path.suffix == ".jsonl":
-            return self._parse_jsonl(content)
-        return self._parse_json(json.loads(content))
+            return normalize_events(
+                self._parse_jsonl(content),
+                source_type=self.source_type,
+                source_path=str(path),
+            )
+        return normalize_events(
+            self._parse_json(json.loads(content)),
+            source_type=self.source_type,
+            source_path=str(path),
+        )
 
     def parse(self, content: str) -> list[CanonicalEvent]:
         stripped = content.lstrip()
         if stripped.startswith("["):
-            return self._parse_json(json.loads(content))
+            return normalize_events(self._parse_json(json.loads(content)), source_type=self.source_type)
         if stripped.startswith("{"):
             if "\n" not in stripped:
-                return self._parse_json(json.loads(content))
-            return self._parse_jsonl(content)
-        return self._parse_jsonl(content)
+                return normalize_events(
+                    self._parse_json(json.loads(content)),
+                    source_type=self.source_type,
+                )
+            return normalize_events(self._parse_jsonl(content), source_type=self.source_type)
+        return normalize_events(self._parse_jsonl(content), source_type=self.source_type)
 
     def _parse_jsonl(self, content: str) -> list[CanonicalEvent]:
         messages: list[dict] = []

--- a/driftshield/src/driftshield/parsers/openclaw.py
+++ b/driftshield/src/driftshield/parsers/openclaw.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.normalization import normalize_events
 
 
 class OpenClawParser:
@@ -35,7 +36,11 @@ class OpenClawParser:
         return "openclaw"
 
     def parse_file(self, file_path: str) -> list[CanonicalEvent]:
-        return self.parse(Path(file_path).read_text())
+        return normalize_events(
+            self.parse(Path(file_path).read_text()),
+            source_type=self.source_type,
+            source_path=file_path,
+        )
 
     def parse(self, content: str) -> list[CanonicalEvent]:
         events: list[CanonicalEvent] = []
@@ -141,7 +146,7 @@ class OpenClawParser:
             if entry_id and previous_event_id is not None:
                 id_map[str(entry_id)] = previous_event_id
 
-        return events
+        return normalize_events(events, source_type=self.source_type)
 
     def _create_tool_call_event(
         self,

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -13,6 +13,7 @@ from sqlalchemy.pool import StaticPool
 
 from driftshield.api.app import create_app
 from driftshield.db.models import Base, DecisionNodeModel, SessionModel
+from driftshield.db.ingest_service import TranscriptIngestService
 from driftshield.db.persistence import IngestOutcome, PersistenceService
 from driftshield.telemetry import TelemetryService
 
@@ -118,6 +119,53 @@ def test_ingest_persists_provenance_fields(client, auth_headers, sample_transcri
     assert session.source_path == "uploads/daily/transcript.jsonl"
     assert session.parser_version == "claude_code@1"
     assert session.ingested_at is not None
+
+
+def test_ingest_stabilizes_normalized_parent_refs(db_session):
+    transcript = "\n".join(
+        [
+            json.dumps(
+                {
+                    "sessionId": "normalized-parent-refs",
+                    "type": "user",
+                    "message": {"role": "user", "content": "Inspect README then summarize it."},
+                    "timestamp": "2026-04-22T10:00:00+00:00",
+                }
+            ),
+            json.dumps(
+                {
+                    "sessionId": "normalized-parent-refs",
+                    "type": "assistant",
+                    "message": {
+                        "model": "claude",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tool_1",
+                                "name": "Read",
+                                "input": {"file_path": "README.md"},
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-22T10:00:01+00:00",
+                }
+            ),
+        ]
+    ).encode()
+
+    _, analysis_result = TranscriptIngestService(db_session).ingest_bytes(
+        raw_bytes=transcript,
+        parser_name="claude_code",
+        source_path="uploads/daily/transcript.jsonl",
+    )
+
+    assert len(analysis_result.events) == 2
+    event_ids = {event.id for event in analysis_result.events}
+    child_event = analysis_result.events[1]
+
+    assert child_event.parent_event_refs == [analysis_result.events[0].id]
+    assert set(child_event.parent_event_refs).issubset(event_ids)
+    assert {"kind": "source_path", "value": "uploads/daily/transcript.jsonl"} in child_event.source_refs
 
 
 def test_reingest_is_explicit_dedupe_no_op(client, auth_headers, sample_transcript, db_session):

--- a/driftshield/tests/core/graph/test_builder.py
+++ b/driftshield/tests/core/graph/test_builder.py
@@ -68,6 +68,33 @@ class TestBuildGraph:
         assert [n.action for n in nodes] == ["first", "second", "third"]
         assert [n.sequence_num for n in nodes] == [0, 1, 2]
 
+    def test_build_prefers_normalized_ordinals_over_timestamp(self):
+        """Normalized event order wins when timestamps are less reliable."""
+        t1 = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2025, 1, 1, 10, 0, 1, tzinfo=timezone.utc)
+
+        later_timestamp_but_first = make_event(
+            session_id="s1",
+            action="first",
+            timestamp=t2,
+            ordinal=0,
+        )
+        earlier_timestamp_but_second = make_event(
+            session_id="s1",
+            action="second",
+            timestamp=t1,
+            ordinal=1,
+            parent_event_id=later_timestamp_but_first.id,
+        )
+
+        graph = build_graph(
+            [earlier_timestamp_but_second, later_timestamp_but_first],
+            session_id="s1",
+        )
+
+        assert [node.action for node in graph.nodes] == ["first", "second"]
+        assert [node.sequence_num for node in graph.nodes] == [0, 1]
+
     def test_build_with_branching(self):
         """Graph can have nodes with multiple children."""
         root = make_event(session_id="s1", action="root")

--- a/driftshield/tests/core/test_models.py
+++ b/driftshield/tests/core/test_models.py
@@ -164,6 +164,27 @@ class TestCanonicalEvent:
         }
         assert payload["ambiguities"] == []
 
+    def test_event_preserves_list_based_constraints(self):
+        event = CanonicalEvent(
+            id=uuid4(),
+            session_id="session-123",
+            timestamp=datetime.now(timezone.utc),
+            event_type=EventType.TOOL_CALL,
+            agent_id="agent-1",
+            action="plan",
+            inputs={
+                "requirements": [
+                    "Ask for confirmation before deleting files.",
+                    "Stay within the repository root.",
+                ]
+            },
+        )
+
+        normalize_events([event], source_type="claude_code")
+
+        assert {"kind": "requirements", "value": "Ask for confirmation before deleting files.", "source": "inputs"} in event.constraints
+        assert {"kind": "requirements", "value": "Stay within the repository root.", "source": "inputs"} in event.constraints
+
 
 class TestSessionStatus:
     def test_status_values(self):

--- a/driftshield/tests/core/test_models.py
+++ b/driftshield/tests/core/test_models.py
@@ -10,6 +10,7 @@ from driftshield.core.models import (
     Session,
     SessionStatus,
 )
+from driftshield.core.normalization import normalize_events
 
 
 class TestEventType:
@@ -124,6 +125,44 @@ class TestCanonicalEvent:
             risk_classification=RiskClassification(coverage_gap=True),
         )
         assert event_with_risk.has_risk_flags() is True
+
+    def test_event_exports_phase_2b_normalized_shape(self):
+        event = CanonicalEvent(
+            id=uuid4(),
+            session_id="session-123",
+            timestamp=datetime.now(timezone.utc),
+            event_type=EventType.TOOL_CALL,
+            agent_id="agent-1",
+            action="read_file",
+            inputs={"file_path": "README.md"},
+            outputs={"result": {"content": "# DriftShield"}},
+            metadata={"tool_use_id": "tool-1"},
+        )
+
+        normalize_events([event], source_type="claude_code")
+        payload = event.to_normalized_dict()
+
+        assert payload["event_kind"] == "tool_call"
+        assert payload["ordinal"] == 0
+        assert payload["actor"] == {"id": "agent-1", "role": "assistant"}
+        assert payload["summary"] == "read_file completed on README.md"
+        assert payload["parent_event_refs"] == []
+        assert payload["source_refs"] == [
+            {"kind": "parser", "value": "claude_code"},
+            {"kind": "tool_use_id", "value": "tool-1"},
+        ]
+        assert payload["artifact_refs"] == [
+            {"kind": "file_path", "value": "README.md", "source": "inputs"},
+        ]
+        assert payload["tool_activity"] == {
+            "name": "read_file",
+            "category": None,
+            "raw_name": "read_file",
+            "status": "completed",
+            "input_keys": ["file_path"],
+            "has_outputs": True,
+        }
+        assert payload["ambiguities"] == []
 
 
 class TestSessionStatus:

--- a/driftshield/tests/core/test_models.py
+++ b/driftshield/tests/core/test_models.py
@@ -185,6 +185,28 @@ class TestCanonicalEvent:
         assert {"kind": "requirements", "value": "Ask for confirmation before deleting files.", "source": "inputs"} in event.constraints
         assert {"kind": "requirements", "value": "Stay within the repository root.", "source": "inputs"} in event.constraints
 
+    def test_event_handles_non_mapping_tool_inputs_in_normalization(self):
+        event = CanonicalEvent(
+            id=uuid4(),
+            session_id="session-123",
+            timestamp=datetime.now(timezone.utc),
+            event_type=EventType.TOOL_CALL,
+            agent_id="agent-1",
+            action="shell",
+            inputs=["npm", "test"],
+        )
+
+        normalize_events([event], source_type="claude_code")
+
+        assert event.tool_activity == {
+            "name": "shell",
+            "category": None,
+            "raw_name": "shell",
+            "status": "pending",
+            "input_keys": [],
+            "has_outputs": False,
+        }
+
 
 class TestSessionStatus:
     def test_status_values(self):

--- a/driftshield/tests/parsers/test_claude_code.py
+++ b/driftshield/tests/parsers/test_claude_code.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from driftshield.parsers.claude_code import ClaudeCodeParser
 from driftshield.core.models import EventType
 
@@ -146,3 +144,22 @@ class TestClaudeCodeParser:
 
         assert len(events) == 1
         assert events[0].outputs == {}
+
+    def test_non_object_tool_inputs_do_not_break_normalization(self):
+        parser = ClaudeCodeParser()
+        content = "\n".join([
+            '{"sessionId":"s6","type":"assistant","timestamp":"2026-03-01T10:00:00Z","message":{"model":"claude","content":[{"type":"tool_use","id":"t6","name":"bash","input":["npm","test"]}]}}'
+        ])
+
+        events = parser.parse(content)
+
+        assert len(events) == 1
+        assert events[0].inputs == ["npm", "test"]
+        assert events[0].tool_activity == {
+            "name": "bash",
+            "category": "shell",
+            "raw_name": "bash",
+            "status": "pending",
+            "input_keys": [],
+            "has_outputs": False,
+        }

--- a/driftshield/tests/parsers/test_normalized_pipeline.py
+++ b/driftshield/tests/parsers/test_normalized_pipeline.py
@@ -1,0 +1,83 @@
+"""Phase 2b normalized event pipeline coverage."""
+
+from pathlib import Path
+
+import pytest
+
+from driftshield.core.analysis.session import analyze_session
+from driftshield.parsers.claude_code import ClaudeCodeParser
+from driftshield.parsers.codex_cli import CodexCliParser
+from driftshield.parsers.crewai import CrewAIParser
+from driftshield.parsers.langchain import LangChainParser
+
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "transcripts"
+
+
+@pytest.mark.parametrize(
+    ("parser", "fixture_name", "expected_parser"),
+    [
+        (ClaudeCodeParser(), "sample_claude_code_session.jsonl", "claude_code"),
+        (LangChainParser(), "sample_langchain_session.json", "langchain"),
+        (CrewAIParser(), "sample_crewai_session.json", "crewai"),
+        (CodexCliParser(), "sample_codex_cli_session.jsonl", "codex_cli"),
+    ],
+)
+def test_supported_parser_fixtures_share_normalized_event_contract(
+    parser,
+    fixture_name,
+    expected_parser,
+):
+    events = parser.parse_file(str(FIXTURES_DIR / fixture_name))
+
+    assert events
+    for index, event in enumerate(events):
+        assert event.ordinal == index
+        assert event.summary
+        assert event.actor is not None
+        assert event.actor["id"]
+        assert any(
+            ref["kind"] == "parser" and ref["value"] == expected_parser
+            for ref in event.source_refs
+        )
+        payload = event.to_normalized_dict()
+        assert payload["event_id"] == str(event.id)
+        assert payload["event_kind"]
+        assert payload["summary"] == event.summary
+
+
+def test_normalized_pipeline_preserves_constraints_and_failure_context():
+    crewai_events = CrewAIParser().parse_file(str(FIXTURES_DIR / "sample_crewai_session.json"))
+    langchain_events = LangChainParser().parse_file(str(FIXTURES_DIR / "sample_langchain_session.json"))
+
+    crewai_tool_event = next(event for event in crewai_events if event.tool_activity is not None)
+    langchain_tool_event = next(event for event in langchain_events if event.tool_activity is not None)
+
+    assert {"kind": "expected_output", "value": "A short list of concrete risks.", "source": "inputs"} in crewai_tool_event.constraints
+    assert langchain_tool_event.failure_context == {
+        "status": "error",
+        "error": "permission warning preserved for analysis",
+        "signals": ["explicit_error"],
+        "declared_failure": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("parser", "fixture_name"),
+    [
+        (ClaudeCodeParser(), "sample_claude_code_session.jsonl"),
+        (LangChainParser(), "sample_langchain_session.json"),
+        (CrewAIParser(), "sample_crewai_session.json"),
+    ],
+)
+def test_analysis_consumes_normalized_parser_output_without_parser_specific_branching(
+    parser,
+    fixture_name,
+):
+    events = parser.parse_file(str(FIXTURES_DIR / fixture_name))
+
+    result = analyze_session(events)
+
+    assert result.events
+    assert [event.ordinal for event in result.events] == list(range(len(result.events)))
+    assert [node.sequence_num for node in result.graph.nodes] == list(range(len(result.graph.nodes)))


### PR DESCRIPTION
## Summary
- add a shared Phase 2b normalized-event pipeline that enriches canonical parser output with ordinals, summaries, source refs, artifact refs, tool activity, constraints, failure context, and ambiguity markers
- normalize parser output before analysis and ingest, and make graph construction prefer normalized ordinals over raw timestamps when both are available
- cover the new contract with representative parser fixtures plus downstream analysis smoke tests

## Verification
- `uv run --directory driftshield pytest tests -q`
- `uv run --directory driftshield pytest tests/core/test_models.py tests/core/graph/test_builder.py tests/parsers/test_normalized_pipeline.py tests/parsers/test_claude_code.py tests/parsers/test_langchain.py tests/parsers/test_crewai.py tests/parsers/test_local_sources.py tests/parsers/test_openclaw.py tests/core/analysis/test_session_analyzer.py -q`
- `uv run --directory driftshield ruff check src tests` *(currently fails on pre-existing repo issues outside this change, including `src/driftshield/db/migrations/env.py`, `src/driftshield/signatures/__init__.py`, and several older test modules)*

## Notes
- Refs tborys/driftshield-meta#39
- `driftshield/uv.lock` was already untracked in the working tree and is not part of this PR.
