### PR TITLE
Build decision lineage graph

### DIFF
--- a/driftshield/frontend/src/api/sessions.ts
+++ b/driftshield/frontend/src/api/sessions.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from './client'
 import type { SessionSummary, SessionDetail, PaginatedResponse, SessionListFilters } from '../types/session'
-import type { GraphResponse } from '../types/graph'
+import { normalizeGraphResponse } from '../types/graph'
 import type { ValidationCreatePayload, ValidationRecord } from '../types/validation'
 
 function buildSessionQuery(page: number, perPage: number, filters: SessionListFilters) {
@@ -46,7 +46,7 @@ export function useSession(id: string) {
 export function useSessionGraph(id: string) {
   return useQuery({
     queryKey: ['session-graph', id],
-    queryFn: () => apiFetch<GraphResponse>(`/api/sessions/${id}/graph`),
+    queryFn: async () => normalizeGraphResponse(await apiFetch<unknown>(`/api/sessions/${id}/graph`)),
     enabled: !!id,
   })
 }

--- a/driftshield/frontend/src/components/investigation/InvestigationView.tsx
+++ b/driftshield/frontend/src/components/investigation/InvestigationView.tsx
@@ -226,7 +226,7 @@ export function InvestigationView({ graph }: InvestigationViewProps) {
                       {node.parent_node_ids.length === 0
                         ? 'Root node'
                         : node.parent_node_ids.length === 1
-                          ? `Parent ${node.parent_node_id?.slice(0, 8)}…`
+                          ? `Parent ${(node.parent_node_id ?? node.parent_node_ids[0])?.slice(0, 8)}…`
                           : `${node.parent_node_ids.length} parents linked`}
                     </div>
                     {node.lineage_ambiguities.length > 0 && (

--- a/driftshield/frontend/src/components/investigation/InvestigationView.tsx
+++ b/driftshield/frontend/src/components/investigation/InvestigationView.tsx
@@ -113,6 +113,10 @@ export function InvestigationView({ graph }: InvestigationViewProps) {
     () => [...graph.nodes].sort((a, b) => a.sequence_num - b.sequence_num),
     [graph.nodes],
   )
+  const inferredEdges = useMemo(
+    () => graph.edges.filter((edge) => edge.inferred),
+    [graph.edges],
+  )
 
   const primaryNarrative = findPrimaryNarrative(selectedNode)
 
@@ -131,6 +135,7 @@ export function InvestigationView({ graph }: InvestigationViewProps) {
               <div className="flex flex-wrap gap-2">
                 <Badge variant="outline">{graph.nodes.length} nodes</Badge>
                 <Badge variant="outline">{graph.edges.length} edges</Badge>
+                <Badge variant="outline">{inferredEdges.length} inferred edges</Badge>
                 <Badge variant={flaggedNodes.length > 0 ? 'destructive' : 'secondary'}>
                   {flaggedNodes.length} flagged
                 </Badge>
@@ -218,8 +223,21 @@ export function InvestigationView({ graph }: InvestigationViewProps) {
                     </div>
                     <div className="mt-2 text-sm font-medium">{node.action || 'Unknown action'}</div>
                     <div className="mt-1 text-xs text-muted-foreground">
-                      {node.parent_node_id ? `Parent ${node.parent_node_id.slice(0, 8)}…` : 'Root node'}
+                      {node.parent_node_ids.length === 0
+                        ? 'Root node'
+                        : node.parent_node_ids.length === 1
+                          ? `Parent ${node.parent_node_id?.slice(0, 8)}…`
+                          : `${node.parent_node_ids.length} parents linked`}
                     </div>
+                    {node.lineage_ambiguities.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {node.lineage_ambiguities.map((ambiguity) => (
+                          <Badge key={ambiguity} variant="outline" className="text-[11px]">
+                            {ambiguity.replace(/_/g, ' ')}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
                   </button>
                   {index < timelineNodes.length - 1 && <Separator className="my-3" />}
                 </div>

--- a/driftshield/frontend/src/components/investigation/LineageGraph.tsx
+++ b/driftshield/frontend/src/components/investigation/LineageGraph.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import {
   ReactFlow, Background, Controls, MiniMap,
   useNodesState, useEdgesState,
-  type Node, type Edge,
+  MarkerType, type Node, type Edge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import Dagre from '@dagrejs/dagre'
@@ -52,6 +52,15 @@ function layoutGraph(graph: GraphResponse, selectedNodeId: string | null): { nod
     id: `e-${index}`,
     source: edge.source,
     target: edge.target,
+    type: 'smoothstep',
+    animated: edge.inferred,
+    label: edge.inferred ? 'inferred' : undefined,
+    style: edge.inferred ? { strokeDasharray: '6 4', stroke: '#f59e0b' } : undefined,
+    labelStyle: edge.inferred ? { fill: '#b45309', fontSize: 11 } : undefined,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      color: edge.inferred ? '#f59e0b' : '#64748b',
+    },
   }))
 
   return { nodes, edges }

--- a/driftshield/frontend/src/components/investigation/NodeInspector.tsx
+++ b/driftshield/frontend/src/components/investigation/NodeInspector.tsx
@@ -77,8 +77,12 @@ export function NodeInspector({ node }: NodeInspectorProps) {
     <div className="p-4 space-y-4 overflow-y-auto">
       <div>
         <h3 className="font-semibold text-lg">{node.action || 'Unknown action'}</h3>
+        {node.summary && (
+          <p className="mt-1 text-sm text-muted-foreground">{node.summary}</p>
+        )}
         <div className="flex flex-wrap items-center gap-2 mt-1">
           <Badge variant="secondary">{node.event_type}</Badge>
+          {node.node_kind && <Badge variant="outline">{node.node_kind}</Badge>}
           <span className="text-sm text-muted-foreground">#{node.sequence_num}</span>
           {node.is_inflection && (
             <Badge variant="outline" className="border-orange-500 text-orange-600">
@@ -110,6 +114,40 @@ export function NodeInspector({ node }: NodeInspectorProps) {
               </CardContent>
             </Card>
           )}
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">Lineage context</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                {node.parent_node_ids.length === 0
+                  ? 'Root node'
+                  : `${node.parent_node_ids.length} parent link${node.parent_node_ids.length > 1 ? 's' : ''}`}
+              </div>
+              {node.parent_node_ids.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {node.parent_node_ids.map((parentId) => (
+                    <Badge key={parentId} variant="outline" className="font-mono text-[11px]">
+                      {parentId}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+              {node.lineage_ambiguities.length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-xs font-medium text-muted-foreground">Lineage ambiguities</div>
+                  <div className="flex flex-wrap gap-2">
+                    {node.lineage_ambiguities.map((ambiguity) => (
+                      <Badge key={ambiguity} variant="secondary">
+                        {ambiguity.replace(/_/g, ' ')}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
           {explanationEntries.length > 0 ? (
             explanationEntries.map(([flag, explanation]) => (
@@ -151,6 +189,21 @@ export function NodeInspector({ node }: NodeInspectorProps) {
                 <CardTitle className="text-sm">Evidence refs</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
+                {node.evidence_refs.length > 0 && (
+                  <div className="space-y-2">
+                    <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Node evidence
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {node.evidence_refs.map((ref) => (
+                        <Badge key={`node-${ref}`} variant="secondary" className="font-mono text-[11px]">
+                          {ref}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 {explanationEntries.map(([flag, explanation]) => (
                   <div key={flag} className="space-y-2">
                     <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">

--- a/driftshield/frontend/src/components/investigation/NodeInspector.tsx
+++ b/driftshield/frontend/src/components/investigation/NodeInspector.tsx
@@ -72,6 +72,8 @@ export function NodeInspector({ node }: NodeInspectorProps) {
   const hasInputs = hasPayloadData(node.inputs)
   const hasOutputs = hasPayloadData(node.outputs)
   const hasMetadata = hasPayloadData(node.metadata)
+  const hasEvidenceContent =
+    node.evidence_refs.length > 0 || explanationEntries.length > 0 || node.inflection_explanation !== null
 
   return (
     <div className="p-4 space-y-4 overflow-y-auto">
@@ -174,7 +176,7 @@ export function NodeInspector({ node }: NodeInspectorProps) {
         </TabsContent>
 
         <TabsContent value="evidence" className="space-y-4 pt-2">
-          {explanationEntries.length === 0 && !node.inflection_explanation ? (
+          {!hasEvidenceContent ? (
             <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-sm">Evidence trail</CardTitle>

--- a/driftshield/frontend/src/types/graph.ts
+++ b/driftshield/frontend/src/types/graph.ts
@@ -48,3 +48,129 @@ export interface GraphResponse {
   nodes: GraphNode[]
   edges: GraphEdge[]
 }
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  return value as UnknownRecord
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function asNullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function asNullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function normalizeExplanationPayload(value: unknown): ExplanationPayload | null {
+  const record = asRecord(value)
+  if (!record) {
+    return null
+  }
+
+  return {
+    reason: typeof record.reason === 'string' ? record.reason : '',
+    confidence: asNullableNumber(record.confidence),
+    evidence_refs: asStringArray(record.evidence_refs),
+  }
+}
+
+function normalizeRiskExplanations(value: unknown): Record<string, ExplanationPayload> {
+  const record = asRecord(value)
+  if (!record) {
+    return {}
+  }
+
+  const entries = Object.entries(record)
+    .map(([flag, explanation]) => {
+      const normalizedExplanation = normalizeExplanationPayload(explanation)
+      return normalizedExplanation ? [flag, normalizedExplanation] : null
+    })
+    .filter((entry): entry is [string, ExplanationPayload] => entry !== null)
+
+  return Object.fromEntries(entries)
+}
+
+function normalizeSessionProvenance(value: unknown): SessionProvenance | null {
+  const record = asRecord(value)
+  if (!record) {
+    return null
+  }
+
+  return {
+    source_session_id: asNullableString(record.source_session_id),
+    source_path: asNullableString(record.source_path),
+    parser_version: asNullableString(record.parser_version),
+    ingested_at: asNullableString(record.ingested_at),
+  }
+}
+
+function normalizeNodePayload(value: unknown): Record<string, unknown> | null {
+  return asRecord(value)
+}
+
+function normalizeGraphNode(value: unknown): GraphNode {
+  const record = asRecord(value) ?? {}
+  const parentNodeId = asNullableString(record.parent_node_id)
+  const parentNodeIds = asStringArray(record.parent_node_ids)
+
+  return {
+    id: asNullableString(record.id) ?? '',
+    node_kind: asNullableString(record.node_kind),
+    event_type: asNullableString(record.event_type) ?? 'UNKNOWN',
+    action: asNullableString(record.action),
+    summary: asNullableString(record.summary),
+    confidence: asNullableNumber(record.confidence),
+    sequence_num: asNullableNumber(record.sequence_num) ?? 0,
+    risk_flags: asStringArray(record.risk_flags),
+    risk_explanations: normalizeRiskExplanations(record.risk_explanations),
+    evidence_refs: asStringArray(record.evidence_refs),
+    is_inflection: Boolean(record.is_inflection),
+    inflection_explanation: normalizeExplanationPayload(record.inflection_explanation),
+    inputs: normalizeNodePayload(record.inputs),
+    outputs: normalizeNodePayload(record.outputs),
+    metadata: normalizeNodePayload(record.metadata),
+    parent_node_id: parentNodeId,
+    parent_node_ids: parentNodeIds.length > 0 ? parentNodeIds : parentNodeId ? [parentNodeId] : [],
+    lineage_ambiguities: asStringArray(record.lineage_ambiguities),
+  }
+}
+
+function normalizeGraphEdge(value: unknown): GraphEdge {
+  const record = asRecord(value) ?? {}
+
+  return {
+    source: asNullableString(record.source) ?? '',
+    target: asNullableString(record.target) ?? '',
+    relationship: asNullableString(record.relationship) ?? 'parent',
+    confidence: asNullableNumber(record.confidence) ?? 1,
+    inferred: Boolean(record.inferred),
+    reason: asNullableString(record.reason),
+    evidence_refs: asStringArray(record.evidence_refs),
+  }
+}
+
+// Keep the investigation view resilient while richer lineage fields roll out across fixtures and persisted payloads.
+export function normalizeGraphResponse(value: unknown): GraphResponse {
+  const record = asRecord(value) ?? {}
+
+  return {
+    session_id: asNullableString(record.session_id) ?? '',
+    provenance: normalizeSessionProvenance(record.provenance),
+    nodes: Array.isArray(record.nodes) ? record.nodes.map(normalizeGraphNode) : [],
+    edges: Array.isArray(record.edges) ? record.edges.map(normalizeGraphEdge) : [],
+  }
+}

--- a/driftshield/frontend/src/types/graph.ts
+++ b/driftshield/frontend/src/types/graph.ts
@@ -13,22 +13,33 @@ export interface SessionProvenance {
 
 export interface GraphNode {
   id: string
+  node_kind: string | null
   event_type: string
   action: string | null
+  summary: string | null
+  confidence: number | null
   sequence_num: number
   risk_flags: string[]
   risk_explanations: Record<string, ExplanationPayload>
+  evidence_refs: string[]
   is_inflection: boolean
   inflection_explanation: ExplanationPayload | null
   inputs: Record<string, unknown> | null
   outputs: Record<string, unknown> | null
   metadata: Record<string, unknown> | null
   parent_node_id: string | null
+  parent_node_ids: string[]
+  lineage_ambiguities: string[]
 }
 
 export interface GraphEdge {
   source: string
   target: string
+  relationship: string
+  confidence: number
+  inferred: boolean
+  reason: string | null
+  evidence_refs: string[]
 }
 
 export interface GraphResponse {

--- a/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
+++ b/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
@@ -281,3 +281,67 @@ test('shows node evidence refs even when no explanations were returned', async (
   await expect(page.getByText('artifact_refs[0]')).toBeVisible()
   await expect(page.getByText('No evidence refs were returned for this node.')).not.toBeVisible()
 })
+
+test('uses parent_node_ids fallback for single-parent timeline labels', async ({ page }) => {
+  await page.route(`**/api/sessions/${sessionId}`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: sessionId,
+        agent_id: 'claude-code',
+        external_id: null,
+        status: 'completed',
+        started_at: '2026-04-21T10:00:00Z',
+        ended_at: '2026-04-21T10:05:00Z',
+        risk_flag_count: 0,
+        has_inflection: false,
+        provenance: null,
+        total_events: 2,
+        flagged_events: 0,
+        risk_summary: {},
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/graph`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session_id: sessionId,
+        provenance: null,
+        nodes: [
+          buildGraphNode({
+            id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            action: 'root',
+            sequence_num: 0,
+          }),
+          buildGraphNode({
+            id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            action: 'child',
+            sequence_num: 1,
+            parent_node_id: null,
+            parent_node_ids: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+          }),
+        ],
+        edges: [
+          {
+            source: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            target: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            relationship: 'explicit_parent',
+            confidence: 1,
+            inferred: false,
+            reason: null,
+            evidence_refs: [],
+          },
+        ],
+      }),
+    })
+  })
+
+  await mockSessionArtifacts(page)
+
+  await page.goto(`/sessions/${sessionId}`)
+
+  await expect(page.getByText('Parent aaaaaaaa…')).toBeVisible()
+  await expect(page.getByText('Parent undefined…')).not.toBeVisible()
+})

--- a/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
+++ b/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
@@ -230,3 +230,54 @@ test('keeps the investigation view alive when graph payload omits lineage fields
   await expect(page.getByText('Investigation graph')).toBeVisible()
   await expect(page.getByText('Root node')).toBeVisible()
 })
+
+test('shows node evidence refs even when no explanations were returned', async ({ page }) => {
+  await page.route(`**/api/sessions/${sessionId}`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: sessionId,
+        agent_id: 'claude-code',
+        external_id: null,
+        status: 'completed',
+        started_at: '2026-04-21T10:00:00Z',
+        ended_at: '2026-04-21T10:05:00Z',
+        risk_flag_count: 0,
+        has_inflection: false,
+        provenance: null,
+        total_events: 1,
+        flagged_events: 0,
+        risk_summary: {},
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/graph`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session_id: sessionId,
+        provenance: null,
+        nodes: [
+          buildGraphNode({
+            event_type: 'OUTPUT',
+            action: 'respond',
+            evidence_refs: ['event:22222222-2222-2222-2222-222222222222', 'artifact_refs[0]'],
+          }),
+        ],
+        edges: [],
+      }),
+    })
+  })
+
+  await mockSessionArtifacts(page)
+
+  await page.goto(`/sessions/${sessionId}`)
+  await page.getByRole('button', { name: /respond/i }).click()
+  await page.getByRole('tab', { name: 'Evidence' }).click()
+
+  await expect(page.getByText('Node evidence')).toBeVisible()
+  await expect(page.getByText('event:22222222-2222-2222-2222-222222222222')).toBeVisible()
+  await expect(page.getByText('artifact_refs[0]')).toBeVisible()
+  await expect(page.getByText('No evidence refs were returned for this node.')).not.toBeVisible()
+})

--- a/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
+++ b/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
@@ -1,6 +1,46 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 
 const sessionId = '11111111-1111-1111-1111-111111111111'
+
+function buildGraphNode(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '22222222-2222-2222-2222-222222222222',
+    node_kind: null,
+    event_type: 'TOOL_CALL',
+    action: 'review_sections',
+    summary: null,
+    confidence: null,
+    sequence_num: 1,
+    risk_flags: [],
+    risk_explanations: {},
+    evidence_refs: [],
+    is_inflection: false,
+    inflection_explanation: null,
+    inputs: null,
+    outputs: null,
+    metadata: null,
+    parent_node_id: null,
+    parent_node_ids: [],
+    lineage_ambiguities: [],
+    ...overrides,
+  }
+}
+
+async function mockSessionArtifacts(page: Page) {
+  await page.route(`**/api/sessions/${sessionId}/reports`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/validations`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  })
+}
 
 test('shows matched signature and recurrence states from backend metadata', async ({ page }) => {
   await page.route(`**/api/sessions/${sessionId}`, async (route) => {
@@ -51,32 +91,17 @@ test('shows matched signature and recurrence states from backend metadata', asyn
         session_id: sessionId,
         provenance: null,
         nodes: [
-          {
-            id: '22222222-2222-2222-2222-222222222222',
-            event_type: 'TOOL_CALL',
-            action: 'review_sections',
-            sequence_num: 1,
+          buildGraphNode({
             risk_flags: ['coverage_gap'],
-            risk_explanations: {},
             is_inflection: true,
-            inflection_explanation: null,
-            inputs: null,
-            outputs: null,
-            metadata: null,
-            parent_node_id: null,
-          },
+          }),
         ],
         edges: [],
       }),
     })
   })
 
-  await page.route(`**/api/sessions/${sessionId}/reports`, async (route) => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify([]),
-    })
-  })
+  await mockSessionArtifacts(page)
 
   await page.goto(`/sessions/${sessionId}`)
 
@@ -116,14 +141,75 @@ test('shows unavailable state when backend omits signature and recurrence fields
         session_id: sessionId,
         provenance: null,
         nodes: [
-          {
-            id: '22222222-2222-2222-2222-222222222222',
+          buildGraphNode({
             event_type: 'OUTPUT',
             action: 'respond',
+          }),
+        ],
+        edges: [],
+      }),
+    })
+  })
+
+  await mockSessionArtifacts(page)
+
+  await page.goto(`/sessions/${sessionId}`)
+
+  await expect(page.getByText('This session does not expose signature or recurrence data yet.')).toBeVisible()
+})
+
+test('keeps the investigation view alive when graph payload omits lineage fields', async ({ page }) => {
+  await page.route(`**/api/sessions/${sessionId}`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: sessionId,
+        agent_id: 'claude-code',
+        external_id: null,
+        status: 'completed',
+        started_at: '2026-04-21T10:00:00Z',
+        ended_at: '2026-04-21T10:05:00Z',
+        risk_flag_count: 2,
+        has_inflection: true,
+        provenance: null,
+        total_events: 4,
+        flagged_events: 2,
+        risk_summary: { coverage_gap: 2 },
+        explanations: { risk_explanations: {}, inflection_explanation: null },
+        signature_match: {
+          status: 'matched',
+          primary_family_id: 'coverage_gap',
+          matched_family_ids: ['coverage_gap'],
+          match_count: 1,
+          summary: 'Matched one known failure family.',
+          raw: null,
+        },
+        recurrence_status: {
+          status: 'new',
+          cluster_id: null,
+          recurrence_count: 0,
+          summary: 'No related runs yet.',
+          raw: null,
+        },
+      }),
+    })
+  })
+
+  await page.route(`**/api/sessions/${sessionId}/graph`, async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session_id: sessionId,
+        provenance: null,
+        nodes: [
+          {
+            id: '22222222-2222-2222-2222-222222222222',
+            event_type: 'TOOL_CALL',
+            action: 'review_sections',
             sequence_num: 1,
-            risk_flags: [],
+            risk_flags: ['coverage_gap'],
             risk_explanations: {},
-            is_inflection: false,
+            is_inflection: true,
             inflection_explanation: null,
             inputs: null,
             outputs: null,
@@ -136,14 +222,11 @@ test('shows unavailable state when backend omits signature and recurrence fields
     })
   })
 
-  await page.route(`**/api/sessions/${sessionId}/reports`, async (route) => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify([]),
-    })
-  })
+  await mockSessionArtifacts(page)
 
   await page.goto(`/sessions/${sessionId}`)
 
-  await expect(page.getByText('This session does not expose signature or recurrence data yet.')).toBeVisible()
+  await expect(page.getByText('Signature: matched')).toBeVisible()
+  await expect(page.getByText('Investigation graph')).toBeVisible()
+  await expect(page.getByText('Root node')).toBeVisible()
 })

--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -280,37 +280,58 @@ def get_session_graph(
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    nodes = (
+    node_models = (
         db.query(DecisionNodeModel)
         .filter(DecisionNodeModel.session_id == session_id)
         .order_by(DecisionNodeModel.sequence_num)
         .all()
     )
-    if not nodes:
+    if not node_models:
         raise HTTPException(status_code=404, detail="No graph data for session")
 
+    graph = PersistenceService(db).load_graph(session_id)
+    if graph is None:
+        raise HTTPException(status_code=404, detail="No graph data for session")
+
+    node_models_by_id = {node.id: node for node in node_models}
     graph_nodes = []
-    edges = []
-    for node in nodes:
+    for graph_node in graph.nodes:
+        node = node_models_by_id[graph_node.id]
         graph_nodes.append(
             GraphNodeResponse(
-                id=node.id,
+                id=graph_node.id,
+                node_kind=graph_node.node_kind,
                 event_type=node.event_type,
                 action=node.action,
-                sequence_num=node.sequence_num,
+                summary=graph_node.summary,
+                confidence=graph_node.confidence,
+                sequence_num=graph_node.sequence_num,
                 risk_flags=_risk_flags_for_node(node),
                 risk_explanations=_risk_explanations_for_node(node),
+                evidence_refs=list(graph_node.evidence_refs),
                 is_inflection=node.is_inflection_node,
                 inflection_explanation=_explanation_payload(node.inflection_explanation),
                 inputs=node.inputs,
                 outputs=node.outputs,
                 metadata=node.metadata_json,
-                parent_node_id=node.parent_node_id,
+                parent_node_id=graph_node.primary_parent_id,
+                parent_node_ids=list(graph_node.parent_ids),
+                lineage_ambiguities=list(graph_node.lineage_ambiguities),
             )
         )
 
-        if node.parent_node_id is not None:
-            edges.append(GraphEdgeResponse(source=node.parent_node_id, target=node.id))
+    edges = [
+        GraphEdgeResponse(
+            source=edge.source_id,
+            target=edge.target_id,
+            relationship=edge.relationship,
+            confidence=edge.confidence,
+            inferred=edge.inferred,
+            reason=edge.reason,
+            evidence_refs=list(edge.evidence_refs),
+        )
+        for edge in graph.edges
+    ]
 
     return GraphResponse(
         session_id=session_id,

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -69,22 +69,33 @@ class SessionDetail(SessionSummary):
 
 class GraphNodeResponse(BaseModel):
     id: uuid.UUID
+    node_kind: str | None = None
     event_type: str
     action: str | None = None
+    summary: str | None = None
+    confidence: float | None = None
     sequence_num: int
     risk_flags: list[str] = Field(default_factory=list)
     risk_explanations: dict[str, ExplanationPayloadResponse] = Field(default_factory=dict)
+    evidence_refs: list[str] = Field(default_factory=list)
     is_inflection: bool = False
     inflection_explanation: ExplanationPayloadResponse | None = None
     inputs: dict[str, Any] | None = None
     outputs: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None
     parent_node_id: uuid.UUID | None = None
+    parent_node_ids: list[uuid.UUID] = Field(default_factory=list)
+    lineage_ambiguities: list[str] = Field(default_factory=list)
 
 
 class GraphEdgeResponse(BaseModel):
     source: uuid.UUID
     target: uuid.UUID
+    relationship: str = "explicit_parent"
+    confidence: float = 1.0
+    inferred: bool = False
+    reason: str | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
 
 
 class GraphResponse(BaseModel):

--- a/driftshield/src/driftshield/core/graph/builder.py
+++ b/driftshield/src/driftshield/core/graph/builder.py
@@ -1,14 +1,19 @@
 """Build lineage graphs from canonical events."""
 
+from uuid import UUID
+
 from driftshield.core.models import CanonicalEvent
-from driftshield.core.graph.models import DecisionNode, LineageGraph
+from driftshield.core.graph.models import DecisionNode, LineageEdge, LineageGraph
 
 
 def build_graph(events: list[CanonicalEvent], session_id: str) -> LineageGraph:
     """
     Build a LineageGraph from a list of CanonicalEvents.
 
-    Events are sorted by timestamp and assigned sequence numbers.
+    Events are sorted by timestamp and assigned sequence numbers. Explicit parent
+    references build the canonical DAG. When a normalized event has no usable
+    parent reference, a low-confidence inferred edge keeps the lineage connected
+    without pretending the source relationship is certain.
     """
     graph = LineageGraph(session_id=session_id)
 
@@ -21,9 +26,204 @@ def build_graph(events: list[CanonicalEvent], session_id: str) -> LineageGraph:
         ),
     )
 
-    # Create nodes with sequence numbers
+    sequence_by_id = {event.id: index for index, event in enumerate(sorted_events)}
+
     for seq_num, event in enumerate(sorted_events):
-        node = DecisionNode(event=event, sequence_num=seq_num)
+        node = DecisionNode(
+            event=event,
+            sequence_num=seq_num,
+            summary=_node_summary(event),
+            confidence=_node_confidence(event),
+            evidence_refs=_node_evidence_refs(event),
+            lineage_ambiguities=_node_ambiguities(event),
+        )
         graph.add_node(node)
 
+    for node in graph.nodes:
+        incoming_edges = _incoming_edges(node, graph, sequence_by_id)
+        node.parent_ids = [edge.source_id for edge in incoming_edges]
+        node.primary_parent_id = _primary_parent_id(node, incoming_edges)
+        node.lineage_ambiguities = _merge_ambiguities(node, incoming_edges)
+        node.confidence = _node_confidence(node.event, incoming_edges=incoming_edges)
+        if not node.evidence_refs:
+            node.evidence_refs = _node_evidence_refs(node.event)
+
+        for edge in incoming_edges:
+            graph.add_edge(edge)
+
     return graph
+
+
+def _lineage_payload(event: CanonicalEvent) -> dict[str, object]:
+    payload = event.metadata.get("lineage") if event.metadata else None
+    return payload if isinstance(payload, dict) else {}
+
+
+def _node_summary(event: CanonicalEvent) -> str | None:
+    lineage = _lineage_payload(event)
+    summary = lineage.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary
+    return event.summary or event.action
+
+
+def _node_ambiguities(event: CanonicalEvent) -> list[str]:
+    lineage = _lineage_payload(event)
+    stored = lineage.get("lineage_ambiguities")
+    if isinstance(stored, list):
+        return [str(item) for item in stored if isinstance(item, str)]
+    return list(event.ambiguities or [])
+
+
+def _node_confidence(
+    event: CanonicalEvent,
+    *,
+    incoming_edges: list[LineageEdge] | None = None,
+) -> float:
+    lineage = _lineage_payload(event)
+    stored = lineage.get("confidence")
+    if isinstance(stored, (int, float)) and not isinstance(stored, bool):
+        return float(stored)
+
+    ambiguities = _node_ambiguities(event)
+    if incoming_edges:
+        return min(edge.confidence for edge in incoming_edges)
+    if ambiguities:
+        return 0.7
+    return 1.0
+
+
+def _node_evidence_refs(event: CanonicalEvent) -> list[str]:
+    lineage = _lineage_payload(event)
+    stored = lineage.get("evidence_refs")
+    if isinstance(stored, list):
+        refs = [str(item) for item in stored if isinstance(item, str)]
+        if refs:
+            return refs
+
+    refs = [f"event:{event.id}"]
+    refs.extend(f"parent_event_refs[{idx}]" for idx, _ in enumerate(event.parent_event_refs))
+    refs.extend(f"source_refs[{idx}]" for idx, _ in enumerate(event.source_refs))
+    refs.extend(f"artifact_refs[{idx}]" for idx, _ in enumerate(event.artifact_refs))
+    refs.extend(f"constraints[{idx}]" for idx, _ in enumerate(event.constraints))
+    if event.tool_activity:
+        refs.append("tool_activity")
+    if event.failure_context:
+        refs.append("failure_context")
+        refs.extend(
+            f"failure_context.signal:{signal}"
+            for signal in event.failure_context.get("signals", [])
+            if isinstance(signal, str)
+        )
+    refs.extend(f"ambiguity:{ambiguity}" for ambiguity in event.ambiguities)
+    return refs
+
+
+def _incoming_edges(
+    node: DecisionNode,
+    graph: LineageGraph,
+    sequence_by_id: dict[UUID, int],
+) -> list[LineageEdge]:
+    persisted_edges = _persisted_incoming_edges(node.event)
+    if persisted_edges:
+        return persisted_edges
+
+    explicit_parent_ids = _valid_parent_ids(node, sequence_by_id)
+    if explicit_parent_ids:
+        return [
+            LineageEdge(
+                source_id=parent_id,
+                target_id=node.id,
+                relationship="explicit_parent",
+                confidence=1.0,
+                evidence_refs=_explicit_edge_evidence_refs(node.event, parent_id),
+            )
+            for parent_id in explicit_parent_ids
+        ]
+
+    if node.sequence_num == 0:
+        return []
+
+    previous_node = graph.nodes[node.sequence_num - 1]
+    reason = "missing_parent_ref"
+    if node.event.parent_event_refs:
+        reason = "missing_parent_target"
+    return [
+        LineageEdge(
+            source_id=previous_node.id,
+            target_id=node.id,
+            relationship="inferred_sequence",
+            confidence=0.35,
+            inferred=True,
+            reason=reason,
+            evidence_refs=[
+                f"event:{node.id}",
+                f"node:{previous_node.id}",
+                f"ambiguity:{reason}",
+            ],
+        )
+    ]
+
+
+def _persisted_incoming_edges(event: CanonicalEvent) -> list[LineageEdge]:
+    lineage = _lineage_payload(event)
+    payloads = lineage.get("incoming_edges")
+    if not isinstance(payloads, list):
+        return []
+
+    edges: list[LineageEdge] = []
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        edge = LineageEdge.from_dict(payload)
+        if edge is not None:
+            edges.append(edge)
+    return edges
+
+
+def _valid_parent_ids(node: DecisionNode, sequence_by_id: dict[UUID, int]) -> list[UUID]:
+    parent_ids: list[UUID] = []
+    for parent_id in node.event.parent_event_refs:
+        parent_seq = sequence_by_id.get(parent_id)
+        if parent_seq is None or parent_seq >= node.sequence_num:
+            continue
+        if parent_id not in parent_ids:
+            parent_ids.append(parent_id)
+    return parent_ids
+
+
+def _explicit_edge_evidence_refs(event: CanonicalEvent, parent_id: UUID) -> list[str]:
+    refs = [f"event:{event.id}", f"node:{parent_id}"]
+    for idx, ref in enumerate(event.parent_event_refs):
+        if ref == parent_id:
+            refs.append(f"parent_event_refs[{idx}]")
+    if event.parent_event_id == parent_id:
+        refs.append("parent_event_id")
+    if event.tool_activity:
+        refs.append("tool_activity")
+    return refs
+
+
+def _primary_parent_id(node: DecisionNode, incoming_edges: list[LineageEdge]) -> UUID | None:
+    lineage = _lineage_payload(node.event)
+    stored = lineage.get("primary_parent_id")
+    if isinstance(stored, str):
+        try:
+            return UUID(stored)
+        except ValueError:
+            pass
+
+    if node.event.parent_event_id is not None:
+        for edge in incoming_edges:
+            if edge.source_id == node.event.parent_event_id:
+                return edge.source_id
+
+    return incoming_edges[0].source_id if incoming_edges else None
+
+
+def _merge_ambiguities(node: DecisionNode, incoming_edges: list[LineageEdge]) -> list[str]:
+    ambiguities = list(node.lineage_ambiguities)
+    for edge in incoming_edges:
+        if edge.reason and edge.reason not in ambiguities:
+            ambiguities.append(edge.reason)
+    return ambiguities

--- a/driftshield/src/driftshield/core/graph/models.py
+++ b/driftshield/src/driftshield/core/graph/models.py
@@ -1,9 +1,61 @@
 """Graph models for behavioral lineage."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
 from driftshield.core.models import CanonicalEvent, EventType
+
+
+@dataclass
+class LineageEdge:
+    """A typed edge between two decision nodes in the lineage graph."""
+
+    source_id: UUID
+    target_id: UUID
+    relationship: str = "explicit_parent"
+    confidence: float = 1.0
+    inferred: bool = False
+    reason: str | None = None
+    evidence_refs: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_id": str(self.source_id),
+            "target_id": str(self.target_id),
+            "relationship": self.relationship,
+            "confidence": self.confidence,
+            "inferred": self.inferred,
+            "reason": self.reason,
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> "LineageEdge | None":
+        source_id = payload.get("source_id")
+        target_id = payload.get("target_id")
+        if not isinstance(source_id, str) or not isinstance(target_id, str):
+            return None
+
+        try:
+            return cls(
+                source_id=UUID(source_id),
+                target_id=UUID(target_id),
+                relationship=(
+                    payload.get("relationship")
+                    if isinstance(payload.get("relationship"), str)
+                    else "explicit_parent"
+                ),
+                confidence=float(payload.get("confidence", 1.0)),
+                inferred=bool(payload.get("inferred", False)),
+                reason=payload.get("reason") if isinstance(payload.get("reason"), str) else None,
+                evidence_refs=[
+                    str(ref)
+                    for ref in payload.get("evidence_refs", [])
+                    if isinstance(ref, str)
+                ],
+            )
+        except (TypeError, ValueError):
+            return None
 
 
 @dataclass
@@ -12,7 +64,25 @@ class DecisionNode:
 
     event: CanonicalEvent
     sequence_num: int
+    summary: str | None = None
+    confidence: float | None = None
+    evidence_refs: list[str] = field(default_factory=list)
+    parent_ids: list[UUID] = field(default_factory=list)
+    lineage_ambiguities: list[str] = field(default_factory=list)
+    primary_parent_id: UUID | None = None
     is_inflection_node: bool = False
+
+    def __post_init__(self) -> None:
+        if self.summary is None:
+            self.summary = self.event.summary or self.event.action
+        if self.confidence is None:
+            self.confidence = 0.7 if self.lineage_ambiguities else 1.0
+        if not self.parent_ids:
+            self.parent_ids = list(self.event.parent_event_refs or [])
+        if self.primary_parent_id is None and self.parent_ids:
+            self.primary_parent_id = self.parent_ids[0]
+        if not self.lineage_ambiguities:
+            self.lineage_ambiguities = list(self.event.ambiguities or [])
 
     @property
     def id(self) -> UUID:
@@ -27,6 +97,10 @@ class DecisionNode:
         return self.event.event_type
 
     @property
+    def node_kind(self) -> str:
+        return self.event.event_kind
+
+    @property
     def inputs(self) -> dict:
         return self.event.inputs
 
@@ -36,7 +110,7 @@ class DecisionNode:
 
     @property
     def parent_event_id(self) -> UUID | None:
-        return self.event.parent_event_id
+        return self.primary_parent_id
 
     def has_risk_flags(self) -> bool:
         return self.event.has_risk_flags()
@@ -47,15 +121,50 @@ class LineageGraph:
     """A directed acyclic graph of decision nodes representing reasoning trajectory."""
 
     session_id: str
-    _nodes: dict = None  # UUID -> DecisionNode
+    _nodes: dict[UUID, DecisionNode] | None = None
+    _edges: list[LineageEdge] | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self._nodes is None:
             self._nodes = {}
+        if self._edges is None:
+            self._edges = []
 
     def add_node(self, node: DecisionNode) -> None:
         """Add a node to the graph."""
         self._nodes[node.id] = node
+        lineage = node.event.metadata.get("lineage") if node.event.metadata else None
+        if isinstance(lineage, dict) and isinstance(lineage.get("incoming_edges"), list):
+            return
+        parent_ids = node.parent_ids or ([node.primary_parent_id] if node.primary_parent_id else [])
+        for index, parent_id in enumerate(parent_ids):
+            self.add_edge(
+                LineageEdge(
+                    source_id=parent_id,
+                    target_id=node.id,
+                    relationship="explicit_parent",
+                    confidence=1.0,
+                    evidence_refs=["parent_event_id" if index == 0 else f"parent_ids[{index}]"],
+                )
+            )
+
+    def add_edge(self, edge: LineageEdge) -> None:
+        """Add an edge to the graph, skipping exact duplicates."""
+        for existing in self._edges:
+            if (
+                existing.source_id == edge.source_id
+                and existing.target_id == edge.target_id
+                and existing.relationship == edge.relationship
+                and existing.reason == edge.reason
+            ):
+                if len(edge.evidence_refs) > len(existing.evidence_refs):
+                    existing.evidence_refs = list(edge.evidence_refs)
+                if edge.confidence != existing.confidence:
+                    existing.confidence = edge.confidence
+                if edge.inferred != existing.inferred:
+                    existing.inferred = edge.inferred
+                return
+        self._edges.append(edge)
 
     def get_node(self, node_id: UUID) -> DecisionNode | None:
         """Get a node by ID."""
@@ -67,34 +176,69 @@ class LineageGraph:
         return sorted(self._nodes.values(), key=lambda n: n.sequence_num)
 
     @property
+    def edges(self) -> list[LineageEdge]:
+        """Return all edges in target/source sequence order."""
+        def _edge_sort_key(edge: LineageEdge) -> tuple[int, int]:
+            target = self.get_node(edge.target_id)
+            source = self.get_node(edge.source_id)
+            return (
+                target.sequence_num if target is not None else -1,
+                source.sequence_num if source is not None else -1,
+            )
+
+        return sorted(self._edges, key=_edge_sort_key)
+
+    @property
+    def root_nodes(self) -> list[DecisionNode]:
+        """Return root nodes in sequence order."""
+        return [node for node in self.nodes if not self.incoming_edges(node.id)]
+
+    @property
     def root(self) -> DecisionNode | None:
-        """Return the root node (sequence_num 0)."""
-        for node in self._nodes.values():
-            if node.sequence_num == 0:
-                return node
-        return None
+        """Return the first root node in sequence order."""
+        roots = self.root_nodes
+        return roots[0] if roots else None
+
+    def incoming_edges(self, node_id: UUID) -> list[LineageEdge]:
+        return [edge for edge in self.edges if edge.target_id == node_id]
+
+    def outgoing_edges(self, node_id: UUID) -> list[LineageEdge]:
+        return [edge for edge in self.edges if edge.source_id == node_id]
 
     def get_children(self, node_id: UUID) -> list[DecisionNode]:
-        """Get all nodes that have this node as parent."""
-        return [
-            node for node in self._nodes.values()
-            if node.parent_event_id == node_id
-        ]
+        """Get all child nodes for a given node."""
+        children: list[DecisionNode] = []
+        for edge in self.outgoing_edges(node_id):
+            child = self.get_node(edge.target_id)
+            if child is not None:
+                children.append(child)
+        return children
+
+    def get_parents(self, node_id: UUID) -> list[DecisionNode]:
+        """Get all parent nodes for a given node."""
+        parents: list[DecisionNode] = []
+        for edge in self.incoming_edges(node_id):
+            parent = self.get_node(edge.source_id)
+            if parent is not None:
+                parents.append(parent)
+        return parents
 
     def get_parent(self, node_id: UUID) -> DecisionNode | None:
-        """Get the parent node of a given node."""
+        """Get the primary parent node of a given node."""
         node = self.get_node(node_id)
-        if node is None or node.parent_event_id is None:
+        if node is None or node.primary_parent_id is None:
             return None
-        return self.get_node(node.parent_event_id)
+        return self.get_node(node.primary_parent_id)
 
     def path_to_root(self, node_id: UUID) -> list[DecisionNode]:
-        """Return path from node to root, starting with the given node."""
-        path = []
+        """Return the primary path from node to root, starting with the given node."""
+        path: list[DecisionNode] = []
         current = self.get_node(node_id)
+        visited: set[UUID] = set()
 
-        while current is not None:
+        while current is not None and current.id not in visited:
             path.append(current)
+            visited.add(current.id)
             current = self.get_parent(current.id)
 
         return path
@@ -105,15 +249,10 @@ class LineageGraph:
             node = self.get_node(start_id)
             return [node] if node else []
 
-        # Walk backward from end to find start
         path_to_root = self.path_to_root(end_id)
 
         try:
-            start_idx = next(
-                i for i, node in enumerate(path_to_root)
-                if node.id == start_id
-            )
-            # Reverse to get start -> end order
+            start_idx = next(i for i, node in enumerate(path_to_root) if node.id == start_id)
             return list(reversed(path_to_root[: start_idx + 1]))
         except StopIteration:
             return []

--- a/driftshield/src/driftshield/core/graph/models.py
+++ b/driftshield/src/driftshield/core/graph/models.py
@@ -138,6 +138,9 @@ class LineageGraph:
             return
         parent_ids = node.parent_ids or ([node.primary_parent_id] if node.primary_parent_id else [])
         for index, parent_id in enumerate(parent_ids):
+            parent_node = self._nodes.get(parent_id)
+            if parent_node is None or parent_node.sequence_num >= node.sequence_num:
+                continue
             self.add_edge(
                 LineageEdge(
                     source_id=parent_id,

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -176,6 +176,19 @@ class PersistenceService:
                 result.inflection_node is not None
                 and node.id == result.inflection_node.id
             )
+            metadata_json = dict(node.event.metadata or {})
+            metadata_json["lineage"] = {
+                "summary": node.summary,
+                "confidence": node.confidence,
+                "evidence_refs": list(node.evidence_refs),
+                "parent_ids": [str(parent_id) for parent_id in node.parent_ids],
+                "primary_parent_id": str(node.primary_parent_id) if node.primary_parent_id else None,
+                "lineage_ambiguities": list(node.lineage_ambiguities),
+                "incoming_edges": [
+                    edge.to_dict()
+                    for edge in result.graph.incoming_edges(node.id)
+                ],
+            }
             node_model = DecisionNodeModel(
                 id=node.id,
                 session_id=session.id,
@@ -186,7 +199,7 @@ class PersistenceService:
                 action=node.action,
                 inputs=node.inputs,
                 outputs=node.outputs,
-                metadata_json=node.event.metadata,
+                metadata_json=metadata_json,
                 assumption_mutation=risk.assumption_mutation,
                 policy_divergence=risk.policy_divergence,
                 constraint_violation=risk.constraint_violation,
@@ -339,6 +352,21 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
     metadata = dict(node.metadata_json or {})
     if node.inflection_explanation is not None:
         metadata["inflection_explanation"] = node.inflection_explanation
+    lineage = metadata.get("lineage") if isinstance(metadata.get("lineage"), dict) else {}
+
+    parent_refs: list[uuid.UUID] = []
+    raw_parent_ids = lineage.get("parent_ids")
+    if isinstance(raw_parent_ids, list):
+        for parent_id in raw_parent_ids:
+            if not isinstance(parent_id, str):
+                continue
+            try:
+                parent_refs.append(uuid.UUID(parent_id))
+            except ValueError:
+                continue
+
+    if node.parent_node_id is not None and node.parent_node_id not in parent_refs:
+        parent_refs.insert(0, node.parent_node_id)
 
     return CanonicalEvent(
         id=node.id,
@@ -351,6 +379,13 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
         inputs=node.inputs,
         outputs=node.outputs,
         metadata=metadata,
+        summary=lineage.get("summary") if isinstance(lineage.get("summary"), str) else None,
+        parent_event_refs=parent_refs,
+        ambiguities=[
+            str(item)
+            for item in lineage.get("lineage_ambiguities", [])
+            if isinstance(item, str)
+        ],
         risk_classification=RiskClassification(
             assumption_mutation=node.assumption_mutation,
             policy_divergence=node.policy_divergence,

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -372,6 +372,7 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
         id=node.id,
         session_id=str(session_id),
         timestamp=node.timestamp,
+        ordinal=node.sequence_num,
         event_type=EventType(node.event_type),
         agent_id="",
         action=node.action,

--- a/driftshield/tests/api/test_graph.py
+++ b/driftshield/tests/api/test_graph.py
@@ -8,7 +8,11 @@ from sqlalchemy.orm import Session as DBSession
 from sqlalchemy.pool import StaticPool
 
 from driftshield.api.app import create_app
+from driftshield.core.analysis.session import analyze_session
+from driftshield.core.models import Session as DomainSession, SessionStatus
 from driftshield.db.models import Base, SessionModel, DecisionNodeModel
+from driftshield.db.persistence import PersistenceService
+from tests.fixtures.lineage import branching_lineage_events
 
 
 @pytest.fixture
@@ -82,3 +86,37 @@ def test_get_graph(client, auth_headers, seeded_graph):
 def test_get_graph_not_found(client, auth_headers):
     response = client.get(f"/api/sessions/{uuid.uuid4()}/graph", headers=auth_headers)
     assert response.status_code == 404
+
+
+def test_get_graph_returns_branching_lineage_metadata(client, auth_headers, db_session):
+    session_id = uuid.uuid4()
+    events = branching_lineage_events(str(session_id))
+    result = analyze_session(events)
+
+    PersistenceService(db_session).save(
+        DomainSession(
+            id=session_id,
+            agent_id="test-agent",
+            started_at=datetime.now(timezone.utc),
+            status=SessionStatus.COMPLETED,
+        ),
+        result,
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/sessions/{session_id}/graph", headers=auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["edges"]) == 4
+
+    merge_node = next(node for node in payload["nodes"] if node["action"] == "synthesize_findings")
+    assert merge_node["parent_node_id"] == str(events[1].id)
+    assert merge_node["parent_node_ids"] == [str(events[1].id), str(events[2].id)]
+    assert merge_node["evidence_refs"]
+
+    merge_edges = [edge for edge in payload["edges"] if edge["target"] == str(events[-1].id)]
+    assert len(merge_edges) == 2
+    assert [edge["source"] for edge in merge_edges] == [str(events[1].id), str(events[2].id)]
+    assert all(edge["relationship"] == "explicit_parent" for edge in merge_edges)
+    assert all(edge["confidence"] == 1.0 for edge in merge_edges)

--- a/driftshield/tests/api/test_schemas.py
+++ b/driftshield/tests/api/test_schemas.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 from driftshield.api.schemas import (
-    SessionSummary, SessionDetail, GraphNodeResponse, GraphEdgeResponse,
+    SessionSummary, GraphNodeResponse, GraphEdgeResponse,
     GraphResponse, PaginatedResponse, IngestResponse,
 )
 
@@ -28,14 +28,28 @@ def test_graph_response_structure():
         nodes=[
             GraphNodeResponse(
                 id=node_id,
+                node_kind="tool_call",
                 event_type="TOOL_CALL",
                 action="read_file",
+                summary="Read the target file.",
                 sequence_num=1,
                 risk_flags=[],
+                evidence_refs=["event:test"],
                 is_inflection=False,
+                parent_node_ids=[],
+                lineage_ambiguities=[],
             )
         ],
-        edges=[],
+        edges=[
+            GraphEdgeResponse(
+                source=node_id,
+                target=node_id,
+                relationship="explicit_parent",
+                confidence=1.0,
+                inferred=False,
+                evidence_refs=["event:test"],
+            )
+        ],
     )
     data = g.model_dump(mode="json")
     assert len(data["nodes"]) == 1

--- a/driftshield/tests/core/graph/test_builder.py
+++ b/driftshield/tests/core/graph/test_builder.py
@@ -3,8 +3,10 @@
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from driftshield.core.normalization import normalize_events
 from driftshield.core.models import CanonicalEvent, EventType
 from driftshield.core.graph.builder import build_graph
+from tests.fixtures.lineage import branching_lineage_events, linear_lineage_events
 
 
 def make_event(**kwargs) -> CanonicalEvent:
@@ -106,3 +108,47 @@ class TestBuildGraph:
         children = graph.get_children(root.id)
         assert len(children) == 2
         assert {c.action for c in children} == {"child1", "child2"}
+
+    def test_build_graph_creates_branching_dag_from_multi_parent_refs(self):
+        """Normalized parent refs can form an explicit DAG instead of a single chain."""
+        events = normalize_events(branching_lineage_events())
+
+        graph = build_graph(events, session_id=events[0].session_id)
+
+        merge_event = events[-1]
+        merge_node = graph.get_node(merge_event.id)
+        assert merge_node is not None
+        assert merge_node.parent_ids == [events[1].id, events[2].id]
+
+        incoming = graph.incoming_edges(merge_node.id)
+        assert [edge.source_id for edge in incoming] == [events[1].id, events[2].id]
+        assert all(edge.confidence == 1.0 for edge in incoming)
+        assert all(edge.relationship == "explicit_parent" for edge in incoming)
+        assert [parent.id for parent in graph.get_parents(merge_node.id)] == [
+            events[1].id,
+            events[2].id,
+        ]
+        assert graph.get_parent(merge_node.id).id == events[1].id
+        assert merge_node.evidence_refs
+
+    def test_build_graph_marks_inferred_edges_when_parent_refs_are_missing(self):
+        """Missing parents stay explicit through inferred low-confidence edges."""
+        events = linear_lineage_events()
+        events[1].parent_event_id = None
+        events[1].parent_event_refs = []
+        events[2].parent_event_id = None
+        events[2].parent_event_refs = []
+
+        normalize_events(events)
+        graph = build_graph(events, session_id=events[0].session_id)
+
+        inferred_edges = [edge for edge in graph.edges if edge.inferred]
+        assert len(inferred_edges) == 2
+        assert all(edge.relationship == "inferred_sequence" for edge in inferred_edges)
+        assert all(edge.confidence < 1.0 for edge in inferred_edges)
+        assert all(edge.reason == "missing_parent_ref" for edge in inferred_edges)
+        assert [node.action for node in graph.path_to_root(events[-1].id)] == [
+            "draft_summary",
+            "inspect_failure",
+            "load_session",
+        ]

--- a/driftshield/tests/core/graph/test_builder.py
+++ b/driftshield/tests/core/graph/test_builder.py
@@ -152,3 +152,24 @@ class TestBuildGraph:
             "inspect_failure",
             "load_session",
         ]
+
+    def test_build_graph_drops_explicit_edges_when_parent_targets_are_missing(self):
+        """Dangling parent refs should fall back to one inferred edge without orphan sources."""
+        events = linear_lineage_events()
+        missing_parent_id = uuid4()
+        events[2].parent_event_id = missing_parent_id
+        events[2].parent_event_refs = [missing_parent_id]
+
+        graph = build_graph(events, session_id=events[0].session_id)
+
+        target_node = graph.get_node(events[2].id)
+        assert target_node is not None
+        incoming_edges = graph.incoming_edges(events[2].id)
+
+        assert len(incoming_edges) == 1
+        assert incoming_edges[0].source_id == events[1].id
+        assert incoming_edges[0].relationship == "inferred_sequence"
+        assert incoming_edges[0].inferred is True
+        assert incoming_edges[0].reason == "missing_parent_target"
+        assert target_node.parent_ids == [events[1].id]
+        assert all(graph.get_node(edge.source_id) is not None for edge in graph.edges)

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -21,6 +21,7 @@ from driftshield.db.models import (
     SessionModel,
 )
 from driftshield.db.persistence import IngestProvenance, PersistenceService
+from tests.fixtures.lineage import branching_lineage_events
 
 
 @pytest.fixture
@@ -144,6 +145,44 @@ def test_load_graph(db_session, sample_analysis_result):
     graph = service.load_graph(domain_session.id)
     assert graph is not None
     assert len(graph.nodes) == 2
+
+
+def test_load_graph_round_trips_branching_lineage_metadata(db_session):
+    session_id = uuid.uuid4()
+    events = branching_lineage_events(str(session_id))
+    result = analyze_session(events)
+    domain_session = DomainSession(
+        id=session_id,
+        agent_id="test-agent",
+        started_at=datetime.now(timezone.utc),
+        status=SessionStatus.COMPLETED,
+    )
+
+    service = PersistenceService(db_session)
+    service.save(domain_session, result)
+    db_session.commit()
+
+    stored_merge = (
+        db_session.query(DecisionNodeModel)
+        .filter(DecisionNodeModel.session_id == session_id)
+        .order_by(DecisionNodeModel.sequence_num.desc())
+        .first()
+    )
+    assert stored_merge is not None
+    assert stored_merge.metadata_json["lineage"]["parent_ids"] == [
+        str(events[1].id),
+        str(events[2].id),
+    ]
+
+    graph = service.load_graph(session_id)
+    assert graph is not None
+    merge_node = graph.get_node(events[-1].id)
+    assert merge_node is not None
+    assert merge_node.parent_ids == [events[1].id, events[2].id]
+    assert [edge.source_id for edge in graph.incoming_edges(events[-1].id)] == [
+        events[1].id,
+        events[2].id,
+    ]
 
 
 def test_load_nonexistent_session(db_session):

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -185,6 +185,56 @@ def test_load_graph_round_trips_branching_lineage_metadata(db_session):
     ]
 
 
+def test_load_graph_preserves_stored_sequence_order_when_timestamps_disagree(db_session):
+    session_id = uuid.uuid4()
+    service = PersistenceService(db_session)
+
+    session = SessionModel(
+        id=session_id,
+        agent_id="test-agent",
+        started_at=datetime.now(timezone.utc),
+        status="completed",
+    )
+    later_timestamp = datetime(2026, 4, 23, 10, 0, 5, tzinfo=timezone.utc)
+    earlier_timestamp = datetime(2026, 4, 23, 10, 0, 1, tzinfo=timezone.utc)
+
+    first_id = uuid.uuid4()
+    second_id = uuid.uuid4()
+    db_session.add(session)
+    db_session.add_all(
+        [
+            DecisionNodeModel(
+                id=first_id,
+                session_id=session_id,
+                sequence_num=0,
+                timestamp=later_timestamp,
+                event_type="TOOL_CALL",
+                action="first",
+                parent_node_id=None,
+                metadata_json={},
+            ),
+            DecisionNodeModel(
+                id=second_id,
+                session_id=session_id,
+                sequence_num=1,
+                timestamp=earlier_timestamp,
+                event_type="OUTPUT",
+                action="second",
+                parent_node_id=first_id,
+                metadata_json={},
+            ),
+        ]
+    )
+    db_session.commit()
+
+    graph = service.load_graph(session_id)
+
+    assert graph is not None
+    assert [node.id for node in graph.nodes] == [first_id, second_id]
+    assert [node.sequence_num for node in graph.nodes] == [0, 1]
+    assert graph.incoming_edges(second_id)[0].source_id == first_id
+
+
 def test_load_nonexistent_session(db_session):
     service = PersistenceService(db_session)
     loaded = service.load_session(uuid.uuid4())

--- a/driftshield/tests/fixtures/lineage.py
+++ b/driftshield/tests/fixtures/lineage.py
@@ -1,0 +1,89 @@
+"""Reusable lineage fixtures for Phase 2b graph coverage."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from driftshield.core.models import CanonicalEvent, EventType
+
+
+def _ts(step: int) -> datetime:
+    base = datetime(2026, 4, 23, 10, 0, tzinfo=timezone.utc)
+    return base + timedelta(seconds=step)
+
+
+def linear_lineage_events(session_id: str = "lineage-linear-001") -> list[CanonicalEvent]:
+    root = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(0),
+        event_type=EventType.TOOL_CALL,
+        agent_id="analyst",
+        action="load_session",
+        outputs={"status": "loaded"},
+    )
+    inspect = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(1),
+        event_type=EventType.TOOL_CALL,
+        agent_id="analyst",
+        action="inspect_failure",
+        parent_event_id=root.id,
+        inputs={"session_id": session_id},
+        outputs={"status": "reviewed"},
+    )
+    conclude = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(2),
+        event_type=EventType.OUTPUT,
+        agent_id="analyst",
+        action="draft_summary",
+        parent_event_id=inspect.id,
+        outputs={"summary": "Failure path reconstructed"},
+    )
+    return [root, inspect, conclude]
+
+
+def branching_lineage_events(session_id: str = "lineage-branching-001") -> list[CanonicalEvent]:
+    root = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(0),
+        event_type=EventType.TOOL_CALL,
+        agent_id="analyst",
+        action="load_session",
+        outputs={"status": "loaded"},
+    )
+    branch_a = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(1),
+        event_type=EventType.BRANCH,
+        agent_id="analyst",
+        action="review_tool_trace",
+        parent_event_id=root.id,
+        outputs={"hypothesis": "Tool path may have diverged"},
+    )
+    branch_b = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(2),
+        event_type=EventType.TOOL_CALL,
+        agent_id="analyst",
+        action="review_user_constraints",
+        parent_event_id=root.id,
+        inputs={"focus": "constraint handling"},
+        outputs={"hypothesis": "User guardrails were underspecified"},
+    )
+    merge = CanonicalEvent(
+        id=uuid4(),
+        session_id=session_id,
+        timestamp=_ts(3),
+        event_type=EventType.OUTPUT,
+        agent_id="analyst",
+        action="synthesize_findings",
+        parent_event_refs=[branch_a.id, branch_b.id],
+        outputs={"summary": "Combined tool and constraint evidence into one narrative"},
+    )
+    return [root, branch_a, branch_b, merge]


### PR DESCRIPTION
## Summary
- replace the old single-parent lineage wrapper with an explicit DAG model that keeps edge confidence, inference reasons, and node evidence refs
- persist lineage metadata on decision nodes and expose the richer graph through the session graph API and investigation UI
- normalize legacy graph payloads in the frontend so the investigation page stays up while richer lineage fields roll out, and cover that with Playwright
- add linear and branching lineage fixtures plus round-trip API and persistence coverage for Phase 2b graph behavior

## Linked Issue
- Refs tborys/driftshield-meta#41

## Verification
- `cd driftshield && uv run --extra dev pytest tests -q`
- `cd driftshield/frontend && VITE_API_KEY=test-key npm run build`
- `cd driftshield && uv run ruff check src/driftshield/core/graph/models.py src/driftshield/core/graph/builder.py src/driftshield/db/persistence.py src/driftshield/api/routes/sessions.py src/driftshield/api/schemas.py tests/fixtures/lineage.py tests/core/graph/test_builder.py tests/db/test_persistence.py tests/api/test_graph.py tests/api/test_schemas.py`
- `cd driftshield/frontend && npx eslint src/types/graph.ts src/components/investigation/LineageGraph.tsx src/components/investigation/InvestigationView.tsx src/components/investigation/NodeInspector.tsx`
- `cd driftshield/frontend && npx eslint src/api/sessions.ts src/types/graph.ts tests/e2e/investigation-signature-summary.spec.ts`
- `cd driftshield/frontend && npx playwright test tests/e2e/investigation-signature-summary.spec.ts --reporter=list`
- Browser verification: served the built frontend through the local FastAPI app against a throwaway SQLite DB, opened `/sessions/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa`, confirmed the investigation page rendered a 4-node / 4-edge branching graph, the timeline surfaced `2 parents linked`, and the selected-node inspector showed the two parent links plus lineage ambiguities.
