### PR TITLE
Add OSS-safe candidate break point detection

### DIFF
--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -50,18 +50,10 @@ def generate_report(
     result = AnalysisResult(
         events=events,
         graph=graph,
-        inflection_node=(
-            selection.node
-            if selection is not None and selection.candidate_break_point.is_identified
-            else None
-        ),
+        inflection_node=selection.node if selection is not None else None,
         total_events=len(events),
         flagged_events=flagged,
-        inflection_explanation=(
-            selection.explanation
-            if selection is not None and selection.candidate_break_point.is_identified
-            else None
-        ),
+        inflection_explanation=selection.explanation if selection is not None else None,
         candidate_break_point=selection.candidate_break_point if selection is not None else None,
     )
 

--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session as DBSession
 
 from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
-from driftshield.core.analysis.inflection import find_inflection_node
+from driftshield.core.analysis.inflection import select_inflection_node
 from driftshield.core.analysis.session import AnalysisResult
 from driftshield.db.models import SessionModel, ReportModel
 from driftshield.db.persistence import PersistenceService
@@ -41,7 +41,7 @@ def generate_report(
         raise HTTPException(status_code=404, detail="No graph data for session")
 
     # Reconstruct AnalysisResult from stored data
-    inflection = find_inflection_node(graph, graph.nodes[-1].id) if graph.nodes else None
+    selection = select_inflection_node(graph, graph.nodes[-1].id) if graph.nodes else None
     events = [node.event for node in graph.nodes]
     flagged = sum(
         1 for e in events if e.risk_classification and e.risk_classification.has_any_flag()
@@ -50,9 +50,19 @@ def generate_report(
     result = AnalysisResult(
         events=events,
         graph=graph,
-        inflection_node=inflection,
+        inflection_node=(
+            selection.node
+            if selection is not None and selection.candidate_break_point.is_identified
+            else None
+        ),
         total_events=len(events),
         flagged_events=flagged,
+        inflection_explanation=(
+            selection.explanation
+            if selection is not None and selection.candidate_break_point.is_identified
+            else None
+        ),
+        candidate_break_point=selection.candidate_break_point if selection is not None else None,
     )
 
     report_type = ReportType(request.report_type)

--- a/driftshield/src/driftshield/cli/commands/analyze.py
+++ b/driftshield/src/driftshield/cli/commands/analyze.py
@@ -144,13 +144,13 @@ def analyze(
     if json_output:
         import json
         if len(all_results) == 1:
-            console.print(format_json(all_results[0][1]))
+            typer.echo(format_json(all_results[0][1]))
         else:
             data = []
             for file_path, result in all_results:
                 import json as json_lib
                 data.append(json_lib.loads(format_json(result)))
-            console.print(json.dumps(data, indent=2))
+            typer.echo(json.dumps(data, indent=2))
     elif quiet:
         for file_path, result in all_results:
             if len(all_results) > 1:

--- a/driftshield/src/driftshield/cli/output.py
+++ b/driftshield/src/driftshield/cli/output.py
@@ -26,16 +26,24 @@ def format_summary(result: AnalysisResult) -> str:
             if count > 0:
                 lines.append(f"  - {risk_type}: {count}")
 
-    if result.inflection_node:
-        node = result.inflection_node
+    if result.candidate_break_point:
         lines.append("")
-        lines.append("Inflection Point:")
-        lines.append(f"  Event #{node.sequence_num} : {node.action}")
-        lines.append(f"  Type      : {node.event_type.value}")
-
-        if node.event.risk_classification:
-            flags = ", ".join(node.event.risk_classification.active_flags())
-            lines.append(f"  Risk      : {flags}")
+        lines.append("Candidate Break Point:")
+        lines.append(f"  Status    : {result.candidate_break_point.status.value}")
+        lines.append(f"  Summary   : {result.candidate_break_point.summary}")
+        if result.candidate_break_point.is_identified and result.inflection_node:
+            node = result.inflection_node
+            lines.append(f"  Event     : #{node.sequence_num} {node.action}")
+            lines.append(f"  Type      : {node.event_type.value}")
+            if result.candidate_break_point.confidence is not None:
+                lines.append(f"  Confidence: {result.candidate_break_point.confidence:.2f}")
+            if node.event.risk_classification:
+                flags = ", ".join(node.event.risk_classification.active_flags())
+                lines.append(f"  Risk      : {flags}")
+        elif result.candidate_break_point.uncertainty_reasons:
+            lines.append(
+                "  Uncertain : " + "; ".join(result.candidate_break_point.uncertainty_reasons)
+            )
 
     return "\n".join(lines)
 
@@ -47,6 +55,11 @@ def format_json(result: AnalysisResult) -> str:
         "total_events": result.total_events,
         "flagged_events": result.flagged_events,
         "risks": result.risk_summary,
+        "candidate_break_point": (
+            result.candidate_break_point.to_dict()
+            if result.candidate_break_point is not None
+            else None
+        ),
     }
 
     if result.inflection_node:

--- a/driftshield/src/driftshield/core/analysis/inflection.py
+++ b/driftshield/src/driftshield/core/analysis/inflection.py
@@ -252,6 +252,9 @@ def select_inflection_node(
     best_score, _, best_node, best_reasons = scored[0]
     runner_up_score = scored[1][0] if len(scored) > 1 else None
     runner_up_node = scored[1][2] if len(scored) > 1 else None
+    selected_score = best_score
+    alternate_score = runner_up_score
+    alternate_node = runner_up_node
 
     fallback_node = _fallback_walkback_node(path)
     fallback_idx = next((idx for idx, node in flagged_candidates if node.id == fallback_node.id), None) if fallback_node else None
@@ -283,12 +286,15 @@ def select_inflection_node(
         best_node = fallback_node
         best_reasons = ["fallback to closest flagged node on the failure path"]
         strategy = "walkback_fallback"
+        selected_score = fallback_score
+        alternate_score = best_score
+        alternate_node = scored[0][2]
     else:
         strategy = "weighted"
 
     confidence = _selection_confidence(
-        selected_score=fallback_score if strategy == "walkback_fallback" and fallback_score is not None else best_score,
-        alternate_score=best_score if strategy == "walkback_fallback" else runner_up_score,
+        selected_score=selected_score,
+        alternate_score=alternate_score,
         strategy=strategy,
     )
 
@@ -313,9 +319,9 @@ def select_inflection_node(
         node=best_node,
         explanation=explanation,
         strategy=strategy,
-        score=fallback_score if strategy == "walkback_fallback" else best_score,
-        runner_up_score=best_score if strategy == "walkback_fallback" else runner_up_score,
-        runner_up_node=runner_up_node,
+        score=selected_score,
+        runner_up_score=alternate_score,
+        runner_up_node=alternate_node,
     )
 
     return InflectionSelection(
@@ -323,9 +329,9 @@ def select_inflection_node(
         explanation=explanation,
         strategy=strategy,
         candidate_break_point=candidate_break_point,
-        score=fallback_score if strategy == "walkback_fallback" else best_score,
-        runner_up_score=best_score if strategy == "walkback_fallback" else runner_up_score,
-        runner_up_node=runner_up_node,
+        score=selected_score,
+        runner_up_score=alternate_score,
+        runner_up_node=alternate_node,
     )
 
 

--- a/driftshield/src/driftshield/core/analysis/inflection.py
+++ b/driftshield/src/driftshield/core/analysis/inflection.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from driftshield.core.graph.models import DecisionNode, LineageGraph
-from driftshield.core.models import ExplanationPayload
+from driftshield.core.models import BreakPointStatus, CandidateBreakPoint, ExplanationPayload
 
 
 @dataclass(frozen=True)
@@ -14,6 +14,10 @@ class InflectionSelection:
     node: DecisionNode | None
     explanation: ExplanationPayload | None
     strategy: str
+    candidate_break_point: CandidateBreakPoint
+    score: float | None = None
+    runner_up_score: float | None = None
+    runner_up_node: DecisionNode | None = None
 
 
 _FLAG_WEIGHTS = {
@@ -90,6 +94,113 @@ def _selection_confidence(
     return round(selected / (selected + alternate), 2)
 
 
+def _dedupe_refs(*groups: list[str]) -> list[str]:
+    seen: set[str] = set()
+    refs: list[str] = []
+    for group in groups:
+        for ref in group:
+            if ref and ref not in seen:
+                seen.add(ref)
+                refs.append(ref)
+    return refs
+
+
+def _risk_evidence_refs(node: DecisionNode) -> list[str]:
+    risk = node.event.risk_classification
+    if risk is None:
+        return []
+
+    refs: list[str] = []
+    for flag in risk.active_flags():
+        explanation = risk.explanation_for(flag)
+        if explanation is not None:
+            refs.extend(explanation.evidence_refs)
+    return refs
+
+
+def _candidate_break_point_from_selection(
+    *,
+    node: DecisionNode | None,
+    explanation: ExplanationPayload | None,
+    strategy: str,
+    score: float | None,
+    runner_up_score: float | None,
+    runner_up_node: DecisionNode | None,
+) -> CandidateBreakPoint:
+    if node is None or explanation is None:
+        return CandidateBreakPoint(
+            status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+            summary=(
+                "No clear break point detected from observable run evidence because no flagged "
+                "divergence step was found on the visible failure path."
+            ),
+            strategy=strategy,
+            uncertainty_reasons=["no flagged divergence evidence was found on the observed path"],
+        )
+
+    risk = node.event.risk_classification
+    risk_flags = risk.active_flags() if risk is not None else []
+    uncertainty_reasons: list[str] = []
+    if strategy == "walkback_fallback":
+        uncertainty_reasons.append(
+            "fallback selection was needed because the strongest visible candidates were too close"
+        )
+    if (
+        score is not None
+        and runner_up_score is not None
+        and (score - runner_up_score) < 1.0
+    ):
+        uncertainty_reasons.append("competing flagged steps were similarly plausible")
+    if node.lineage_ambiguities:
+        uncertainty_reasons.append("selected step has lineage ambiguities")
+
+    evidence_refs = _dedupe_refs(
+        [f"node:{node.id}"],
+        explanation.evidence_refs,
+        list(node.evidence_refs),
+        _risk_evidence_refs(node),
+        [f"node:{runner_up_node.id}"] if runner_up_node is not None else [],
+    )
+
+    is_identified = (
+        explanation.confidence is not None
+        and explanation.confidence >= 0.6
+        and strategy != "walkback_fallback"
+    )
+
+    if is_identified:
+        return CandidateBreakPoint(
+            status=BreakPointStatus.IDENTIFIED,
+            summary=(
+                f"Observable evidence suggests the run visibly broke at event "
+                f"#{node.sequence_num} ({node.action})."
+            ),
+            node_id=node.id,
+            sequence_num=node.sequence_num,
+            action=node.action,
+            confidence=explanation.confidence,
+            evidence_refs=evidence_refs,
+            risk_flags=risk_flags,
+            uncertainty_reasons=uncertainty_reasons,
+            strategy=strategy,
+        )
+
+    if not uncertainty_reasons:
+        uncertainty_reasons.append("observable evidence was too weak to isolate one break point")
+
+    return CandidateBreakPoint(
+        status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+        summary=(
+            "No clear break point detected from observable run evidence because the visible "
+            "flagged steps were too weak or too close to distinguish confidently."
+        ),
+        confidence=explanation.confidence,
+        evidence_refs=evidence_refs,
+        uncertainty_reasons=uncertainty_reasons,
+        strategy=strategy,
+    )
+
+
 def select_inflection_node(
     graph: LineageGraph,
     failure_node_id: UUID,
@@ -97,7 +208,19 @@ def select_inflection_node(
     """Select the most meaningful inflection node using weighted scoring with walkback fallback."""
     path = graph.path_to_root(failure_node_id)
     if not path:
-        return InflectionSelection(node=None, explanation=None, strategy="none")
+        return InflectionSelection(
+            node=None,
+            explanation=None,
+            strategy="none",
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+                summary=(
+                    "No clear break point detected because no observable failure path was available."
+                ),
+                strategy="none",
+                uncertainty_reasons=["no observable failure path was available"],
+            ),
+        )
 
     flagged_candidates = [
         (idx, node)
@@ -105,7 +228,20 @@ def select_inflection_node(
         if node.has_risk_flags()
     ]
     if not flagged_candidates:
-        return InflectionSelection(node=None, explanation=None, strategy="none")
+        return InflectionSelection(
+            node=None,
+            explanation=None,
+            strategy="none",
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+                summary=(
+                    "No clear break point detected from observable run evidence because no "
+                    "flagged divergence step was found on the visible failure path."
+                ),
+                strategy="none",
+                uncertainty_reasons=["no flagged divergence evidence was found on the observed path"],
+            ),
+        )
 
     scored: list[tuple[float, int, DecisionNode, list[str]]] = []
     for idx, node in flagged_candidates:
@@ -115,6 +251,7 @@ def select_inflection_node(
     scored.sort(key=lambda item: (item[0], -item[1]), reverse=True)
     best_score, _, best_node, best_reasons = scored[0]
     runner_up_score = scored[1][0] if len(scored) > 1 else None
+    runner_up_node = scored[1][2] if len(scored) > 1 else None
 
     fallback_node = _fallback_walkback_node(path)
     fallback_idx = next((idx for idx, node in flagged_candidates if node.id == fallback_node.id), None) if fallback_node else None
@@ -123,7 +260,20 @@ def select_inflection_node(
         fallback_score, _ = _weighted_candidate_score(path, fallback_idx)
 
     if fallback_node is None:
-        return InflectionSelection(node=None, explanation=None, strategy="none")
+        return InflectionSelection(
+            node=None,
+            explanation=None,
+            strategy="none",
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+                summary=(
+                    "No clear break point detected from observable run evidence because no "
+                    "supported flagged node was available on the visible failure path."
+                ),
+                strategy="none",
+                uncertainty_reasons=["no supported flagged node was available"],
+            ),
+        )
 
     if (
         best_node.id != fallback_node.id
@@ -159,7 +309,24 @@ def select_inflection_node(
         ],
     )
 
-    return InflectionSelection(node=best_node, explanation=explanation, strategy=strategy)
+    candidate_break_point = _candidate_break_point_from_selection(
+        node=best_node,
+        explanation=explanation,
+        strategy=strategy,
+        score=fallback_score if strategy == "walkback_fallback" else best_score,
+        runner_up_score=best_score if strategy == "walkback_fallback" else runner_up_score,
+        runner_up_node=runner_up_node,
+    )
+
+    return InflectionSelection(
+        node=best_node,
+        explanation=explanation,
+        strategy=strategy,
+        candidate_break_point=candidate_break_point,
+        score=fallback_score if strategy == "walkback_fallback" else best_score,
+        runner_up_score=best_score if strategy == "walkback_fallback" else runner_up_score,
+        runner_up_node=runner_up_node,
+    )
 
 
 def find_inflection_node(
@@ -173,3 +340,11 @@ def find_inflection_node(
     retains the historical backward-walk selection as a fallback path.
     """
     return select_inflection_node(graph, failure_node_id).node
+
+
+def select_candidate_break_point(
+    graph: LineageGraph,
+    failure_node_id: UUID,
+) -> CandidateBreakPoint:
+    """Return the OSS-safe candidate break-point finding for a failed run."""
+    return select_inflection_node(graph, failure_node_id).candidate_break_point

--- a/driftshield/src/driftshield/core/analysis/session.py
+++ b/driftshield/src/driftshield/core/analysis/session.py
@@ -14,7 +14,7 @@ from driftshield.core.analysis.inflection import select_inflection_node
 from driftshield.core.analysis.risk import RiskAnalyzer
 from driftshield.core.graph.builder import build_graph
 from driftshield.core.graph.models import DecisionNode, LineageGraph
-from driftshield.core.models import CanonicalEvent, ExplanationPayload
+from driftshield.core.models import BreakPointStatus, CandidateBreakPoint, CanonicalEvent, ExplanationPayload
 from driftshield.core.normalization import normalize_events
 
 
@@ -28,6 +28,7 @@ class AnalysisResult:
     total_events: int
     flagged_events: int
     inflection_explanation: ExplanationPayload | None = None
+    candidate_break_point: CandidateBreakPoint | None = None
 
     @property
     def has_risks(self) -> bool:
@@ -64,6 +65,12 @@ def analyze_session(
             total_events=0,
             flagged_events=0,
             inflection_explanation=None,
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+                summary="No clear break point detected because no observable events were available.",
+                strategy="none",
+                uncertainty_reasons=["no observable events were available"],
+            ),
         )
 
     if session_id is None:
@@ -86,11 +93,19 @@ def analyze_session(
 
     inflection_node = None
     inflection_explanation = None
+    candidate_break_point = CandidateBreakPoint(
+        status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+        summary="No clear break point detected because no observable events were available.",
+        strategy="none",
+        uncertainty_reasons=["no observable events were available"],
+    )
     if graph.nodes:
         last_node = graph.nodes[-1]
         selection = select_inflection_node(graph, last_node.id)
-        inflection_node = selection.node
-        inflection_explanation = selection.explanation
+        candidate_break_point = selection.candidate_break_point
+        if candidate_break_point.is_identified:
+            inflection_node = selection.node
+            inflection_explanation = selection.explanation
 
     flagged_count = sum(1 for event in analyzed_events if event.has_risk_flags())
 
@@ -101,4 +116,5 @@ def analyze_session(
         total_events=len(analyzed_events),
         flagged_events=flagged_count,
         inflection_explanation=inflection_explanation,
+        candidate_break_point=candidate_break_point,
     )

--- a/driftshield/src/driftshield/core/analysis/session.py
+++ b/driftshield/src/driftshield/core/analysis/session.py
@@ -103,9 +103,8 @@ def analyze_session(
         last_node = graph.nodes[-1]
         selection = select_inflection_node(graph, last_node.id)
         candidate_break_point = selection.candidate_break_point
-        if candidate_break_point.is_identified:
-            inflection_node = selection.node
-            inflection_explanation = selection.explanation
+        inflection_node = selection.node
+        inflection_explanation = selection.explanation
 
     flagged_count = sum(1 for event in analyzed_events if event.has_risk_flags())
 

--- a/driftshield/src/driftshield/core/models.py
+++ b/driftshield/src/driftshield/core/models.py
@@ -44,6 +44,100 @@ class ExplanationPayload:
         )
 
 
+class BreakPointStatus(str, Enum):
+    """Status of the OSS-safe candidate break-point assessment."""
+
+    IDENTIFIED = "identified"
+    NO_CLEAR_BREAK_POINT = "no_clear_break_point"
+
+
+@dataclass
+class CandidateBreakPoint:
+    """Observable, OSS-safe break-point finding for a single analyzed run."""
+
+    status: BreakPointStatus
+    summary: str
+    finding_kind: str = "candidate_break_point"
+    node_id: UUID | None = None
+    sequence_num: int | None = None
+    action: str | None = None
+    confidence: float | None = None
+    evidence_refs: list[str] = field(default_factory=list)
+    risk_flags: list[str] = field(default_factory=list)
+    uncertainty_reasons: list[str] = field(default_factory=list)
+    strategy: str = "none"
+
+    @property
+    def is_identified(self) -> bool:
+        return self.status is BreakPointStatus.IDENTIFIED and self.node_id is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_kind": self.finding_kind,
+            "status": self.status.value,
+            "summary": self.summary,
+            "node_id": str(self.node_id) if self.node_id is not None else None,
+            "sequence_num": self.sequence_num,
+            "action": self.action,
+            "confidence": self.confidence,
+            "evidence_refs": list(self.evidence_refs),
+            "risk_flags": list(self.risk_flags),
+            "uncertainty_reasons": list(self.uncertainty_reasons),
+            "strategy": self.strategy,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "CandidateBreakPoint | None":
+        if not isinstance(payload, dict):
+            return None
+
+        status_value = payload.get("status")
+        summary = payload.get("summary")
+        if not isinstance(status_value, str) or not isinstance(summary, str):
+            return None
+
+        try:
+            status = BreakPointStatus(status_value)
+        except ValueError:
+            return None
+
+        node_id_value = payload.get("node_id")
+        node_id: UUID | None = None
+        if isinstance(node_id_value, str) and node_id_value:
+            try:
+                node_id = UUID(node_id_value)
+            except ValueError:
+                return None
+
+        return cls(
+            finding_kind=(
+                payload.get("finding_kind")
+                if isinstance(payload.get("finding_kind"), str)
+                else "candidate_break_point"
+            ),
+            status=status,
+            summary=summary,
+            node_id=node_id,
+            sequence_num=payload.get("sequence_num")
+            if isinstance(payload.get("sequence_num"), int)
+            else None,
+            action=payload.get("action") if isinstance(payload.get("action"), str) else None,
+            confidence=payload.get("confidence")
+            if isinstance(payload.get("confidence"), (int, float))
+            else None,
+            evidence_refs=[
+                str(ref) for ref in payload.get("evidence_refs", []) if isinstance(ref, str)
+            ],
+            risk_flags=[str(flag) for flag in payload.get("risk_flags", []) if isinstance(flag, str)],
+            uncertainty_reasons=[
+                str(reason)
+                for reason in payload.get("uncertainty_reasons", [])
+                if isinstance(reason, str)
+            ],
+            strategy=payload.get("strategy") if isinstance(payload.get("strategy"), str) else "none",
+        )
+
+
 @dataclass
 class RiskClassification:
     """Risk flags for a decision node transition."""

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -585,9 +585,31 @@ def _build_forensic_case_artifact_refs(
                 "inflection_node_id": (
                     str(result.inflection_node.id) if result.inflection_node is not None else None
                 ),
+                "candidate_break_point": (
+                    result.candidate_break_point.to_dict()
+                    if result.candidate_break_point is not None
+                    else None
+                ),
             },
         ),
     ]
+
+    if result.candidate_break_point is not None:
+        refs.append(
+            ForensicArtifactRef(
+                ref_id=f"finding:candidate_break_point:{session.id}",
+                kind="finding",
+                role="candidate_break_point",
+                target_ref=(
+                    str(result.candidate_break_point.node_id)
+                    if result.candidate_break_point.node_id is not None
+                    else str(session.id)
+                ),
+                summary=result.candidate_break_point.summary,
+                evidence_refs=list(result.candidate_break_point.evidence_refs),
+                metadata=result.candidate_break_point.to_dict(),
+            )
+        )
 
     included_node_refs = 0
     for node in result.graph.nodes:

--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -38,6 +38,7 @@ class ReportBuilder:
             inflection_action=(
                 result.inflection_node.action if result.inflection_node else None
             ),
+            candidate_break_point=result.candidate_break_point,
             total_events=result.total_events,
             flagged_events=result.flagged_events,
         )
@@ -67,16 +68,29 @@ class ReportBuilder:
         )
 
     def _build_inflection_section(self, result: AnalysisResult) -> ReportSection:
-        if result.inflection_node:
+        if result.candidate_break_point and result.candidate_break_point.is_identified:
+            break_point = result.candidate_break_point
             content = (
-                f"Inflection detected at node #{result.inflection_node.sequence_num} "
-                f"({result.inflection_node.action}). "
-                f"This is where the agent's reasoning first diverged from expected behaviour."
+                f"{break_point.summary} Confidence {break_point.confidence:.2f}."
+                if break_point.confidence is not None
+                else break_point.summary
+            )
+            if break_point.uncertainty_reasons:
+                content += " Uncertainty: " + "; ".join(break_point.uncertainty_reasons) + "."
+        elif result.candidate_break_point:
+            break_point = result.candidate_break_point
+            content = break_point.summary
+            if break_point.uncertainty_reasons:
+                content += " Uncertainty: " + "; ".join(break_point.uncertainty_reasons) + "."
+        elif result.inflection_node:
+            content = (
+                f"Observable evidence suggests the run visibly broke at event "
+                f"#{result.inflection_node.sequence_num} ({result.inflection_node.action})."
             )
         else:
-            content = "No inflection node detected. The decision path appears consistent."
+            content = "No clear break point detected from observable run evidence."
         return ReportSection(
-            title="Inflection Node Identification",
+            title="Candidate Break Point Assessment",
             content=content,
         )
 

--- a/driftshield/src/driftshield/reports/json_export.py
+++ b/driftshield/src/driftshield/reports/json_export.py
@@ -11,6 +11,11 @@ def export_json(report: ReportData) -> dict[str, Any]:
         "report_type": report.report_type.value,
         "total_events": report.total_events,
         "flagged_events": report.flagged_events,
+        "candidate_break_point": (
+            report.candidate_break_point.to_dict()
+            if report.candidate_break_point is not None
+            else None
+        ),
         "inflection_node_id": str(report.inflection_node_id) if report.inflection_node_id else None,
         "inflection_action": report.inflection_action,
         "classification": report.classification,

--- a/driftshield/src/driftshield/reports/models.py
+++ b/driftshield/src/driftshield/reports/models.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
+from driftshield.core.models import CandidateBreakPoint
+
 
 class ReportType(Enum):
     FULL = "full"
@@ -44,6 +46,7 @@ class ReportData:
     sections: list[ReportSection]
     inflection_node_id: uuid.UUID | None = None
     inflection_action: str | None = None
+    candidate_break_point: CandidateBreakPoint | None = None
     total_events: int = 0
     flagged_events: int = 0
     classification: str = "isolated"

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -13,6 +13,7 @@ from driftshield.core.models import (
     CanonicalEvent,
     EventType,
     ForensicCaseState,
+    RiskClassification,
     Session as DomainSession,
     SessionStatus,
 )
@@ -178,6 +179,69 @@ def test_generate_report_updates_forensic_case_without_losing_saved_evidence_art
         and ref.metadata == {"kind": "path", "value": "/tmp/evidence.txt", "source": "inputs"}
         for ref in case.artifact_refs
     )
+
+
+def test_generate_report_preserves_legacy_inflection_fields_for_uncertain_break_points(
+    client,
+    auth_headers,
+    db_session,
+):
+    session_id = uuid.uuid4()
+    events = [
+        CanonicalEvent(
+            id=uuid.uuid4(),
+            session_id=str(session_id),
+            timestamp=datetime.now(timezone.utc),
+            event_type=EventType.TOOL_CALL,
+            agent_id="test-agent",
+            action="early_policy_drift",
+            risk_classification=RiskClassification(policy_divergence=True),
+        ),
+        CanonicalEvent(
+            id=uuid.uuid4(),
+            session_id=str(session_id),
+            timestamp=datetime.now(timezone.utc),
+            event_type=EventType.TOOL_CALL,
+            agent_id="test-agent",
+            action="later_constraint_drift",
+            parent_event_id=None,
+            risk_classification=RiskClassification(constraint_violation=True),
+        ),
+        CanonicalEvent(
+            id=uuid.uuid4(),
+            session_id=str(session_id),
+            timestamp=datetime.now(timezone.utc),
+            event_type=EventType.OUTPUT,
+            agent_id="test-agent",
+            action="failure",
+        ),
+    ]
+    events[1].parent_event_id = events[0].id
+    events[1].parent_event_refs = [events[0].id]
+    events[2].parent_event_id = events[1].id
+    events[2].parent_event_refs = [events[1].id]
+    domain_session = DomainSession(
+        id=session_id,
+        agent_id="test-agent",
+        started_at=datetime.now(timezone.utc),
+        status=SessionStatus.COMPLETED,
+    )
+    service = PersistenceService(db_session)
+    service.save(domain_session, analyze_session(events))
+    db_session.commit()
+
+    response = client.post(
+        f"/api/sessions/{session_id}/report",
+        headers=auth_headers,
+        json={"report_type": "full"},
+    )
+
+    assert response.status_code == 201
+
+    report = db_session.get(ReportModel, uuid.UUID(response.json()["id"]))
+    assert report is not None
+    assert report.content_json["candidate_break_point"]["status"] == "no_clear_break_point"
+    assert report.content_json["inflection_node_id"] is not None
 
 
 def test_graveyard_summary_route_is_removed(client, auth_headers):

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -131,6 +131,7 @@ def test_generated_report_has_real_content(client, auth_headers, seeded_session,
     assert "Forensic Analysis Report" in data["content_markdown"]
     assert data["content_json"]["sections"] is not None
     assert len(data["content_json"]["sections"]) == 4
+    assert data["content_json"]["candidate_break_point"]["status"] == "no_clear_break_point"
     assert "recurrence_probability" not in data["content_json"]
 
 

--- a/driftshield/tests/cli/test_output.py
+++ b/driftshield/tests/cli/test_output.py
@@ -3,9 +3,13 @@
 from datetime import datetime, timezone
 from uuid import uuid4
 
-import pytest
-
-from driftshield.core.models import CanonicalEvent, EventType, RiskClassification
+from driftshield.core.models import (
+    BreakPointStatus,
+    CandidateBreakPoint,
+    CanonicalEvent,
+    EventType,
+    RiskClassification,
+)
 from driftshield.core.graph.builder import build_graph
 from driftshield.core.analysis.session import AnalysisResult
 from driftshield.cli.output import format_summary, format_json
@@ -30,12 +34,30 @@ def make_analysis_result(
                 inflection_node = node
                 break
 
+    candidate_break_point = CandidateBreakPoint(
+        status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+        summary="No clear break point detected from observable run evidence.",
+    )
+    if inflection_node is not None:
+        candidate_break_point = CandidateBreakPoint(
+            status=BreakPointStatus.IDENTIFIED,
+            summary=(
+                f"Observable evidence suggests the run visibly broke at event "
+                f"#{inflection_node.sequence_num} ({inflection_node.action})."
+            ),
+            node_id=inflection_node.id,
+            sequence_num=inflection_node.sequence_num,
+            action=inflection_node.action,
+            confidence=1.0,
+        )
+
     return AnalysisResult(
         events=events,
         graph=graph,
         inflection_node=inflection_node,
         total_events=len(events),
         flagged_events=flagged,
+        candidate_break_point=candidate_break_point,
     )
 
 
@@ -47,6 +69,7 @@ class TestFormatSummary:
 
         assert "Events:  0" in output or "Events: 0" in output
         assert "Flagged: 0" in output or "Flagged:  0" in output
+        assert "Candidate Break Point:" in output
 
     def test_shows_session_id(self):
         """Summary shows session ID."""
@@ -72,6 +95,10 @@ class TestFormatSummary:
             inflection_node=None,
             total_events=1,
             flagged_events=1,
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.NO_CLEAR_BREAK_POINT,
+                summary="No clear break point detected from observable run evidence.",
+            ),
         )
         output = format_summary(result)
 
@@ -95,10 +122,18 @@ class TestFormatSummary:
             inflection_node=graph.nodes[0],
             total_events=1,
             flagged_events=1,
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.IDENTIFIED,
+                summary="Observable evidence suggests the run visibly broke at event #0 (bad_decision).",
+                node_id=graph.nodes[0].id,
+                sequence_num=graph.nodes[0].sequence_num,
+                action=graph.nodes[0].action,
+                confidence=1.0,
+            ),
         )
         output = format_summary(result)
 
-        assert "Inflection" in output
+        assert "Candidate Break Point" in output
         assert "bad_decision" in output
 
 
@@ -131,8 +166,20 @@ class TestFormatJson:
             inflection_node=graph.nodes[0],
             total_events=1,
             flagged_events=1,
+            candidate_break_point=CandidateBreakPoint(
+                status=BreakPointStatus.IDENTIFIED,
+                summary=(
+                    "Observable evidence suggests the run visibly broke at event #0 "
+                    "(inflection_action)."
+                ),
+                node_id=graph.nodes[0].id,
+                sequence_num=graph.nodes[0].sequence_num,
+                action=graph.nodes[0].action,
+                confidence=1.0,
+            ),
         )
         output = format_json(result)
 
         assert "inflection" in output
         assert "inflection_action" in output
+        assert "candidate_break_point" in output

--- a/driftshield/tests/core/analysis/test_explanations.py
+++ b/driftshield/tests/core/analysis/test_explanations.py
@@ -107,6 +107,14 @@ def test_analyze_session_emits_inflection_explanation_from_flagged_node() -> Non
             "inflection_reason:recovery penalty for 1 clean node(s) after this point",
         ],
     )
+    assert result.candidate_break_point is not None
+    assert result.candidate_break_point.status.value == "identified"
+    assert result.candidate_break_point.node_id == risky_event.id
+    assert f"node:{risky_event.id}" in result.candidate_break_point.evidence_refs
+    assert "risk:coverage_gap" in result.candidate_break_point.evidence_refs
+    assert "inflection_reason:severity from coverage_gap" in result.candidate_break_point.evidence_refs
+    assert "inputs.sections" in result.candidate_break_point.evidence_refs
+    assert "outputs.reviewed_sections" in result.candidate_break_point.evidence_refs
     assert result.inflection_node.event.risk_classification is not None
     assert result.inflection_node.event.risk_classification.explanations["coverage_gap"] == ExplanationPayload(
         reason="Output referenced fewer items than were provided in the input.",

--- a/driftshield/tests/core/analysis/test_inflection.py
+++ b/driftshield/tests/core/analysis/test_inflection.py
@@ -172,6 +172,34 @@ class TestInflectionWithScenarios:
         assert selection.candidate_break_point.confidence < 0.6
         assert selection.candidate_break_point.uncertainty_reasons
 
+    def test_fallback_break_point_evidence_tracks_actual_top_competitor(self):
+        event1 = make_event(
+            action="earliest_coverage_gap",
+            risk_classification=RiskClassification(coverage_gap=True),
+        )
+        event2 = make_event(
+            action="middle_constraint_drift",
+            parent_event_id=event1.id,
+            risk_classification=RiskClassification(constraint_violation=True),
+        )
+        event3 = make_event(
+            action="latest_context_drift",
+            parent_event_id=event2.id,
+            risk_classification=RiskClassification(context_contamination=True),
+        )
+        event4 = make_event(action="failure", parent_event_id=event3.id)
+
+        graph = build_graph([event1, event2, event3, event4], session_id="test")
+        selection = select_inflection_node(graph, event4.id)
+
+        assert selection.strategy == "walkback_fallback"
+        assert selection.node is not None
+        assert selection.node.id == event3.id
+        assert selection.runner_up_node is not None
+        assert selection.runner_up_node.id == event2.id
+        assert f"node:{event2.id}" in selection.candidate_break_point.evidence_refs
+        assert f"node:{event1.id}" not in selection.candidate_break_point.evidence_refs
+
     def test_assumption_introduction_scenario(self):
         """Finds correct inflection in assumption introduction scenario."""
         graph, metadata = assumption_introduction_scenario()

--- a/driftshield/tests/core/analysis/test_inflection.py
+++ b/driftshield/tests/core/analysis/test_inflection.py
@@ -150,6 +150,28 @@ class TestInflectionWithScenarios:
         assert result.id == metadata["expected_inflection_node_id"]
         assert result.action == metadata["expected_inflection_node_action"]
 
+    def test_candidate_break_point_returns_no_clear_when_candidates_are_too_close(self):
+        event1 = make_event(
+            action="early_policy_drift",
+            risk_classification=RiskClassification(policy_divergence=True),
+        )
+        event2 = make_event(
+            action="later_constraint_drift",
+            parent_event_id=event1.id,
+            risk_classification=RiskClassification(constraint_violation=True),
+        )
+        event3 = make_event(action="failure", parent_event_id=event2.id)
+
+        graph = build_graph([event1, event2, event3], session_id="test")
+        selection = select_inflection_node(graph, event3.id)
+
+        assert selection.node is not None
+        assert selection.candidate_break_point.status.value == "no_clear_break_point"
+        assert selection.candidate_break_point.node_id is None
+        assert selection.candidate_break_point.confidence is not None
+        assert selection.candidate_break_point.confidence < 0.6
+        assert selection.candidate_break_point.uncertainty_reasons
+
     def test_assumption_introduction_scenario(self):
         """Finds correct inflection in assumption introduction scenario."""
         graph, metadata = assumption_introduction_scenario()

--- a/driftshield/tests/core/analysis/test_session_analyzer.py
+++ b/driftshield/tests/core/analysis/test_session_analyzer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from driftshield.core.analysis.session import analyze_session, AnalysisResult
-from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.models import CanonicalEvent, EventType, RiskClassification
 from driftshield.parsers.claude_code import ClaudeCodeParser
 from tests.fixtures.scenarios import (
     coverage_gap_scenario,
@@ -98,6 +98,25 @@ class TestAnalyzeSession:
         # If risks were detected, inflection should be found
         if any(e.has_risk_flags() for e in result.events):
             assert result.inflection_node is not None
+
+    def test_preserves_legacy_inflection_node_when_candidate_break_point_is_uncertain(self):
+        event1 = make_event(
+            action="early_policy_drift",
+            risk_classification=RiskClassification(policy_divergence=True),
+        )
+        event2 = make_event(
+            action="later_constraint_drift",
+            parent_event_id=event1.id,
+            risk_classification=RiskClassification(constraint_violation=True),
+        )
+        event3 = make_event(action="failure", parent_event_id=event2.id)
+
+        result = analyze_session([event1, event2, event3])
+
+        assert result.candidate_break_point is not None
+        assert result.candidate_break_point.status.value == "no_clear_break_point"
+        assert result.inflection_node is not None
+        assert result.inflection_explanation is not None
 
     def test_with_real_transcript(self):
         """Runs analysis on real transcript without error."""

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -174,6 +174,11 @@ def test_save_creates_draft_forensic_case_with_evidence_artifacts(
         for ref in case.artifact_refs
     )
     assert any(
+        ref.role == "candidate_break_point"
+        and ref.metadata["status"] == "no_clear_break_point"
+        for ref in case.artifact_refs
+    )
+    assert any(
         ref.role == "event_artifact"
         and ref.target_ref == str(result.graph.nodes[0].id)
         and ref.metadata == {"kind": "path", "value": "/test", "source": "inputs"}
@@ -568,6 +573,14 @@ def test_save_and_load_graph_round_trip_explanations(db_session):
             "inflection_reason:point-of-no-return position near the observed failure",
         ],
     }
+    case = service.load_case_for_session(session_id)
+    assert case is not None
+    assert any(
+        ref.role == "candidate_break_point"
+        and ref.metadata["status"] == "identified"
+        and ref.metadata["node_id"] == str(event.id)
+        for ref in case.artifact_refs
+    )
 
     graph = service.load_graph(session_id)
 

--- a/driftshield/tests/reports/test_builder.py
+++ b/driftshield/tests/reports/test_builder.py
@@ -44,7 +44,7 @@ def test_build_full_report(sample_result):
     assert report_data.report_type == ReportType.FULL
     assert len(report_data.sections) == 4
     assert report_data.sections[0].title == "Behavioural Lineage Reconstruction"
-    assert report_data.sections[1].title == "Inflection Node Identification"
+    assert report_data.sections[1].title == "Candidate Break Point Assessment"
     assert report_data.sections[2].title == "Risk State Transition Mapping"
     assert report_data.sections[3].title == "Systemic Exposure Assessment"
 
@@ -67,3 +67,13 @@ def test_lineage_section_has_node_table(sample_result):
     assert len(lineage.node_table) == len(result.graph.nodes)
     for row in lineage.node_table:
         assert row.event_type in ["TOOL_CALL", "OUTPUT", "BRANCH", "ASSUMPTION", "CONSTRAINT_CHECK", "HANDOFF"]
+
+
+def test_break_point_section_uses_candidate_break_point_summary(sample_result):
+    result, session = sample_result
+    builder = ReportBuilder()
+    report_data = builder.build(session, result, report_type=ReportType.FULL)
+
+    break_point = report_data.candidate_break_point
+    assert break_point is not None
+    assert report_data.sections[1].content.startswith(break_point.summary)

--- a/driftshield/tests/reports/test_json_export.py
+++ b/driftshield/tests/reports/test_json_export.py
@@ -52,3 +52,5 @@ def test_export_json_section_structure(report_data):
     assert "title" in section
     assert "content" in section
     assert "node_table" in section
+    assert data["candidate_break_point"] is not None
+    assert data["candidate_break_point"]["status"] == "no_clear_break_point"

--- a/driftshield/tests/reports/test_markdown.py
+++ b/driftshield/tests/reports/test_markdown.py
@@ -41,7 +41,7 @@ def test_render_full_report_markdown(full_report_data):
     assert "# Forensic Analysis Report" in md
     assert "test-agent" in md
     assert "Behavioural Lineage Reconstruction" in md
-    assert "Inflection Node Identification" in md
+    assert "Candidate Break Point Assessment" in md
     assert "Risk State Transition Mapping" in md
     assert "Systemic Exposure Assessment" in md
 


### PR DESCRIPTION
## Summary
- add a stable OSS-safe candidate break point result with explicit `identified` and `no_clear_break_point` outcomes
- thread the break-point finding through analysis results, forensic-case artifacts, report generation, and CLI JSON/text output while keeping legacy inflection selection compatible
- prevent Rich from wrapping `analyze --json` output so CLI JSON stays parseable after the richer payload lands

## Verification
- `cd driftshield && uv run --extra dev pytest tests/core/analysis/test_inflection.py tests/core/analysis/test_explanations.py tests/db/test_persistence.py tests/reports/test_builder.py tests/reports/test_markdown.py tests/reports/test_json_export.py tests/api/test_reports.py tests/cli/test_output.py -q`
- `cd driftshield && uv run --extra dev pytest tests/cli/test_analyze.py -q`
- `cd driftshield && uv run --extra dev pytest tests -q`
- `cd driftshield && uv run --extra dev ruff check src/driftshield/core/models.py src/driftshield/core/analysis/inflection.py src/driftshield/core/analysis/session.py src/driftshield/reports/models.py src/driftshield/reports/builder.py src/driftshield/reports/json_export.py src/driftshield/cli/output.py src/driftshield/cli/commands/analyze.py src/driftshield/api/routes/reports.py src/driftshield/db/persistence.py tests/core/analysis/test_inflection.py tests/core/analysis/test_explanations.py tests/db/test_persistence.py tests/reports/test_builder.py tests/reports/test_markdown.py tests/reports/test_json_export.py tests/api/test_reports.py tests/cli/test_output.py`

## Links
- Refs tborys/driftshield-meta#68
