### PR TITLE
feat: persist forensic case records

### DIFF
--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -73,6 +73,7 @@ def generate_report(
     )
     db.add(report)
     db.flush()
+    service.upsert_forensic_case(domain_session, result, report=report)
 
     return {"id": report.id, "report_type": report.report_type}
 

--- a/driftshield/src/driftshield/core/models.py
+++ b/driftshield/src/driftshield/core/models.py
@@ -203,3 +203,78 @@ class Session:
     def __post_init__(self):
         if self.metadata is None:
             self.metadata = {}
+
+
+class ForensicCaseState(str, Enum):
+    """User-visible lifecycle state for a persisted single-run forensic case."""
+
+    DRAFT = "draft"
+    REPORTED = "reported"
+    REVIEWED = "reviewed"
+    CLOSED = "closed"
+
+
+@dataclass
+class ForensicArtifactRef:
+    """Durable reference to a stored case artifact or evidence pointer."""
+
+    ref_id: str
+    kind: str
+    role: str
+    target_ref: str
+    summary: str | None = None
+    evidence_refs: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ref_id": self.ref_id,
+            "kind": self.kind,
+            "role": self.role,
+            "target_ref": self.target_ref,
+            "summary": self.summary,
+            "evidence_refs": list(self.evidence_refs),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ForensicArtifactRef | None":
+        if payload is None:
+            return None
+
+        ref_id = payload.get("ref_id")
+        kind = payload.get("kind")
+        role = payload.get("role")
+        target_ref = payload.get("target_ref")
+        if not all(isinstance(value, str) and value for value in (ref_id, kind, role, target_ref)):
+            return None
+
+        metadata = payload.get("metadata")
+        return cls(
+            ref_id=ref_id,
+            kind=kind,
+            role=role,
+            target_ref=target_ref,
+            summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
+            evidence_refs=[
+                str(ref)
+                for ref in payload.get("evidence_refs", [])
+                if isinstance(ref, str)
+            ],
+            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+        )
+
+
+@dataclass
+class ForensicCase:
+    """Durable single-run forensic case used by the Phase 2b OSS-safe workflow."""
+
+    id: UUID
+    session_id: UUID
+    state: ForensicCaseState
+    report_id: UUID | None = None
+    artifact_refs: list[ForensicArtifactRef] = field(default_factory=list)
+    review_refs: list[str] = field(default_factory=list)
+    audit_refs: list[str] = field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/driftshield/src/driftshield/db/migrations/versions/b7c1e3d5f6a2_add_forensic_cases_table.py
+++ b/driftshield/src/driftshield/db/migrations/versions/b7c1e3d5f6a2_add_forensic_cases_table.py
@@ -1,0 +1,47 @@
+"""add forensic cases table
+
+Revision ID: b7c1e3d5f6a2
+Revises: 9b3d7e1a4c2f
+Create Date: 2026-04-23 14:15:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c1e3d5f6a2"
+down_revision: str | None = "9b3d7e1a4c2f"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forensic_cases",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("state", sa.String(), nullable=False),
+        sa.Column("artifact_refs", sa.JSON(), nullable=False),
+        sa.Column("review_refs", sa.JSON(), nullable=False),
+        sa.Column("audit_refs", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["report_id"], ["reports.id"]),
+        sa.ForeignKeyConstraint(["session_id"], ["sessions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_forensic_cases_report_id", "forensic_cases", ["report_id"], unique=False)
+    op.create_index("ix_forensic_cases_session_id", "forensic_cases", ["session_id"], unique=True)
+    op.create_index("ix_forensic_cases_state", "forensic_cases", ["state"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_forensic_cases_state", table_name="forensic_cases")
+    op.drop_index("ix_forensic_cases_session_id", table_name="forensic_cases")
+    op.drop_index("ix_forensic_cases_report_id", table_name="forensic_cases")
+    op.drop_table("forensic_cases")

--- a/driftshield/src/driftshield/db/models.py
+++ b/driftshield/src/driftshield/db/models.py
@@ -167,6 +167,30 @@ class ReportModel(Base):
     generated_by: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
+class ForensicCaseModel(Base):
+    __tablename__ = "forensic_cases"
+    __table_args__ = (
+        Index("ix_forensic_cases_session_id", "session_id", unique=True),
+        Index("ix_forensic_cases_state", "state"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("sessions.id"), nullable=False
+    )
+    report_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("reports.id"), nullable=True, index=True
+    )
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_refs: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
+    review_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    audit_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
 class AnalystValidationModel(Base):
     __tablename__ = "analyst_validations"
 

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -7,16 +7,21 @@ from sqlalchemy.orm import Session as DBSession
 
 from driftshield.core.analysis.session import AnalysisResult
 from driftshield.core.graph.builder import build_graph
-from driftshield.core.graph.models import LineageGraph
+from driftshield.core.graph.models import DecisionNode, LineageGraph
 from driftshield.core.models import (
     CanonicalEvent,
     EventType,
+    ForensicArtifactRef,
+    ForensicCase,
+    ForensicCaseState,
     RiskClassification,
     Session as DomainSession,
     SessionStatus,
 )
 from driftshield.db.models import (
     DecisionNodeModel,
+    ForensicCaseModel,
+    ReportModel,
     SessionModel,
 )
 
@@ -116,6 +121,7 @@ class PersistenceService:
         self._db.add(session_model)
         self._db.flush()
         self._save_result(session, result)
+        self.upsert_forensic_case(session, result)
         return session_model
 
     def upsert(
@@ -135,6 +141,7 @@ class PersistenceService:
         )
         self._replace_session_result(session.id)
         self._save_result(session, result)
+        self.upsert_forensic_case(session, result)
         return session_model
 
     def _apply_session_fields(
@@ -189,6 +196,7 @@ class PersistenceService:
                     for edge in result.graph.incoming_edges(node.id)
                 ],
             }
+            metadata_json["normalized_event"] = _normalized_event_payload(node.event)
             node_model = DecisionNodeModel(
                 id=node.id,
                 session_id=session.id,
@@ -223,7 +231,10 @@ class PersistenceService:
             id=model.id,
             agent_id=model.agent_id or "",
             started_at=model.started_at,
+            external_id=model.external_id,
+            ended_at=model.ended_at,
             status=SessionStatus(model.status),
+            metadata=dict(model.metadata_json or {}),
         )
 
     def load_graph(self, session_id: uuid.UUID) -> LineageGraph | None:
@@ -245,6 +256,63 @@ class PersistenceService:
                 graph_node.is_inflection_node = node.is_inflection_node
 
         return graph
+
+    def load_case(self, case_id: uuid.UUID) -> ForensicCase | None:
+        model = self._db.get(ForensicCaseModel, case_id)
+        if model is None:
+            return None
+        return _case_model_to_domain(model)
+
+    def load_case_for_session(self, session_id: uuid.UUID) -> ForensicCase | None:
+        model = (
+            self._db.query(ForensicCaseModel)
+            .filter(ForensicCaseModel.session_id == session_id)
+            .one_or_none()
+        )
+        if model is None:
+            return None
+        return _case_model_to_domain(model)
+
+    def upsert_forensic_case(
+        self,
+        session: DomainSession,
+        result: AnalysisResult,
+        *,
+        report: ReportModel | None = None,
+    ) -> ForensicCase:
+        now = datetime.now(timezone.utc)
+        model = (
+            self._db.query(ForensicCaseModel)
+            .filter(ForensicCaseModel.session_id == session.id)
+            .one_or_none()
+        )
+        if model is None:
+            model = ForensicCaseModel(
+                id=uuid.uuid4(),
+                session_id=session.id,
+                report_id=None,
+                state=ForensicCaseState.DRAFT.value,
+                artifact_refs=[],
+                review_refs=[],
+                audit_refs=[],
+                created_at=now,
+                updated_at=now,
+            )
+            self._db.add(model)
+
+        model.report_id = report.id if report is not None else None
+        model.state = (
+            ForensicCaseState.REPORTED.value if report is not None else ForensicCaseState.DRAFT.value
+        )
+        model.artifact_refs = [
+            ref.to_dict()
+            for ref in _build_forensic_case_artifact_refs(session, result, report=report)
+        ]
+        model.review_refs = list(model.review_refs or [])
+        model.audit_refs = list(model.audit_refs or [])
+        model.updated_at = now
+        self._db.flush()
+        return _case_model_to_domain(model)
 
     def list_sessions(
         self,
@@ -353,6 +421,11 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
     if node.inflection_explanation is not None:
         metadata["inflection_explanation"] = node.inflection_explanation
     lineage = metadata.get("lineage") if isinstance(metadata.get("lineage"), dict) else {}
+    normalized_event = (
+        metadata.get("normalized_event")
+        if isinstance(metadata.get("normalized_event"), dict)
+        else {}
+    )
 
     parent_refs: list[uuid.UUID] = []
     raw_parent_ids = lineage.get("parent_ids")
@@ -368,11 +441,24 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
     if node.parent_node_id is not None and node.parent_node_id not in parent_refs:
         parent_refs.insert(0, node.parent_node_id)
 
+    ambiguities = [
+        str(item)
+        for item in lineage.get("lineage_ambiguities", [])
+        if isinstance(item, str)
+    ]
+    for item in normalized_event.get("ambiguities", []):
+        if isinstance(item, str) and item not in ambiguities:
+            ambiguities.append(item)
+
     return CanonicalEvent(
         id=node.id,
         session_id=str(session_id),
         timestamp=node.timestamp,
-        ordinal=node.sequence_num,
+        ordinal=(
+            normalized_event.get("ordinal")
+            if isinstance(normalized_event.get("ordinal"), int)
+            else node.sequence_num
+        ),
         event_type=EventType(node.event_type),
         agent_id="",
         action=node.action,
@@ -380,13 +466,33 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
         inputs=node.inputs,
         outputs=node.outputs,
         metadata=metadata,
-        summary=lineage.get("summary") if isinstance(lineage.get("summary"), str) else None,
+        actor=(
+            dict(normalized_event.get("actor"))
+            if isinstance(normalized_event.get("actor"), dict)
+            else None
+        ),
+        summary=(
+            lineage.get("summary")
+            if isinstance(lineage.get("summary"), str)
+            else normalized_event.get("summary")
+            if isinstance(normalized_event.get("summary"), str)
+            else None
+        ),
         parent_event_refs=parent_refs,
-        ambiguities=[
-            str(item)
-            for item in lineage.get("lineage_ambiguities", [])
-            if isinstance(item, str)
-        ],
+        source_refs=_normalized_event_refs(normalized_event.get("source_refs")),
+        artifact_refs=_normalized_event_refs(normalized_event.get("artifact_refs")),
+        constraints=_normalized_event_refs(normalized_event.get("constraints")),
+        tool_activity=(
+            dict(normalized_event.get("tool_activity"))
+            if isinstance(normalized_event.get("tool_activity"), dict)
+            else None
+        ),
+        failure_context=(
+            dict(normalized_event.get("failure_context"))
+            if isinstance(normalized_event.get("failure_context"), dict)
+            else None
+        ),
+        ambiguities=ambiguities,
         risk_classification=RiskClassification(
             assumption_mutation=node.assumption_mutation,
             policy_divergence=node.policy_divergence,
@@ -395,4 +501,215 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
             coverage_gap=node.coverage_gap,
             explanations=RiskClassification.explanations_from_dict(node.risk_explanations),
         ),
+    )
+
+
+def _normalized_event_payload(event: CanonicalEvent) -> dict[str, object]:
+    return {
+        "ordinal": event.ordinal,
+        "actor": dict(event.actor or {}),
+        "summary": event.summary,
+        "source_refs": [dict(ref) for ref in event.source_refs],
+        "artifact_refs": [dict(ref) for ref in event.artifact_refs],
+        "constraints": [dict(ref) for ref in event.constraints],
+        "tool_activity": dict(event.tool_activity or {}) if event.tool_activity else None,
+        "failure_context": dict(event.failure_context or {}) if event.failure_context else None,
+        "ambiguities": list(event.ambiguities),
+    }
+
+
+def _normalized_event_refs(payload: object) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    if not isinstance(payload, list):
+        return refs
+
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        refs.append(
+            {
+                str(key): str(value)
+                for key, value in item.items()
+                if isinstance(key, str) and isinstance(value, str)
+            }
+        )
+    return refs
+
+
+def _build_forensic_case_artifact_refs(
+    session: DomainSession,
+    result: AnalysisResult,
+    *,
+    report: ReportModel | None = None,
+) -> list[ForensicArtifactRef]:
+    refs = [
+        ForensicArtifactRef(
+            ref_id=f"session:{session.id}",
+            kind="analysis_session",
+            role="session",
+            target_ref=str(session.id),
+            summary=f"{session.status.value} run for {session.agent_id}",
+            metadata={
+                "agent_id": session.agent_id,
+                "status": session.status.value,
+                "started_at": session.started_at.isoformat(),
+                "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+            },
+        ),
+        ForensicArtifactRef(
+            ref_id=f"lineage:{session.id}",
+            kind="lineage_graph",
+            role="lineage",
+            target_ref=str(session.id),
+            summary=f"{len(result.graph.nodes)} nodes and {len(result.graph.edges)} edges",
+            metadata={
+                "node_count": len(result.graph.nodes),
+                "edge_count": len(result.graph.edges),
+                "flagged_events": result.flagged_events,
+                "inflection_node_id": (
+                    str(result.inflection_node.id) if result.inflection_node is not None else None
+                ),
+            },
+        ),
+    ]
+
+    included_node_refs = 0
+    for node in result.graph.nodes:
+        if _include_forensic_case_node(node):
+            included_node_refs += 1
+            refs.append(
+                ForensicArtifactRef(
+                    ref_id=f"decision_node:{node.id}",
+                    kind="decision_node",
+                    role="evidence_node",
+                    target_ref=str(node.id),
+                    summary=node.summary,
+                    evidence_refs=list(node.evidence_refs),
+                    metadata={
+                        "sequence_num": node.sequence_num,
+                        "event_type": node.event_type.value,
+                        "action": node.action,
+                        "confidence": node.confidence,
+                        "parent_node_ids": [str(parent_id) for parent_id in node.parent_ids],
+                        "lineage_ambiguities": list(node.lineage_ambiguities),
+                        "risk_flags": _active_risk_flags(node.event.risk_classification),
+                        "is_inflection": node.is_inflection_node,
+                        "failure_context": (
+                            dict(node.event.failure_context)
+                            if node.event.failure_context
+                            else None
+                        ),
+                        "source_refs": [dict(ref) for ref in node.event.source_refs],
+                    },
+                )
+            )
+
+        for index, artifact in enumerate(node.event.artifact_refs):
+            refs.append(
+                ForensicArtifactRef(
+                    ref_id=f"decision_node:{node.id}:artifact:{index}",
+                    kind="artifact",
+                    role="event_artifact",
+                    target_ref=str(node.id),
+                    summary=_artifact_summary(artifact),
+                    evidence_refs=[f"artifact_refs[{index}]"],
+                    metadata=dict(artifact),
+                )
+            )
+
+    if included_node_refs == 0 and result.graph.nodes:
+        first_node = result.graph.nodes[0]
+        refs.append(
+            ForensicArtifactRef(
+                ref_id=f"decision_node:{first_node.id}",
+                kind="decision_node",
+                role="lineage_node",
+                target_ref=str(first_node.id),
+                summary=first_node.summary,
+                evidence_refs=list(first_node.evidence_refs),
+                metadata={
+                    "sequence_num": first_node.sequence_num,
+                    "event_type": first_node.event_type.value,
+                    "action": first_node.action,
+                    "confidence": first_node.confidence,
+                    "parent_node_ids": [str(parent_id) for parent_id in first_node.parent_ids],
+                    "lineage_ambiguities": list(first_node.lineage_ambiguities),
+                    "risk_flags": _active_risk_flags(first_node.event.risk_classification),
+                    "is_inflection": first_node.is_inflection_node,
+                    "failure_context": (
+                        dict(first_node.event.failure_context)
+                        if first_node.event.failure_context
+                        else None
+                    ),
+                    "source_refs": [dict(ref) for ref in first_node.event.source_refs],
+                },
+            )
+        )
+
+    if report is not None:
+        refs.append(
+            ForensicArtifactRef(
+                ref_id=f"report:{report.id}",
+                kind="report",
+                role="report_artifact",
+                target_ref=str(report.id),
+                summary=f"{report.report_type} report",
+                metadata={
+                    "report_type": report.report_type,
+                    "generated_at": report.generated_at.isoformat(),
+                    "generated_by": report.generated_by,
+                },
+            )
+        )
+
+    return refs
+
+
+def _include_forensic_case_node(node: DecisionNode) -> bool:
+    return bool(
+        node.evidence_refs
+        or node.lineage_ambiguities
+        or node.is_inflection_node
+        or node.has_risk_flags()
+        or node.event.failure_context
+        or node.event.artifact_refs
+    )
+
+
+def _active_risk_flags(risk: RiskClassification | None) -> list[str]:
+    if risk is None:
+        return []
+    return risk.active_flags()
+
+
+def _artifact_summary(artifact: dict[str, str]) -> str | None:
+    kind = artifact.get("kind")
+    value = artifact.get("value")
+    if kind and value:
+        return f"{kind}: {value}"
+    if value:
+        return value
+    if kind:
+        return kind
+    return None
+
+
+def _case_model_to_domain(model: ForensicCaseModel) -> ForensicCase:
+    return ForensicCase(
+        id=model.id,
+        session_id=model.session_id,
+        state=ForensicCaseState(model.state),
+        report_id=model.report_id,
+        artifact_refs=[
+            artifact
+            for artifact in (
+                ForensicArtifactRef.from_dict(payload)
+                for payload in (model.artifact_refs or [])
+            )
+            if artifact is not None
+        ],
+        review_refs=[str(ref) for ref in (model.review_refs or []) if isinstance(ref, str)],
+        audit_refs=[str(ref) for ref in (model.audit_refs or []) if isinstance(ref, str)],
+        created_at=model.created_at,
+        updated_at=model.updated_at,
     )

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -300,13 +300,23 @@ class PersistenceService:
             )
             self._db.add(model)
 
-        model.report_id = report.id if report is not None else None
-        model.state = (
-            ForensicCaseState.REPORTED.value if report is not None else ForensicCaseState.DRAFT.value
-        )
+        effective_report = report
+        next_state = ForensicCaseState.DRAFT.value
+        if effective_report is not None:
+            next_state = ForensicCaseState.REPORTED.value
+        elif model.report_id is not None:
+            effective_report = self._db.get(ReportModel, model.report_id)
+            next_state = model.state
+
+        model.report_id = effective_report.id if effective_report is not None else None
+        model.state = next_state
         model.artifact_refs = [
             ref.to_dict()
-            for ref in _build_forensic_case_artifact_refs(session, result, report=report)
+            for ref in _build_forensic_case_artifact_refs(
+                session,
+                result,
+                report=effective_report,
+            )
         ]
         model.review_refs = list(model.review_refs or [])
         model.audit_refs = list(model.audit_refs or [])

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -303,7 +303,13 @@ class PersistenceService:
         effective_report = report
         next_state = ForensicCaseState.DRAFT.value
         if effective_report is not None:
-            next_state = ForensicCaseState.REPORTED.value
+            if model.state in {
+                ForensicCaseState.REVIEWED.value,
+                ForensicCaseState.CLOSED.value,
+            }:
+                next_state = model.state
+            else:
+                next_state = ForensicCaseState.REPORTED.value
         elif model.report_id is not None:
             effective_report = self._db.get(ReportModel, model.report_id)
             next_state = model.state

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -8,7 +8,16 @@ from sqlalchemy.orm import Session as DBSession
 from sqlalchemy.pool import StaticPool
 
 from driftshield.api.app import create_app
+from driftshield.core.analysis.session import analyze_session
+from driftshield.core.models import (
+    CanonicalEvent,
+    EventType,
+    ForensicCaseState,
+    Session as DomainSession,
+    SessionStatus,
+)
 from driftshield.db.models import Base, SessionModel, DecisionNodeModel, ReportModel
+from driftshield.db.persistence import PersistenceService
 
 
 @pytest.fixture
@@ -123,6 +132,51 @@ def test_generated_report_has_real_content(client, auth_headers, seeded_session,
     assert data["content_json"]["sections"] is not None
     assert len(data["content_json"]["sections"]) == 4
     assert "recurrence_probability" not in data["content_json"]
+
+
+def test_generate_report_updates_forensic_case_without_losing_saved_evidence_artifacts(
+    client,
+    auth_headers,
+    db_session,
+):
+    session_id = uuid.uuid4()
+    event = CanonicalEvent(
+        id=uuid.uuid4(),
+        session_id=str(session_id),
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="test-agent",
+        action="read_file",
+        inputs={"path": "/tmp/evidence.txt"},
+        outputs={"content": "evidence"},
+    )
+    domain_session = DomainSession(
+        id=session_id,
+        agent_id="test-agent",
+        started_at=datetime.now(timezone.utc),
+        status=SessionStatus.COMPLETED,
+    )
+    service = PersistenceService(db_session)
+    service.save(domain_session, analyze_session([event]))
+    db_session.commit()
+
+    response = client.post(
+        f"/api/sessions/{session_id}/report",
+        headers=auth_headers,
+        json={"report_type": "full"},
+    )
+
+    assert response.status_code == 201
+
+    case = service.load_case_for_session(session_id)
+    assert case is not None
+    assert case.state is ForensicCaseState.REPORTED
+    assert case.report_id == uuid.UUID(response.json()["id"])
+    assert any(
+        ref.role == "event_artifact"
+        and ref.metadata == {"kind": "path", "value": "/tmp/evidence.txt", "source": "inputs"}
+        for ref in case.artifact_refs
+    )
 
 
 def test_graveyard_summary_route_is_removed(client, auth_headers):

--- a/driftshield/tests/db/test_models.py
+++ b/driftshield/tests/db/test_models.py
@@ -9,6 +9,7 @@ from driftshield.db.models import (
     AnalystValidationModel,
     Base,
     DecisionNodeModel,
+    ForensicCaseModel,
     ReportModel,
     SessionModel,
 )
@@ -198,6 +199,69 @@ def test_create_report(db_session):
     assert loaded.report_type == "full"
     assert "Sample report content" in loaded.content_markdown
     assert loaded.content_json == {"sections": []}
+
+
+def test_create_forensic_case(db_session):
+    session_id = uuid.uuid4()
+    report_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            started_at=now,
+            status="completed",
+        )
+    )
+    db_session.add(
+        ReportModel(
+            id=report_id,
+            session_id=session_id,
+            generated_at=now,
+            report_type="summary",
+            content_markdown="# Report",
+            content_json={"sections": []},
+            generated_by="system",
+        )
+    )
+    db_session.flush()
+
+    case_id = uuid.uuid4()
+    db_session.add(
+        ForensicCaseModel(
+            id=case_id,
+            session_id=session_id,
+            report_id=report_id,
+            state="reported",
+            artifact_refs=[
+                {
+                    "ref_id": f"session:{session_id}",
+                    "kind": "analysis_session",
+                    "role": "session",
+                    "target_ref": str(session_id),
+                }
+            ],
+            review_refs=[],
+            audit_refs=[],
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db_session.commit()
+
+    loaded = db_session.get(ForensicCaseModel, case_id)
+    assert loaded is not None
+    assert loaded.session_id == session_id
+    assert loaded.report_id == report_id
+    assert loaded.state == "reported"
+    assert loaded.artifact_refs == [
+        {
+            "ref_id": f"session:{session_id}",
+            "kind": "analysis_session",
+            "role": "session",
+            "target_ref": str(session_id),
+        }
+    ]
 
 
 def test_create_analyst_validation(db_session):

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -11,6 +11,7 @@ from driftshield.core.models import (
     CanonicalEvent,
     EventType,
     ExplanationPayload,
+    ForensicCaseState,
     RiskClassification,
     Session as DomainSession,
     SessionStatus,
@@ -18,6 +19,7 @@ from driftshield.core.models import (
 from driftshield.db.models import (
     Base,
     DecisionNodeModel,
+    ReportModel,
     SessionModel,
 )
 from driftshield.db.persistence import IngestProvenance, PersistenceService
@@ -145,6 +147,73 @@ def test_load_graph(db_session, sample_analysis_result):
     graph = service.load_graph(domain_session.id)
     assert graph is not None
     assert len(graph.nodes) == 2
+
+
+def test_save_creates_draft_forensic_case_with_evidence_artifacts(
+    db_session,
+    sample_analysis_result,
+):
+    result, domain_session = sample_analysis_result
+    service = PersistenceService(db_session)
+    service.save(domain_session, result)
+    db_session.commit()
+
+    case = service.load_case_for_session(domain_session.id)
+
+    assert case is not None
+    assert case.state is ForensicCaseState.DRAFT
+    assert case.report_id is None
+    assert any(
+        ref.kind == "analysis_session" and ref.target_ref == str(domain_session.id)
+        for ref in case.artifact_refs
+    )
+    assert any(
+        ref.kind == "lineage_graph"
+        and ref.metadata["node_count"] == len(result.graph.nodes)
+        for ref in case.artifact_refs
+    )
+    assert any(
+        ref.role == "event_artifact"
+        and ref.target_ref == str(result.graph.nodes[0].id)
+        and ref.metadata == {"kind": "path", "value": "/test", "source": "inputs"}
+        for ref in case.artifact_refs
+    )
+
+
+def test_upsert_forensic_case_links_report_and_round_trips_by_case_id(
+    db_session,
+    sample_analysis_result,
+):
+    result, domain_session = sample_analysis_result
+    service = PersistenceService(db_session)
+    service.save(domain_session, result)
+    db_session.flush()
+
+    report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=domain_session.id,
+        generated_at=datetime.now(timezone.utc),
+        report_type="full",
+        content_markdown="# Report",
+        content_json={"sections": []},
+        generated_by="system",
+    )
+    db_session.add(report)
+    db_session.flush()
+
+    saved_case = service.upsert_forensic_case(domain_session, result, report=report)
+    db_session.commit()
+
+    loaded_case = service.load_case(saved_case.id)
+
+    assert loaded_case is not None
+    assert loaded_case.id == saved_case.id
+    assert loaded_case.state is ForensicCaseState.REPORTED
+    assert loaded_case.report_id == report.id
+    assert any(
+        ref.role == "report_artifact" and ref.target_ref == str(report.id)
+        for ref in loaded_case.artifact_refs
+    )
 
 
 def test_load_graph_round_trips_branching_lineage_metadata(db_session):
@@ -421,3 +490,17 @@ def test_save_and_load_graph_round_trip_explanations(db_session):
             "inflection_reason:point-of-no-return position near the observed failure",
         ],
     }
+
+
+def test_load_graph_preserves_normalized_event_artifact_refs(db_session, sample_analysis_result):
+    result, domain_session = sample_analysis_result
+    service = PersistenceService(db_session)
+    service.save(domain_session, result)
+    db_session.commit()
+
+    graph = service.load_graph(domain_session.id)
+
+    assert graph is not None
+    assert graph.nodes[0].event.artifact_refs == [
+        {"kind": "path", "value": "/test", "source": "inputs"}
+    ]

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -19,6 +19,7 @@ from driftshield.core.models import (
 from driftshield.db.models import (
     Base,
     DecisionNodeModel,
+    ForensicCaseModel,
     ReportModel,
     SessionModel,
 )
@@ -249,6 +250,68 @@ def test_upsert_preserves_existing_reported_case_when_no_new_report_is_supplied(
     assert loaded_case.report_id == report.id
     assert any(
         ref.role == "report_artifact" and ref.target_ref == str(report.id)
+        for ref in loaded_case.artifact_refs
+    )
+
+
+@pytest.mark.parametrize(
+    "terminal_state",
+    [ForensicCaseState.REVIEWED, ForensicCaseState.CLOSED],
+)
+def test_upsert_preserves_terminal_case_state_when_report_is_regenerated(
+    db_session,
+    sample_analysis_result,
+    terminal_state,
+):
+    result, domain_session = sample_analysis_result
+    service = PersistenceService(db_session)
+    service.save(domain_session, result)
+    db_session.flush()
+
+    first_report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=domain_session.id,
+        generated_at=datetime.now(timezone.utc),
+        report_type="full",
+        content_markdown="# Report",
+        content_json={"sections": []},
+        generated_by="system",
+    )
+    db_session.add(first_report)
+    db_session.flush()
+    service.upsert_forensic_case(domain_session, result, report=first_report)
+    db_session.flush()
+
+    stored_case = (
+        db_session.query(ForensicCaseModel)
+        .filter(ForensicCaseModel.session_id == domain_session.id)
+        .one()
+    )
+    stored_case.state = terminal_state.value
+    db_session.flush()
+
+    regenerated_report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=domain_session.id,
+        generated_at=datetime.now(timezone.utc),
+        report_type="summary",
+        content_markdown="# Regenerated Report",
+        content_json={"sections": []},
+        generated_by="system",
+    )
+    db_session.add(regenerated_report)
+    db_session.flush()
+
+    service.upsert_forensic_case(domain_session, result, report=regenerated_report)
+    db_session.commit()
+
+    loaded_case = service.load_case_for_session(domain_session.id)
+
+    assert loaded_case is not None
+    assert loaded_case.state is terminal_state
+    assert loaded_case.report_id == regenerated_report.id
+    assert any(
+        ref.role == "report_artifact" and ref.target_ref == str(regenerated_report.id)
         for ref in loaded_case.artifact_refs
     )
 

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -263,6 +263,7 @@ def test_upsert_preserves_terminal_case_state_when_report_is_regenerated(
     sample_analysis_result,
     terminal_state,
 ):
+    # Regenerating a report should refresh linkage without reopening finished cases.
     result, domain_session = sample_analysis_result
     service = PersistenceService(db_session)
     service.save(domain_session, result)

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -216,6 +216,43 @@ def test_upsert_forensic_case_links_report_and_round_trips_by_case_id(
     )
 
 
+def test_upsert_preserves_existing_reported_case_when_no_new_report_is_supplied(
+    db_session,
+    sample_analysis_result,
+):
+    result, domain_session = sample_analysis_result
+    service = PersistenceService(db_session)
+    service.save(domain_session, result)
+    db_session.flush()
+
+    report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=domain_session.id,
+        generated_at=datetime.now(timezone.utc),
+        report_type="full",
+        content_markdown="# Report",
+        content_json={"sections": []},
+        generated_by="system",
+    )
+    db_session.add(report)
+    db_session.flush()
+    service.upsert_forensic_case(domain_session, result, report=report)
+    db_session.flush()
+
+    service.upsert(domain_session, result)
+    db_session.commit()
+
+    loaded_case = service.load_case_for_session(domain_session.id)
+
+    assert loaded_case is not None
+    assert loaded_case.state is ForensicCaseState.REPORTED
+    assert loaded_case.report_id == report.id
+    assert any(
+        ref.role == "report_artifact" and ref.target_ref == str(report.id)
+        for ref in loaded_case.artifact_refs
+    )
+
+
 def test_load_graph_round_trips_branching_lineage_metadata(db_session):
     session_id = uuid.uuid4()
     events = branching_lineage_events(str(session_id))

--- a/driftshield/tests/db/test_persistence_integration.py
+++ b/driftshield/tests/db/test_persistence_integration.py
@@ -12,10 +12,16 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from driftshield.core.models import (
-    CanonicalEvent, EventType, ExplanationPayload, RiskClassification, Session as DomainSession, SessionStatus,
+    CanonicalEvent,
+    EventType,
+    ExplanationPayload,
+    ForensicCaseState,
+    RiskClassification,
+    Session as DomainSession,
+    SessionStatus,
 )
 from driftshield.core.analysis.session import analyze_session
-from driftshield.db.models import Base
+from driftshield.db.models import Base, ReportModel
 from driftshield.db.persistence import PersistenceService
 
 POSTGRES_URL = os.environ.get(
@@ -116,4 +122,56 @@ def test_roundtrip_save_and_load_explanations(pg_session):
         reason="Output referenced fewer items than were provided in the input.",
         confidence=0.86,
         evidence_refs=["inputs.sections", "outputs.reviewed_sections"],
+    )
+
+
+def test_roundtrip_save_and_load_forensic_case(pg_session):
+    session_id = uuid.uuid4()
+    event = CanonicalEvent(
+        id=uuid.uuid4(),
+        session_id=str(session_id),
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="integration-test",
+        action="read_file",
+        inputs={"path": "/tmp/integration-evidence.txt"},
+        outputs={"content": "captured"},
+    )
+    domain_session = DomainSession(
+        id=session_id,
+        agent_id="integration-test",
+        started_at=datetime.now(timezone.utc),
+        status=SessionStatus.COMPLETED,
+    )
+    result = analyze_session([event])
+    service = PersistenceService(pg_session)
+    service.save(domain_session, result)
+
+    report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=session_id,
+        generated_at=datetime.now(timezone.utc),
+        report_type="full",
+        content_markdown="# Report",
+        content_json={"sections": []},
+        generated_by="integration-test",
+    )
+    pg_session.add(report)
+    pg_session.flush()
+    service.upsert_forensic_case(domain_session, result, report=report)
+    pg_session.commit()
+
+    case = service.load_case_for_session(session_id)
+
+    assert case is not None
+    assert case.state is ForensicCaseState.REPORTED
+    assert case.report_id == report.id
+    assert any(
+        ref.role == "event_artifact"
+        and ref.metadata == {
+            "kind": "path",
+            "value": "/tmp/integration-evidence.txt",
+            "source": "inputs",
+        }
+        for ref in case.artifact_refs
     )


### PR DESCRIPTION
## Summary
- add durable Phase 2b forensic case models and artifact references for one analyzed run
- persist normalized event evidence artifacts so saved cases keep traceability across reloads and report generation
- advance cases from `draft` to `reported` when a local forensic report is stored

## Verification
- `uv run --extra dev pytest tests/db/test_models.py tests/db/test_persistence.py tests/api/test_reports.py -q`
- `uv run --extra dev pytest tests/core/test_models.py tests/db tests/api/test_reports.py tests/api/test_sessions.py tests/api/test_graph.py -q`
- `uv run --extra dev pytest tests -q`
- `uv run --extra dev ruff check src/driftshield/core/models.py src/driftshield/db/models.py src/driftshield/db/persistence.py src/driftshield/api/routes/reports.py tests/db/test_models.py tests/db/test_persistence.py tests/api/test_reports.py tests/db/test_persistence_integration.py`

## Notes
- repo-wide `uv run --extra dev ruff check src tests` still reports pre-existing unrelated violations outside this change

Refs tborys/driftshield-meta#66