### PR TITLE
feat: add OSS-safe forensic report v1

### DIFF
--- a/driftshield/src/driftshield/cli/commands/report.py
+++ b/driftshield/src/driftshield/cli/commands/report.py
@@ -1,5 +1,6 @@
 """Report command for DriftShield CLI."""
 
+import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -10,6 +11,7 @@ from driftshield.cli.parsers import detect_parser, get_parser
 from driftshield.core.analysis.session import analyze_session
 from driftshield.core.models import Session as DomainSession, SessionStatus
 from driftshield.reports.builder import ReportBuilder
+from driftshield.reports.json_export import export_json
 from driftshield.reports.markdown import render_markdown
 from driftshield.reports.models import ReportType
 
@@ -17,6 +19,12 @@ from driftshield.reports.models import ReportType
 def report_command(
     path: Path = typer.Argument(..., help="Path to transcript file"),
     report_type: str = typer.Option("full", "--type", help="Report type: full or summary"),
+    output_format: str = typer.Option(
+        "markdown",
+        "--format",
+        "-f",
+        help="Output format: markdown or json",
+    ),
     output: Path | None = typer.Option(None, "--output", "-o", help="Output file path"),
     parser_name: str | None = typer.Option(None, "--parser", help="Parser to use"),
 ):
@@ -51,10 +59,16 @@ def report_command(
     rt = ReportType(report_type)
     builder = ReportBuilder()
     report_data = builder.build(session, result, report_type=rt)
-    md = render_markdown(report_data)
+    if output_format == "markdown":
+        rendered = render_markdown(report_data)
+    elif output_format == "json":
+        rendered = json.dumps(export_json(report_data), indent=2) + "\n"
+    else:
+        typer.echo(f"Error: unsupported output format {output_format!r}", err=True)
+        raise typer.Exit(1)
 
     if output:
-        output.write_text(md)
+        output.write_text(rendered)
         typer.echo(f"Report written to {output}")
     else:
-        typer.echo(md)
+        typer.echo(rendered)

--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -1,9 +1,28 @@
+from collections.abc import Mapping
 from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
 
-from driftshield.core.models import Session as DomainSession
 from driftshield.core.analysis.session import AnalysisResult
+from driftshield.core.graph.models import DecisionNode
+from driftshield.core.models import Session as DomainSession
 from driftshield.reports.models import (
-    ReportData, ReportSection, ReportType, NodeRow, RiskTransition,
+    EvidenceRef,
+    NodeRow,
+    PatternMatch,
+    ReportData,
+    ReportFinding,
+    ReportSection,
+    ReportSummary,
+    ReportType,
+    RiskTransition,
+)
+
+
+OSS_SAFETY_NOTE = (
+    "This OSS-safe report is built from observable single-run evidence only; it may "
+    "identify a visible break-point candidate or local resemblance signals, but it "
+    "does not claim decision-grade root cause, causal certainty, or system-level priority."
 )
 
 
@@ -14,6 +33,11 @@ class ReportBuilder:
         result: AnalysisResult,
         report_type: ReportType = ReportType.FULL,
     ) -> ReportData:
+        pattern_matches = self._build_pattern_matches(session)
+        findings = self._build_findings(session, result, pattern_matches)
+        evidence_index = self._build_evidence_index(session, result, findings, pattern_matches)
+        summary = self._build_summary(session, result, pattern_matches)
+
         sections = [
             self._build_lineage_section(result),
             self._build_inflection_section(result),
@@ -41,6 +65,11 @@ class ReportBuilder:
             candidate_break_point=result.candidate_break_point,
             total_events=result.total_events,
             flagged_events=result.flagged_events,
+            classification=self._classification_label(result),
+            summary=summary,
+            findings=findings,
+            pattern_matches=pattern_matches,
+            evidence_index=evidence_index,
         )
 
     def _build_lineage_section(self, result: AnalysisResult) -> ReportSection:
@@ -50,20 +79,22 @@ class ReportBuilder:
             rc = node.event.risk_classification
             if rc:
                 risk_flags = rc.active_flags()
-            rows.append(NodeRow(
-                sequence=node.sequence_num,
-                node_id=node.id,
-                event_type=node.event_type.value,
-                action=node.action,
-                risk_flags=risk_flags,
-                is_inflection=(
-                    result.inflection_node is not None
-                    and node.id == result.inflection_node.id
-                ),
-            ))
+            rows.append(
+                NodeRow(
+                    sequence=node.sequence_num,
+                    node_id=node.id,
+                    event_type=node.event_type.value,
+                    action=node.action,
+                    risk_flags=risk_flags,
+                    is_inflection=(
+                        result.inflection_node is not None
+                        and node.id == result.inflection_node.id
+                    ),
+                )
+            )
         return ReportSection(
             title="Behavioural Lineage Reconstruction",
-            content="Chronological reconstruction of the agent's decision path.",
+            content="Chronological reconstruction of the observable agent decision path.",
             node_table=rows,
         )
 
