### PR TITLE
fix: preserve family-only signature summaries in reports

### DIFF
--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -356,7 +356,9 @@ class ReportBuilder:
         match_id = _string_value(payload.get("match_id")) or f"pattern_match:{session.id}:{index}"
 
         if signature_id is not None:
-            resolved_family_id = family_id or family_ids[0]
+            resolved_family_id = family_id or (family_ids[0] if family_ids else None)
+            if resolved_family_id is None:
+                return []
             return [
                 PatternMatch(
                     match_id=match_id,

--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -257,10 +257,7 @@ class ReportBuilder:
                         finding_id=f"finding:pattern_resemblance:{match.match_id}",
                         finding_kind="pattern_resemblance",
                         subject_ref=match.scope_ref,
-                        summary=(
-                            f"Local OSS-safe signals resemble {match.family_id} "
-                            f"via {match.signature_id}."
-                        ),
+                        summary=_pattern_resemblance_finding_summary(match),
                         evidence_refs=(
                             list(match.evidence_refs)
                             if match.evidence_refs
@@ -324,42 +321,72 @@ class ReportBuilder:
         for index, item in enumerate(candidates, start=1):
             if not isinstance(item, Mapping):
                 continue
-            match = self._pattern_match_from_payload(session, item, index)
-            if match is not None:
-                matches.append(match)
+            matches.extend(self._pattern_matches_from_payload(session, item, index))
         return matches
 
-    def _pattern_match_from_payload(
+    def _pattern_matches_from_payload(
         self,
         session: DomainSession,
         payload: Mapping[str, Any],
         index: int,
-    ) -> PatternMatch | None:
+    ) -> list[PatternMatch]:
         signature_id = _string_value(payload.get("signature_id"))
         family_id = _string_value(payload.get("family_id") or payload.get("primary_family_id"))
-        if signature_id is None or family_id is None:
-            return None
+        family_ids = _ordered_family_ids(payload)
+        if family_id is not None and family_id not in family_ids:
+            family_ids.insert(0, family_id)
+
+        if signature_id is None and not family_ids:
+            return []
 
         signature_layer = (
             dict(payload.get("signature_layer"))
             if isinstance(payload.get("signature_layer"), Mapping)
             else {}
         )
+        rationale = _string_value(payload.get("rationale") or payload.get("summary")) or ""
+        if rationale and "symptom" not in signature_layer:
+            signature_layer["symptom"] = rationale
         evidence_refs = _string_list(
             payload.get("evidence_refs") or payload.get("evidence_event_refs")
         )
-        return PatternMatch(
-            match_id=_string_value(payload.get("match_id"))
-            or f"pattern_match:{session.id}:{index}",
-            signature_id=signature_id,
-            family_id=family_id,
-            signature_layer=signature_layer,
-            scope_ref=_string_value(payload.get("scope_ref")) or f"session:{session.id}",
-            evidence_refs=evidence_refs,
-            confidence=_float_value(payload.get("confidence")),
-            rationale=_string_value(payload.get("rationale") or payload.get("summary")) or "",
-            source=_string_value(payload.get("source")) or "local",
-        )
+        scope_ref = _string_value(payload.get("scope_ref")) or f"session:{session.id}"
+        confidence = _float_value(payload.get("confidence"))
+        source = _string_value(payload.get("source")) or "local"
+        match_id = _string_value(payload.get("match_id")) or f"pattern_match:{session.id}:{index}"
+
+        if signature_id is not None:
+            resolved_family_id = family_id or family_ids[0]
+            return [
+                PatternMatch(
+                    match_id=match_id,
+                    signature_id=signature_id,
+                    family_id=resolved_family_id,
+                    signature_layer=signature_layer,
+                    scope_ref=scope_ref,
+                    evidence_refs=evidence_refs,
+                    confidence=confidence,
+                    rationale=rationale,
+                    source=source,
+                )
+            ]
+
+        matches: list[PatternMatch] = []
+        for family_offset, derived_family_id in enumerate(family_ids, start=1):
+            matches.append(
+                PatternMatch(
+                    match_id=f"{match_id}:{family_offset}",
+                    signature_id=f"family:{derived_family_id}",
+                    family_id=derived_family_id,
+                    signature_layer=dict(signature_layer),
+                    scope_ref=scope_ref,
+                    evidence_refs=evidence_refs,
+                    confidence=confidence,
+                    rationale=rationale,
+                    source=source,
+                )
+            )
+        return matches
 
     def _pattern_resemblance_summary(
         self,
@@ -557,6 +584,29 @@ def _confidence_label(confidence: float | None) -> str:
 
 def _plural(noun: str, count: int) -> str:
     return noun if count == 1 else f"{noun}s"
+
+
+def _ordered_family_ids(payload: Mapping[str, Any]) -> list[str]:
+    ordered: list[str] = []
+
+    primary_family_id = _string_value(payload.get("primary_family_id"))
+    if primary_family_id is not None:
+        ordered.append(primary_family_id)
+
+    matched_family_ids = payload.get("matched_family_ids")
+    if isinstance(matched_family_ids, list):
+        for item in matched_family_ids:
+            family_id = _string_value(item)
+            if family_id is not None and family_id not in ordered:
+                ordered.append(family_id)
+
+    return ordered
+
+
+def _pattern_resemblance_finding_summary(match: PatternMatch) -> str:
+    if match.signature_id.startswith("family:"):
+        return f"Local OSS-safe signals resemble {match.family_id}."
+    return f"Local OSS-safe signals resemble {match.family_id} via {match.signature_id}."
 
 
 def _lineage_excerpt(result: AnalysisResult) -> str:

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -309,6 +309,60 @@ def test_generate_report_projects_legacy_family_only_signature_summary(
     assert report.content_json["pattern_matches"][0]["signature_id"] == "family:coverage_gap"
 
 
+def test_generate_report_ignores_signature_only_payload_without_family_fields(
+    client,
+    auth_headers,
+    db_session,
+):
+    session_id = uuid.uuid4()
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            agent_id="legacy-agent",
+            started_at=datetime.now(timezone.utc),
+            status="completed",
+            metadata_json={
+                "signature_summary": {
+                    "signature_id": "sig:test",
+                    "summary": "Incomplete signature payload without family metadata.",
+                }
+            },
+        )
+    )
+    db_session.add_all(
+        [
+            DecisionNodeModel(
+                id=uuid.uuid4(),
+                session_id=session_id,
+                sequence_num=1,
+                event_type="TOOL_CALL",
+                action="review",
+                coverage_gap=True,
+            ),
+            DecisionNodeModel(
+                id=uuid.uuid4(),
+                session_id=session_id,
+                sequence_num=2,
+                event_type="OUTPUT",
+                action="deliver",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = client.post(
+        f"/api/sessions/{session_id}/report",
+        headers=auth_headers,
+        json={"report_type": "full"},
+    )
+
+    assert response.status_code == 201
+
+    report = db_session.get(ReportModel, uuid.UUID(response.json()["id"]))
+    assert report is not None
+    assert report.content_json["pattern_matches"] == []
+
+
 def test_graveyard_summary_route_is_removed(client, auth_headers):
     response = client.get("/api/graveyard/summary", headers=auth_headers)
     assert response.status_code == 404

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -248,6 +248,67 @@ def test_generate_report_preserves_legacy_inflection_fields_for_uncertain_break_
     assert report.content_json["inflection_node_id"] is not None
 
 
+def test_generate_report_projects_legacy_family_only_signature_summary(
+    client,
+    auth_headers,
+    db_session,
+):
+    session_id = uuid.uuid4()
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            agent_id="legacy-agent",
+            started_at=datetime.now(timezone.utc),
+            status="completed",
+            metadata_json={
+                "signature_summary": {
+                    "status": "matched",
+                    "primary_family_id": "coverage_gap",
+                    "matched_family_ids": ["coverage_gap", "verification_failure"],
+                    "match_count": 2,
+                    "summary": "Matched two known failure families.",
+                }
+            },
+        )
+    )
+    db_session.add_all(
+        [
+            DecisionNodeModel(
+                id=uuid.uuid4(),
+                session_id=session_id,
+                sequence_num=1,
+                event_type="TOOL_CALL",
+                action="review",
+                coverage_gap=True,
+            ),
+            DecisionNodeModel(
+                id=uuid.uuid4(),
+                session_id=session_id,
+                sequence_num=2,
+                event_type="OUTPUT",
+                action="deliver",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = client.post(
+        f"/api/sessions/{session_id}/report",
+        headers=auth_headers,
+        json={"report_type": "full"},
+    )
+
+    assert response.status_code == 201
+
+    report = db_session.get(ReportModel, uuid.UUID(response.json()["id"]))
+    assert report is not None
+    assert [match["family_id"] for match in report.content_json["pattern_matches"]] == [
+        "coverage_gap",
+        "verification_failure",
+    ]
+    assert report.content_json["pattern_matches"][0]["signature_id"] == "family:coverage_gap"
+
+
 def test_graveyard_summary_route_is_removed(client, auth_headers):
     response = client.get("/api/graveyard/summary", headers=auth_headers)
     assert response.status_code == 404

--- a/driftshield/tests/reports/test_builder.py
+++ b/driftshield/tests/reports/test_builder.py
@@ -157,3 +157,27 @@ def test_report_v1_can_describe_local_pattern_resemblance_from_metadata(sample_r
     assert report.pattern_matches[0].signature_id == "SIG-COMM-001"
     assert report.pattern_matches[0].family_id == "coverage_gap"
     assert "coverage_gap" in report.summary.pattern_resemblance
+
+
+def test_report_v1_accepts_legacy_family_only_signature_summary(sample_result):
+    result, session = sample_result
+    session.metadata = {
+        "signature_summary": {
+            "status": "matched",
+            "primary_family_id": "coverage_gap",
+            "matched_family_ids": ["coverage_gap", "verification_failure"],
+            "match_count": 2,
+            "summary": "Matched two known failure families.",
+        }
+    }
+
+    report = ReportBuilder().build(session, result, report_type=ReportType.FULL)
+
+    assert [match.family_id for match in report.pattern_matches] == [
+        "coverage_gap",
+        "verification_failure",
+    ]
+    assert report.pattern_matches[0].signature_id == "family:coverage_gap"
+    assert report.pattern_matches[0].rationale == "Matched two known failure families."
+    assert "coverage_gap" in report.summary.pattern_resemblance
+    assert "verification_failure" in report.summary.pattern_resemblance

--- a/driftshield/tests/reports/test_builder.py
+++ b/driftshield/tests/reports/test_builder.py
@@ -181,3 +181,20 @@ def test_report_v1_accepts_legacy_family_only_signature_summary(sample_result):
     assert report.pattern_matches[0].rationale == "Matched two known failure families."
     assert "coverage_gap" in report.summary.pattern_resemblance
     assert "verification_failure" in report.summary.pattern_resemblance
+
+
+def test_report_v1_ignores_signature_only_payload_without_family_fields(sample_result):
+    result, session = sample_result
+    session.metadata = {
+        "signature_summary": {
+            "signature_id": "sig:test",
+            "summary": "Incomplete signature payload without family metadata.",
+        }
+    }
+
+    report = ReportBuilder().build(session, result, report_type=ReportType.FULL)
+
+    assert report.pattern_matches == []
+    assert report.summary.pattern_resemblance == (
+        "No local pattern resemblance was available from OSS-safe signals."
+    )


### PR DESCRIPTION
## Summary
- preserve report pattern-resemblance output when session metadata only contains legacy family-level signature summary fields
- synthesize stable local pattern matches from primary_family_id and matched_family_ids instead of silently dropping them
- add regression coverage for builder and API report generation on the existing family-only metadata shape

## Why
Codex correctly flagged that the OSS report v1 builder only accepted metadata with signature_id, which dropped the repo's existing signature_summary / signature_match family-level shape from forensic reports.

## Verification
- uv run --extra dev pytest tests/reports/test_builder.py tests/api/test_reports.py -q
- uv run --extra dev pytest tests/reports tests/api/test_reports.py tests/api/test_sessions.py -q
- uv run ruff check src/driftshield/reports tests/reports tests/api/test_reports.py tests/api/test_sessions.py

Refs tborys/driftshield-meta#70