@@ -97,31 +128,473 @@ class ReportBuilder:
     def _build_risk_transition_section(self, result: AnalysisResult) -> ReportSection:
         transitions = []
         nodes = result.graph.nodes
-        for i, node in enumerate(nodes):
+        for index, node in enumerate(nodes):
             rc = node.event.risk_classification
             if rc and rc.has_any_flag():
                 for flag in rc.active_flags():
-                    if i + 1 < len(nodes):
-                        transitions.append(RiskTransition(
-                            from_node_id=node.id,
-                            to_node_id=nodes[i + 1].id,
-                            risk_type=flag,
-                            description=f"{flag} introduced at {node.action}",
-                        ))
+                    if index + 1 < len(nodes):
+                        transitions.append(
+                            RiskTransition(
+                                from_node_id=node.id,
+                                to_node_id=nodes[index + 1].id,
+                                risk_type=flag,
+                                description=f"{flag} introduced at {node.action}",
+                            )
+                        )
         return ReportSection(
             title="Risk State Transition Mapping",
-            content="How risk propagated through the decision graph.",
+            content="How risk flags moved through the visible single-run decision graph.",
             risk_transitions=transitions,
         )
 
     def _build_exposure_section(self, result: AnalysisResult) -> ReportSection:
         if result.flagged_events == 0:
-            classification = "No risk flags detected."
+            classification = "No risk flags were detected in this single run."
         elif result.flagged_events == 1:
-            classification = "Isolated: single point of risk in the decision path."
+            classification = "Isolated: one visible risk point was found in this run."
         else:
-            classification = f"Multiple risk points ({result.flagged_events} flagged events)."
+            classification = f"Multiple visible risk points ({result.flagged_events} flagged events)."
         return ReportSection(
-            title="Systemic Exposure Assessment",
+            title="Single-Run Exposure Assessment",
             content=classification,
         )
+
+    def _build_summary(
+        self,
+        session: DomainSession,
+        result: AnalysisResult,
+        pattern_matches: list[PatternMatch],
+    ) -> ReportSummary:
+        break_point = result.candidate_break_point
+        confidence = break_point.confidence if break_point is not None else None
+        where_it_broke = self._where_it_broke(result)
+        uncertainty = (
+            list(break_point.uncertainty_reasons)
+            if break_point is not None and break_point.uncertainty_reasons
+            else ["only observable single-run evidence was evaluated"]
+        )
+
+        event_count = f"{result.total_events} observable {_plural('event', result.total_events)}"
+        risk_count = f"{result.flagged_events} risk-flagged {_plural('event', result.flagged_events)}"
+        what_happened = (
+            f"DriftShield reconstructed {event_count} for a {session.status.value} run "
+            f"and found {risk_count}."
+        )
+
+        return ReportSummary(
+            headline=f"{what_happened} {where_it_broke}",
+            what_happened=what_happened,
+            where_it_broke=where_it_broke,
+            evidence_basis=(
+                f"The report cites {len(result.graph.nodes)} lineage "
+                f"{_plural('node', len(result.graph.nodes))}, candidate break-point evidence, "
+                "and risk explanations where available."
+            ),
+            confidence=confidence,
+            confidence_label=_confidence_label(confidence),
+            uncertainty=uncertainty,
+            pattern_resemblance=self._pattern_resemblance_summary(pattern_matches, result),
+            oss_safety_note=OSS_SAFETY_NOTE,
+        )
+
+    def _where_it_broke(self, result: AnalysisResult) -> str:
+        break_point = result.candidate_break_point
+        if break_point is None:
+            return "No candidate break point was available from the observable evidence."
+        if break_point.is_identified:
+            action = f" ({break_point.action})" if break_point.action else ""
+            return f"Visible break-point candidate: event #{break_point.sequence_num}{action}."
+        return break_point.summary
+
+    def _build_findings(
+        self,
+        session: DomainSession,
+        result: AnalysisResult,
+        pattern_matches: list[PatternMatch],
+    ) -> list[ReportFinding]:
+        findings = [
+            ReportFinding(
+                finding_id=f"finding:run_reconstruction:{session.id}",
+                finding_kind="run_reconstruction",
+                subject_ref=f"session:{session.id}",
+                summary=(
+                    f"Reconstructed {result.total_events} observable "
+                    f"{_plural('event', result.total_events)} with "
+                    f"{result.flagged_events} risk-flagged "
+                    f"{_plural('event', result.flagged_events)}."
+                ),
+                evidence_refs=[f"session:{session.id}", f"lineage:{session.id}"],
+                confidence=1.0,
+            )
+        ]
+
+        break_point = result.candidate_break_point
+        if break_point is not None:
+            findings.append(
+                ReportFinding(
+                    finding_id=f"finding:candidate_break_point:{session.id}",
+                    finding_kind="candidate_break_point",
+                    subject_ref=(
+                        f"node:{break_point.node_id}"
+                        if break_point.node_id is not None
+                        else f"session:{session.id}"
+                    ),
+                    summary=break_point.summary,
+                    evidence_refs=(
+                        list(break_point.evidence_refs)
+                        if break_point.evidence_refs
+                        else [f"lineage:{session.id}"]
+                    ),
+                    confidence=break_point.confidence,
+                    status=break_point.status.value,
+                )
+            )
+
+        if pattern_matches:
+            for match in pattern_matches:
+                findings.append(
+                    ReportFinding(
+                        finding_id=f"finding:pattern_resemblance:{match.match_id}",
+                        finding_kind="pattern_resemblance",
+                        subject_ref=match.scope_ref,
+                        summary=(
+                            f"Local OSS-safe signals resemble {match.family_id} "
+                            f"via {match.signature_id}."
+                        ),
+                        evidence_refs=(
+                            list(match.evidence_refs)
+                            if match.evidence_refs
+                            else [f"session:{session.id}"]
+                        ),
+                        confidence=match.confidence,
+                        status="matched",
+                    )
+                )
+        elif active_flags := self._active_risk_flags(result):
+            findings.append(
+                ReportFinding(
+                    finding_id=f"finding:pattern_resemblance:{session.id}",
+                    finding_kind="pattern_resemblance",
+                    subject_ref=f"session:{session.id}",
+                    summary=(
+                        "No named OSS-safe pattern match was available, but local risk "
+                        f"signals indicate: {', '.join(active_flags)}."
+                    ),
+                    evidence_refs=[f"risk:{flag}" for flag in active_flags],
+                    confidence=break_point.confidence if break_point is not None else None,
+                    status="available_as_local_risk_class_only",
+                )
+            )
+
+        if break_point is not None and not break_point.is_identified:
+            findings.append(
+                ReportFinding(
+                    finding_id=f"finding:evidence_gap:{session.id}",
+                    finding_kind="evidence_gap",
+                    subject_ref=f"session:{session.id}",
+                    summary=(
+                        "Observable evidence was not strong enough to isolate a single "
+                        "break point."
+                    ),
+                    evidence_refs=(
+                        list(break_point.evidence_refs)
+                        if break_point.evidence_refs
+                        else [f"lineage:{session.id}"]
+                    ),
+                    confidence=break_point.confidence,
+                    status="open",
+                )
+            )
+
+        return findings
+
+    def _build_pattern_matches(self, session: DomainSession) -> list[PatternMatch]:
+        metadata = session.metadata if isinstance(session.metadata, Mapping) else {}
+        payload = metadata.get("signature_match") or metadata.get("signature_summary")
+        if not isinstance(payload, Mapping):
+            return []
+
+        raw_matches = payload.get("matches")
+        if isinstance(raw_matches, list):
+            candidates = raw_matches
+        else:
+            candidates = [payload]
+
+        matches: list[PatternMatch] = []
+        for index, item in enumerate(candidates, start=1):
+            if not isinstance(item, Mapping):
+                continue
+            match = self._pattern_match_from_payload(session, item, index)
+            if match is not None:
+                matches.append(match)
+        return matches
+
+    def _pattern_match_from_payload(
+        self,
+        session: DomainSession,
+        payload: Mapping[str, Any],
+        index: int,
+    ) -> PatternMatch | None:
+        signature_id = _string_value(payload.get("signature_id"))
+        family_id = _string_value(payload.get("family_id") or payload.get("primary_family_id"))
+        if signature_id is None or family_id is None:
+            return None
+
+        signature_layer = (
+            dict(payload.get("signature_layer"))
+            if isinstance(payload.get("signature_layer"), Mapping)
+            else {}
+        )
+        evidence_refs = _string_list(
+            payload.get("evidence_refs") or payload.get("evidence_event_refs")
+        )
+        return PatternMatch(
+            match_id=_string_value(payload.get("match_id"))
+            or f"pattern_match:{session.id}:{index}",
+            signature_id=signature_id,
+            family_id=family_id,
+            signature_layer=signature_layer,
+            scope_ref=_string_value(payload.get("scope_ref")) or f"session:{session.id}",
+            evidence_refs=evidence_refs,
+            confidence=_float_value(payload.get("confidence")),
+            rationale=_string_value(payload.get("rationale") or payload.get("summary")) or "",
+            source=_string_value(payload.get("source")) or "local",
+        )
+
+    def _pattern_resemblance_summary(
+        self,
+        pattern_matches: list[PatternMatch],
+        result: AnalysisResult,
+    ) -> str:
+        if pattern_matches:
+            families = ", ".join(match.family_id for match in pattern_matches)
+            return f"Local OSS-safe pattern signals resemble: {families}."
+
+        active_flags = self._active_risk_flags(result)
+        if active_flags:
+            return (
+                "No named OSS-safe pattern match was available; local risk signals "
+                f"include: {', '.join(active_flags)}."
+            )
+
+        return "No local pattern resemblance was available from OSS-safe signals."
+
+    def _build_evidence_index(
+        self,
+        session: DomainSession,
+        result: AnalysisResult,
+        findings: list[ReportFinding],
+        pattern_matches: list[PatternMatch],
+    ) -> list[EvidenceRef]:
+        index: dict[str, EvidenceRef] = {}
+
+        def add(ref: EvidenceRef) -> None:
+            if ref.ref_id not in index:
+                index[ref.ref_id] = ref
+
+        add(
+            EvidenceRef(
+                ref_id=f"session:{session.id}",
+                target_kind="analysis_session",
+                target_ref=str(session.id),
+                role="session",
+                excerpt=f"{session.status.value} run for {session.agent_id}",
+            )
+        )
+        add(
+            EvidenceRef(
+                ref_id=f"lineage:{session.id}",
+                target_kind="lineage_graph",
+                target_ref=str(session.id),
+                role="lineage",
+                excerpt=_lineage_excerpt(result),
+            )
+        )
+
+        for node in result.graph.nodes:
+            add(self._node_evidence_ref(node))
+            for flag in _node_risk_flags(node):
+                add(
+                    EvidenceRef(
+                        ref_id=f"risk:{flag}",
+                        target_kind="finding",
+                        target_ref=flag,
+                        role="risk_signal",
+                        excerpt=f"Risk signal active on event #{node.sequence_num}.",
+                    )
+                )
+
+        for finding in findings:
+            for token in finding.evidence_refs:
+                add(self._evidence_ref_from_token(token, session, result))
+
+        for match in pattern_matches:
+            for token in match.evidence_refs:
+                add(self._evidence_ref_from_token(token, session, result))
+
+        return list(index.values())
+
+    def _evidence_ref_from_token(
+        self,
+        token: str,
+        session: DomainSession,
+        result: AnalysisResult,
+    ) -> EvidenceRef:
+        if token == f"session:{session.id}":
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="analysis_session",
+                target_ref=str(session.id),
+                role="session",
+                excerpt=f"{session.status.value} run for {session.agent_id}",
+            )
+
+        if token == f"lineage:{session.id}":
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="lineage_graph",
+                target_ref=str(session.id),
+                role="lineage",
+                excerpt=_lineage_excerpt(result),
+            )
+
+        if token.startswith("node:"):
+            node_id = token.removeprefix("node:")
+            node = _node_by_id(result, node_id)
+            if node is not None:
+                return self._node_evidence_ref(node)
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="decision_node",
+                target_ref=node_id,
+                role="lineage_node",
+            )
+
+        if token.startswith("risk:"):
+            risk_flag = token.removeprefix("risk:")
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="finding",
+                target_ref=risk_flag,
+                role="risk_signal",
+                excerpt=f"Risk signal: {risk_flag}.",
+            )
+
+        if token.startswith("inflection_reason:"):
+            reason = token.removeprefix("inflection_reason:")
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="analysis_reason",
+                target_ref=reason,
+                role="selection_reason",
+                excerpt=reason,
+            )
+
+        if token.startswith("event:"):
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="normalized_event",
+                target_ref=token,
+                role="event_evidence",
+            )
+
+        if "." in token:
+            return EvidenceRef(
+                ref_id=token,
+                target_kind="normalized_event_field",
+                target_ref=token,
+                role="field_evidence",
+                excerpt=token,
+            )
+
+        return EvidenceRef(
+            ref_id=token,
+            target_kind="analysis_evidence",
+            target_ref=token,
+            role="supporting_evidence",
+        )
+
+    def _node_evidence_ref(self, node: DecisionNode) -> EvidenceRef:
+        summary = node.summary or node.action
+        return EvidenceRef(
+            ref_id=f"node:{node.id}",
+            target_kind="decision_node",
+            target_ref=str(node.id),
+            role="lineage_node",
+            excerpt=f"Event #{node.sequence_num}: {summary}",
+            metadata={
+                "sequence_num": node.sequence_num,
+                "event_type": node.event_type.value,
+                "risk_flags": _node_risk_flags(node),
+                "lineage_ambiguities": list(node.lineage_ambiguities),
+            },
+        )
+
+    def _active_risk_flags(self, result: AnalysisResult) -> list[str]:
+        return [
+            flag
+            for flag, count in result.risk_summary.items()
+            if count > 0
+        ]
+
+    def _classification_label(self, result: AnalysisResult) -> str:
+        if result.flagged_events == 0:
+            return "no_risk_flags"
+        if result.flagged_events == 1:
+            return "isolated"
+        return "multiple_visible_risk_points"
+
+
+def _confidence_label(confidence: float | None) -> str:
+    if confidence is None:
+        return "unknown"
+    if confidence >= 0.8:
+        return "high"
+    if confidence >= 0.6:
+        return "medium"
+    return "low"
+
+
+def _plural(noun: str, count: int) -> str:
+    return noun if count == 1 else f"{noun}s"
+
+
+def _lineage_excerpt(result: AnalysisResult) -> str:
+    node_count = len(result.graph.nodes)
+    edge_count = len(result.graph.edges)
+    return (
+        f"{node_count} {_plural('node', node_count)} and "
+        f"{edge_count} {_plural('edge', edge_count)}"
+    )
+
+
+def _node_risk_flags(node: DecisionNode) -> list[str]:
+    risk = node.event.risk_classification
+    return risk.active_flags() if risk is not None else []
+
+
+def _node_by_id(result: AnalysisResult, value: str) -> DecisionNode | None:
+    try:
+        node_id = UUID(value)
+    except ValueError:
+        return None
+
+    return result.graph.get_node(node_id)
+
+
+def _string_value(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _float_value(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]

--- a/driftshield/src/driftshield/reports/json_export.py
+++ b/driftshield/src/driftshield/reports/json_export.py
@@ -5,12 +5,61 @@ from driftshield.reports.models import ReportData
 
 def export_json(report: ReportData) -> dict[str, Any]:
     return {
+        "schema_version": report.schema_version,
         "session_id": str(report.session_id),
         "agent_id": report.agent_id,
         "generated_at": report.generated_at.isoformat(),
         "report_type": report.report_type.value,
         "total_events": report.total_events,
         "flagged_events": report.flagged_events,
+        "summary": {
+            "headline": report.summary.headline,
+            "what_happened": report.summary.what_happened,
+            "where_it_broke": report.summary.where_it_broke,
+            "evidence_basis": report.summary.evidence_basis,
+            "confidence": report.summary.confidence,
+            "confidence_label": report.summary.confidence_label,
+            "uncertainty": list(report.summary.uncertainty),
+            "pattern_resemblance": report.summary.pattern_resemblance,
+            "oss_safety_note": report.summary.oss_safety_note,
+        },
+        "findings": [
+            {
+                "finding_id": finding.finding_id,
+                "finding_kind": finding.finding_kind,
+                "subject_ref": finding.subject_ref,
+                "summary": finding.summary,
+                "evidence_refs": list(finding.evidence_refs),
+                "confidence": finding.confidence,
+                "status": finding.status,
+            }
+            for finding in report.findings
+        ],
+        "pattern_matches": [
+            {
+                "match_id": match.match_id,
+                "signature_id": match.signature_id,
+                "family_id": match.family_id,
+                "signature_layer": dict(match.signature_layer),
+                "scope_ref": match.scope_ref,
+                "evidence_refs": list(match.evidence_refs),
+                "confidence": match.confidence,
+                "rationale": match.rationale,
+                "source": match.source,
+            }
+            for match in report.pattern_matches
+        ],
+        "evidence_index": [
+            {
+                "ref_id": ref.ref_id,
+                "target_kind": ref.target_kind,
+                "target_ref": ref.target_ref,
+                "role": ref.role,
+                "excerpt": ref.excerpt,
+                "metadata": dict(ref.metadata),
+            }
+            for ref in report.evidence_index
+        ],
         "candidate_break_point": (
             report.candidate_break_point.to_dict()
             if report.candidate_break_point is not None

--- a/driftshield/src/driftshield/reports/models.py
+++ b/driftshield/src/driftshield/reports/models.py
@@ -2,6 +2,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from driftshield.core.models import CandidateBreakPoint
 
@@ -38,6 +39,53 @@ class ReportSection:
 
 
 @dataclass
+class ReportSummary:
+    headline: str = ""
+    what_happened: str = ""
+    where_it_broke: str = ""
+    evidence_basis: str = ""
+    confidence: float | None = None
+    confidence_label: str = "unknown"
+    uncertainty: list[str] = field(default_factory=list)
+    pattern_resemblance: str = ""
+    oss_safety_note: str = ""
+
+
+@dataclass
+class ReportFinding:
+    finding_id: str
+    finding_kind: str
+    subject_ref: str
+    summary: str
+    evidence_refs: list[str] = field(default_factory=list)
+    confidence: float | None = None
+    status: str = "reported"
+
+
+@dataclass
+class PatternMatch:
+    match_id: str
+    signature_id: str
+    family_id: str
+    signature_layer: dict[str, Any]
+    scope_ref: str
+    evidence_refs: list[str] = field(default_factory=list)
+    confidence: float | None = None
+    rationale: str = ""
+    source: str = "local"
+
+
+@dataclass
+class EvidenceRef:
+    ref_id: str
+    target_kind: str
+    target_ref: str
+    role: str
+    excerpt: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class ReportData:
     session_id: uuid.UUID
     agent_id: str
@@ -50,3 +98,8 @@ class ReportData:
     total_events: int = 0
     flagged_events: int = 0
     classification: str = "isolated"
+    schema_version: str = "forensic_report.v1"
+    summary: ReportSummary = field(default_factory=ReportSummary)
+    findings: list[ReportFinding] = field(default_factory=list)
+    pattern_matches: list[PatternMatch] = field(default_factory=list)
+    evidence_index: list[EvidenceRef] = field(default_factory=list)

--- a/driftshield/src/driftshield/reports/templates/full.md.j2
+++ b/driftshield/src/driftshield/reports/templates/full.md.j2
@@ -6,7 +6,37 @@
 **Generated:** {{ report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}
 **Events:** {{ report.total_events }} total, {{ report.flagged_events }} flagged
 
+> OSS safety: {{ report.summary.oss_safety_note }}
+
 ---
+
+## What happened
+
+{{ report.summary.what_happened }}
+
+## Rough break point
+
+{{ report.summary.where_it_broke }}
+
+## Evidence basis
+
+{{ report.summary.evidence_basis }}
+
+## Confidence and uncertainty
+
+**Confidence:** {{ report.summary.confidence_label }}{% if report.summary.confidence is not none %} ({{ '%.2f'|format(report.summary.confidence) }}){% endif %}
+{% if report.summary.uncertainty %}
+
+**Uncertainty:**
+{% for reason in report.summary.uncertainty %}
+- {{ reason }}
+{% endfor %}
+{% endif %}
+
+## Pattern resemblance
+
+{{ report.summary.pattern_resemblance }}
+
 {% for section in report.sections %}
 
 ## {{ loop.index }}. {{ section.title }}
@@ -25,4 +55,12 @@
 - **{{ t.from_node_id | string | truncate(8, False, '') }}** → **{{ t.to_node_id | string | truncate(8, False, '') }}**: {{ t.description }}
 {% endfor %}
 {% endif %}
+{% endfor %}
+
+## Evidence Index
+
+| Ref | Target | Role | Excerpt |
+|---|---|---|---|
+{% for ref in report.evidence_index %}
+| {{ ref.ref_id }} | {{ ref.target_kind }}: {{ ref.target_ref | string | truncate(12, False, '') }} | {{ ref.role }} | {{ ref.excerpt or 'n/a' }} |
 {% endfor %}

--- a/driftshield/src/driftshield/reports/templates/summary.md.j2
+++ b/driftshield/src/driftshield/reports/templates/summary.md.j2
@@ -5,7 +5,33 @@
 **Agent:** {{ report.agent_id }}
 **Generated:** {{ report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}
 
+> OSS safety: {{ report.summary.oss_safety_note }}
+
 ---
+
+## What happened
+
+{{ report.summary.what_happened }}
+
+## Rough break point
+
+{{ report.summary.where_it_broke }}
+
+## Confidence and uncertainty
+
+**Confidence:** {{ report.summary.confidence_label }}{% if report.summary.confidence is not none %} ({{ '%.2f'|format(report.summary.confidence) }}){% endif %}
+{% if report.summary.uncertainty %}
+
+**Uncertainty:**
+{% for reason in report.summary.uncertainty %}
+- {{ reason }}
+{% endfor %}
+{% endif %}
+
+## Pattern resemblance
+
+{{ report.summary.pattern_resemblance }}
+
 {% for section in report.sections %}
 
 ## {{ loop.index }}. {{ section.title }}

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -132,6 +132,10 @@ def test_generated_report_has_real_content(client, auth_headers, seeded_session,
     assert "Forensic Analysis Report" in data["content_markdown"]
     assert data["content_json"]["sections"] is not None
     assert len(data["content_json"]["sections"]) == 4
+    assert data["content_json"]["schema_version"] == "forensic_report.v1"
+    assert data["content_json"]["summary"]["what_happened"]
+    assert data["content_json"]["findings"]
+    assert data["content_json"]["evidence_index"]
     assert data["content_json"]["candidate_break_point"]["status"] == "no_clear_break_point"
     assert "recurrence_probability" not in data["content_json"]
 

--- a/driftshield/tests/cli/test_report_command.py
+++ b/driftshield/tests/cli/test_report_command.py
@@ -36,7 +36,7 @@ def sample_transcript(tmp_path):
         },
     ]
     filepath = tmp_path / "transcript.jsonl"
-    filepath.write_text("\n".join(json.dumps(l) for l in lines))
+    filepath.write_text("\n".join(json.dumps(line) for line in lines))
     return filepath
 
 
@@ -51,6 +51,16 @@ def test_report_command_summary_type(sample_transcript):
     assert result.exit_code == 0
     assert "Forensic Analysis Report" in result.stdout
     assert "Risk State Transition Mapping" not in result.stdout
+
+
+def test_report_command_outputs_json(sample_transcript):
+    result = runner.invoke(app, ["report", str(sample_transcript), "--format", "json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["schema_version"] == "forensic_report.v1"
+    assert data["summary"]["what_happened"]
+    assert data["evidence_index"]
 
 
 def test_report_command_supports_bundled_quickstart_fixture(tmp_path):

--- a/driftshield/tests/reports/test_builder.py
+++ b/driftshield/tests/reports/test_builder.py
@@ -4,7 +4,10 @@ from datetime import datetime, timezone
 import pytest
 
 from driftshield.core.models import (
-    CanonicalEvent, EventType, Session as DomainSession, SessionStatus,
+    CanonicalEvent,
+    EventType,
+    Session as DomainSession,
+    SessionStatus,
 )
 from driftshield.core.analysis.session import analyze_session
 from driftshield.reports.builder import ReportBuilder
@@ -34,6 +37,39 @@ def sample_result():
     return result, session
 
 
+@pytest.fixture
+def failed_report():
+    session_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    risky_event = CanonicalEvent(
+        id=uuid.uuid4(),
+        session_id=str(session_id),
+        timestamp=now,
+        event_type=EventType.TOOL_CALL,
+        agent_id="test-agent",
+        action="review_sections",
+        inputs={"sections": ["intro", "body", "appendix"]},
+        outputs={"reviewed_sections": ["intro", "body"]},
+    )
+    failure_event = CanonicalEvent(
+        id=uuid.uuid4(),
+        session_id=str(session_id),
+        timestamp=now,
+        event_type=EventType.OUTPUT,
+        agent_id="test-agent",
+        action="deliver_answer",
+        parent_event_id=risky_event.id,
+    )
+    result = analyze_session([risky_event, failure_event])
+    session = DomainSession(
+        id=session_id,
+        agent_id="test-agent",
+        started_at=now,
+        status=SessionStatus.FAILED,
+    )
+    return ReportBuilder().build(session, result, report_type=ReportType.FULL)
+
+
 def test_build_full_report(sample_result):
     result, session = sample_result
     builder = ReportBuilder()
@@ -46,7 +82,7 @@ def test_build_full_report(sample_result):
     assert report_data.sections[0].title == "Behavioural Lineage Reconstruction"
     assert report_data.sections[1].title == "Candidate Break Point Assessment"
     assert report_data.sections[2].title == "Risk State Transition Mapping"
-    assert report_data.sections[3].title == "Systemic Exposure Assessment"
+    assert report_data.sections[3].title == "Single-Run Exposure Assessment"
 
 
 def test_build_summary_report(sample_result):
@@ -77,3 +113,47 @@ def test_break_point_section_uses_candidate_break_point_summary(sample_result):
     break_point = report_data.candidate_break_point
     assert break_point is not None
     assert report_data.sections[1].content.startswith(break_point.summary)
+
+
+def test_report_v1_contains_summary_findings_and_evidence_index(failed_report):
+    assert failed_report.schema_version == "forensic_report.v1"
+    assert "observable event" in failed_report.summary.what_happened
+    assert "event #" in failed_report.summary.where_it_broke
+    assert "single-run evidence" in failed_report.summary.oss_safety_note
+    assert "does not claim decision-grade" in failed_report.summary.oss_safety_note
+
+    candidate_findings = [
+        finding
+        for finding in failed_report.findings
+        if finding.finding_kind == "candidate_break_point"
+    ]
+    assert candidate_findings
+    assert all(finding.evidence_refs for finding in failed_report.findings)
+    assert any(ref.target_kind == "decision_node" for ref in failed_report.evidence_index)
+    assert any(ref.ref_id.startswith("node:") for ref in failed_report.evidence_index)
+
+
+def test_report_v1_can_describe_local_pattern_resemblance_from_metadata(sample_result):
+    result, session = sample_result
+    session.metadata = {
+        "signature_match": {
+            "matches": [
+                {
+                    "signature_id": "SIG-COMM-001",
+                    "family_id": "coverage_gap",
+                    "signature_layer": {"symptom": "required evidence skipped"},
+                    "confidence": 0.72,
+                    "rationale": "local community signature matched reviewed event shape",
+                    "evidence_event_refs": [f"node:{result.graph.nodes[0].id}"],
+                    "source": "local",
+                }
+            ]
+        }
+    }
+
+    report = ReportBuilder().build(session, result, report_type=ReportType.FULL)
+
+    assert report.pattern_matches
+    assert report.pattern_matches[0].signature_id == "SIG-COMM-001"
+    assert report.pattern_matches[0].family_id == "coverage_gap"
+    assert "coverage_gap" in report.summary.pattern_resemblance

--- a/driftshield/tests/reports/test_json_export.py
+++ b/driftshield/tests/reports/test_json_export.py
@@ -54,3 +54,16 @@ def test_export_json_section_structure(report_data):
     assert "node_table" in section
     assert data["candidate_break_point"] is not None
     assert data["candidate_break_point"]["status"] == "no_clear_break_point"
+
+
+def test_export_json_includes_forensic_report_v1_contract(report_data):
+    data = export_json(report_data)
+
+    assert data["schema_version"] == "forensic_report.v1"
+    assert data["summary"]["what_happened"]
+    assert "does not claim decision-grade" in data["summary"]["oss_safety_note"]
+    assert data["findings"]
+    assert data["evidence_index"]
+    assert all(item["evidence_refs"] for item in data["findings"])
+    assert "root_cause" not in data
+    assert "recurrence_probability" not in data

--- a/driftshield/tests/reports/test_markdown.py
+++ b/driftshield/tests/reports/test_markdown.py
@@ -43,7 +43,11 @@ def test_render_full_report_markdown(full_report_data):
     assert "Behavioural Lineage Reconstruction" in md
     assert "Candidate Break Point Assessment" in md
     assert "Risk State Transition Mapping" in md
-    assert "Systemic Exposure Assessment" in md
+    assert "Single-Run Exposure Assessment" in md
+    assert "What happened" in md
+    assert "Confidence and uncertainty" in md
+    assert "Evidence Index" in md
+    assert "does not claim decision-grade" in md
 
 
 def test_render_has_node_table(full_report_data):


### PR DESCRIPTION
## Summary
- Adds a versioned forensic_report.v1 contract with OSS-safe summary, findings, evidence index, and optional local pattern matches.
- Updates Markdown rendering to explain what happened, roughly where it broke, confidence/uncertainty, evidence basis, and OSS safety boundaries.
- Adds CLI JSON output via `driftshield report --format json` while preserving existing Markdown output and API report storage.

## Verification
- `uv run --extra dev pytest tests/reports tests/cli/test_report_command.py tests/api/test_reports.py -q`
- `uv run --extra dev pytest tests -q`
- `uv run ruff check src/driftshield/reports src/driftshield/cli/commands/report.py tests/reports tests/cli/test_report_command.py tests/api/test_reports.py`
- `./scripts/check-public-scope.sh`
- `npm run build` in `driftshield/frontend`
- Generated dogfood report smoke test in Markdown and JSON from `tests/fixtures/transcripts/dogfood/constraint_violation_session.jsonl`

## Notes
- Full `uv run ruff check src tests` still reports unrelated pre-existing lint issues outside this change.

Refs tborys/driftshield-meta#70