### PR TITLE
feat(api): add end-to-end forensic report workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ source .venv/bin/activate
 driftshield ingest --latest
 ```
 
+### Generate a forensic report through the API
+
+With the backend running and `API_KEY` exported from `driftshield/.env`, upload a
+transcript directly to the API and get the persisted `forensic_report.v1` payload
+back in one call:
+
+```bash
+cd driftshield
+source .venv/bin/activate
+set -a
+source .env
+set +a
+curl -sS \
+  -X POST http://localhost:8080/api/forensics/report \
+  -H "X-API-Key: $API_KEY" \
+  -F "file=@tests/fixtures/transcripts/sample_claude_code_session.jsonl" \
+  -F "format=claude_code" \
+  -F "report_type=summary"
+```
+
+This returns the ingested `session_id`, persisted forensic case metadata, and the
+full JSON report contract that the CLI and dashboard surfaces share.
+
 ## How It Works
 
 ```
@@ -206,6 +229,9 @@ driftshield inspect <file.jsonl> --node 0
 
 # Generate a report
 driftshield report <file.jsonl>
+
+# Generate a JSON report contract from the CLI
+driftshield report <file.jsonl> --format json
 
 # Discover available transcript sources
 driftshield connectors list

--- a/docs/oss-bootstrap-verification.md
+++ b/docs/oss-bootstrap-verification.md
@@ -58,6 +58,49 @@ This command validates:
 - bundled sample report generation
 - ingest API smoke tests
 
+## Manual forensic workflow smoke paths
+
+These checks cover the operator-facing CLI and API paths for the Phase 2b forensic
+workflow.
+
+### CLI smoke
+
+From `driftshield/` after setup:
+
+```bash
+source .venv/bin/activate
+driftshield report tests/fixtures/transcripts/sample_claude_code_session.jsonl --format json
+```
+
+Expected result:
+- exit code `0`
+- response includes `"schema_version": "forensic_report.v1"`
+- response includes a non-empty `summary.what_happened`
+
+### API smoke
+
+With the backend running and `API_KEY` exported from `driftshield/.env`:
+
+```bash
+cd driftshield
+source .venv/bin/activate
+set -a
+source .env
+set +a
+curl -sS \
+  -X POST http://localhost:8080/api/forensics/report \
+  -H "X-API-Key: $API_KEY" \
+  -F "file=@tests/fixtures/transcripts/sample_claude_code_session.jsonl" \
+  -F "format=claude_code" \
+  -F "report_type=summary"
+```
+
+Expected result:
+- first run returns HTTP `201`; repeat upload of the same file returns HTTP `200`
+- payload includes `report.content_json.schema_version = "forensic_report.v1"`
+- payload includes `forensic_case.state = "reported"`
+- repeat upload reuses the same `session_id`
+
 ## OSS boundary checks
 
 When updating docs or workflows, avoid presenting these as bundled OSS

--- a/driftshield/src/driftshield/api/ingest_workflow.py
+++ b/driftshield/src/driftshield/api/ingest_workflow.py
@@ -1,0 +1,97 @@
+import hashlib
+import os
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session as DBSession
+
+from driftshield.cli.parsers import PARSERS
+from driftshield.core.analysis.session import AnalysisResult
+from driftshield.db.ingest_service import TranscriptIngestService, metrics_payload_from_analysis_result
+from driftshield.db.persistence import IngestOutcome, IngestProvenance, PersistenceService
+from driftshield.telemetry import TelemetryService
+
+
+def detect_format(filename: str | None) -> str:
+    if filename and filename.endswith(".jsonl"):
+        return "claude_code"
+    return "unknown"
+
+
+def resolve_format(format_name: str, filename: str | None) -> str:
+    normalised = format_name.replace("-", "_")
+    if normalised == "auto":
+        normalised = detect_format(filename)
+    if normalised not in PARSERS:
+        raise HTTPException(status_code=422, detail=f"Unsupported format: {format_name}")
+    return normalised
+
+
+def ingest_transcript_bytes(
+    db: DBSession,
+    *,
+    raw_bytes: bytes,
+    format_name: str,
+    filename: str | None,
+) -> tuple[IngestOutcome, AnalysisResult | None, str]:
+    normalised = resolve_format(format_name, filename)
+    _validate_request_size(raw_bytes)
+
+    ingest_service = TranscriptIngestService(db)
+    try:
+        outcome, analysis_result = ingest_service.ingest_bytes(
+            raw_bytes=raw_bytes,
+            parser_name=normalised,
+            source_path=filename,
+        )
+        db.commit()
+        if not outcome.deduplicated and analysis_result is not None:
+            _record_analysis_telemetry(analysis_result)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except IntegrityError:
+        db.rollback()
+        outcome = PersistenceService(db).get_ingest_outcome(
+            IngestProvenance(
+                transcript_hash=hashlib.sha256(raw_bytes).hexdigest(),
+                source_session_id=None,
+                source_path=filename,
+                parser_version=f"{normalised}@1",
+                ingested_at=datetime.now(timezone.utc),
+            )
+        )
+        if outcome is None:
+            raise
+        analysis_result = None
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=422,
+            detail=f"Failed to process transcript: {exc}",
+        ) from exc
+
+    return outcome, analysis_result, normalised
+
+
+def _record_analysis_telemetry(result: AnalysisResult) -> None:
+    metrics = metrics_payload_from_analysis_result(result)
+    try:
+        TelemetryService().record_analysis_event(
+            outcome_status=metrics["outcome_status"],
+            match_count=metrics["match_count"],
+            primary_family_id=metrics["primary_family_id"],
+            mixed_family=metrics["mixed_family"],
+            not_classifiable_reason=metrics["not_classifiable_reason"],
+        )
+    except Exception:
+        pass
+
+
+def _validate_request_size(raw_bytes: bytes) -> None:
+    max_request_bytes = int(os.environ.get("MAX_REQUEST_BYTES", str(25 * 1024 * 1024)))
+    if len(raw_bytes) > max_request_bytes:
+        raise HTTPException(status_code=413, detail=f"Request body exceeds {max_request_bytes} bytes")

--- a/driftshield/src/driftshield/api/ingest_workflow.py
+++ b/driftshield/src/driftshield/api/ingest_workflow.py
@@ -1,11 +1,11 @@
 import hashlib
-import os
 from datetime import datetime, timezone
 
-from fastapi import HTTPException
+from fastapi import HTTPException, UploadFile
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DBSession
 
+from driftshield.api.security import get_max_request_bytes
 from driftshield.cli.parsers import PARSERS
 from driftshield.core.analysis.session import AnalysisResult
 from driftshield.db.ingest_service import TranscriptIngestService, metrics_payload_from_analysis_result
@@ -34,6 +34,7 @@ def ingest_transcript_bytes(
     raw_bytes: bytes,
     format_name: str,
     filename: str | None,
+    commit: bool = True,
 ) -> tuple[IngestOutcome, AnalysisResult | None, str]:
     normalised = resolve_format(format_name, filename)
     _validate_request_size(raw_bytes)
@@ -45,9 +46,10 @@ def ingest_transcript_bytes(
             parser_name=normalised,
             source_path=filename,
         )
-        db.commit()
-        if not outcome.deduplicated and analysis_result is not None:
-            _record_analysis_telemetry(analysis_result)
+        if commit:
+            db.commit()
+            if not outcome.deduplicated and analysis_result is not None:
+                record_analysis_telemetry(analysis_result)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except IntegrityError:
@@ -77,7 +79,29 @@ def ingest_transcript_bytes(
     return outcome, analysis_result, normalised
 
 
-def _record_analysis_telemetry(result: AnalysisResult) -> None:
+def read_upload_bytes(
+    file: UploadFile,
+    *,
+    chunk_size: int = 1024 * 1024,
+) -> bytes:
+    max_request_bytes = get_max_request_bytes()
+    total_bytes = 0
+    chunks: list[bytes] = []
+
+    while True:
+        chunk = file.file.read(chunk_size)
+        if not chunk:
+            break
+
+        total_bytes += len(chunk)
+        if total_bytes > max_request_bytes:
+            raise HTTPException(status_code=413, detail=f"Request body exceeds {max_request_bytes} bytes")
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+def record_analysis_telemetry(result: AnalysisResult) -> None:
     metrics = metrics_payload_from_analysis_result(result)
     try:
         TelemetryService().record_analysis_event(
@@ -92,6 +116,6 @@ def _record_analysis_telemetry(result: AnalysisResult) -> None:
 
 
 def _validate_request_size(raw_bytes: bytes) -> None:
-    max_request_bytes = int(os.environ.get("MAX_REQUEST_BYTES", str(25 * 1024 * 1024)))
+    max_request_bytes = get_max_request_bytes()
     if len(raw_bytes) > max_request_bytes:
         raise HTTPException(status_code=413, detail=f"Request body exceeds {max_request_bytes} bytes")

--- a/driftshield/src/driftshield/api/routes/ingest.py
+++ b/driftshield/src/driftshield/api/routes/ingest.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session as DBSession
 
 from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
-from driftshield.api.ingest_workflow import ingest_transcript_bytes
+from driftshield.api.ingest_workflow import ingest_transcript_bytes, read_upload_bytes
 from driftshield.api.schemas import IngestResponse
 
 router = APIRouter()
@@ -18,7 +18,7 @@ def ingest_transcript(
     db: DBSession = Depends(get_db),
 ):
     del api_key
-    raw_bytes = file.file.read()
+    raw_bytes = read_upload_bytes(file)
     outcome, _, _ = ingest_transcript_bytes(
         db,
         raw_bytes=raw_bytes,

--- a/driftshield/src/driftshield/api/routes/ingest.py
+++ b/driftshield/src/driftshield/api/routes/ingest.py
@@ -1,18 +1,10 @@
-import hashlib
-import os
-from datetime import datetime, timezone
-
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
-from sqlalchemy.exc import IntegrityError
+from fastapi import APIRouter, Depends, File, Form, Response, UploadFile
 from sqlalchemy.orm import Session as DBSession
 
 from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
+from driftshield.api.ingest_workflow import ingest_transcript_bytes
 from driftshield.api.schemas import IngestResponse
-from driftshield.cli.parsers import PARSERS
-from driftshield.db.ingest_service import TranscriptIngestService, metrics_payload_from_analysis_result
-from driftshield.db.persistence import IngestProvenance, PersistenceService
-from driftshield.telemetry import TelemetryService
 
 router = APIRouter()
 
@@ -26,58 +18,13 @@ def ingest_transcript(
     db: DBSession = Depends(get_db),
 ):
     del api_key
-
-    normalised = format.replace("-", "_")
-    if normalised == "auto":
-        normalised = _detect_format(file.filename)
-    if normalised not in PARSERS:
-        raise HTTPException(status_code=422, detail=f"Unsupported format: {format}")
-
     raw_bytes = file.file.read()
-    max_request_bytes = int(os.environ.get("MAX_REQUEST_BYTES", str(25 * 1024 * 1024)))
-    if len(raw_bytes) > max_request_bytes:
-        raise HTTPException(status_code=413, detail=f"Request body exceeds {max_request_bytes} bytes")
-    ingest_service = TranscriptIngestService(db)
-    try:
-        outcome, analysis_result = ingest_service.ingest_bytes(
-            raw_bytes=raw_bytes,
-            parser_name=normalised,
-            source_path=file.filename,
-        )
-        db.commit()
-        if not outcome.deduplicated and analysis_result is not None:
-            metrics = metrics_payload_from_analysis_result(analysis_result)
-            try:
-                TelemetryService().record_analysis_event(
-                    outcome_status=metrics["outcome_status"],
-                    match_count=metrics["match_count"],
-                    primary_family_id=metrics["primary_family_id"],
-                    mixed_family=metrics["mixed_family"],
-                    not_classifiable_reason=metrics["not_classifiable_reason"],
-                )
-            except Exception:
-                pass
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    except IntegrityError:
-        db.rollback()
-        outcome = PersistenceService(db).get_ingest_outcome(
-            IngestProvenance(
-                transcript_hash=hashlib.sha256(raw_bytes).hexdigest(),
-                source_session_id=None,
-                source_path=file.filename,
-                parser_version=f"{normalised}@1",
-                ingested_at=datetime.now(timezone.utc),
-            )
-        )
-        if outcome is None:
-            raise
-    except Exception as exc:
-        db.rollback()
-        raise HTTPException(
-            status_code=422,
-            detail=f"Failed to process transcript: {exc}",
-        ) from exc
+    outcome, _, _ = ingest_transcript_bytes(
+        db,
+        raw_bytes=raw_bytes,
+        format_name=format,
+        filename=file.filename,
+    )
 
     if outcome.deduplicated:
         response.status_code = 200
@@ -90,9 +37,3 @@ def ingest_transcript(
         status=outcome.status,
         deduplicated=outcome.deduplicated,
     )
-
-
-def _detect_format(filename: str | None) -> str:
-    if filename and filename.endswith(".jsonl"):
-        return "claude_code"
-    return "unknown"

--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -6,7 +6,11 @@ from sqlalchemy.orm import Session as DBSession
 
 from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
-from driftshield.api.ingest_workflow import ingest_transcript_bytes
+from driftshield.api.ingest_workflow import (
+    ingest_transcript_bytes,
+    read_upload_bytes,
+    record_analysis_telemetry,
+)
 from driftshield.api.schemas import (
     ForensicCaseResponse,
     ForensicWorkflowResponse,
@@ -57,39 +61,48 @@ def generate_forensic_report(
 ):
     del api_key
     requested_report_type = _parse_report_type(report_type)
-    raw_bytes = file.file.read()
-    outcome, _, parser_name = ingest_transcript_bytes(
-        db,
-        raw_bytes=raw_bytes,
-        format_name=format,
-        filename=file.filename,
-    )
+    raw_bytes = read_upload_bytes(file)
 
-    if outcome.deduplicated:
-        existing_report = _load_existing_report_for_case(
+    try:
+        outcome, analysis_result, parser_name = ingest_transcript_bytes(
+            db,
+            raw_bytes=raw_bytes,
+            format_name=format,
+            filename=file.filename,
+            commit=False,
+        )
+
+        if outcome.deduplicated:
+            existing_report = _load_existing_report_for_case(
+                session_id=outcome.session_id,
+                report_type=requested_report_type,
+                db=db,
+            )
+            if existing_report is not None:
+                report, forensic_case = existing_report
+                response.status_code = 200
+                return ForensicWorkflowResponse(
+                    session_id=outcome.session_id,
+                    ingest_status=outcome.status,
+                    deduplicated=outcome.deduplicated,
+                    parser_name=parser_name,
+                    source_path=file.filename,
+                    report=_report_response(report),
+                    forensic_case=_forensic_case_response(forensic_case),
+                )
+
+        report, forensic_case = _create_report_for_session(
             session_id=outcome.session_id,
             report_type=requested_report_type,
             db=db,
         )
-        if existing_report is not None:
-            report, forensic_case = existing_report
-            response.status_code = 200
-            return ForensicWorkflowResponse(
-                session_id=outcome.session_id,
-                ingest_status=outcome.status,
-                deduplicated=outcome.deduplicated,
-                parser_name=parser_name,
-                source_path=file.filename,
-                report=_report_response(report),
-                forensic_case=_forensic_case_response(forensic_case),
-            )
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
 
-    report, forensic_case = _create_report_for_session(
-        session_id=outcome.session_id,
-        report_type=requested_report_type,
-        db=db,
-    )
-    db.commit()
+    if not outcome.deduplicated and analysis_result is not None:
+        record_analysis_telemetry(analysis_result)
 
     return ForensicWorkflowResponse(
         session_id=outcome.session_id,

--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -1,14 +1,22 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
 from pydantic import BaseModel
 from sqlalchemy.orm import Session as DBSession
 
 from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
+from driftshield.api.ingest_workflow import ingest_transcript_bytes
+from driftshield.api.schemas import (
+    ForensicCaseResponse,
+    ForensicWorkflowResponse,
+    GeneratedReportResponse,
+)
 from driftshield.core.analysis.inflection import select_inflection_node
 from driftshield.core.analysis.session import AnalysisResult
-from driftshield.db.models import SessionModel, ReportModel
+from driftshield.core.graph.models import LineageGraph
+from driftshield.core.models import ForensicCase
+from driftshield.db.models import ReportModel
 from driftshield.db.persistence import PersistenceService
 from driftshield.reports.builder import ReportBuilder
 from driftshield.reports.json_export import export_json
@@ -29,55 +37,53 @@ def generate_report(
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
 ):
-    session_model = db.get(SessionModel, session_id)
-    if session_model is None:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    service = PersistenceService(db)
-    domain_session = service.load_session(session_id)
-    graph = service.load_graph(session_id)
-
-    if graph is None:
-        raise HTTPException(status_code=404, detail="No graph data for session")
-
-    # Reconstruct AnalysisResult from stored data
-    selection = select_inflection_node(graph, graph.nodes[-1].id) if graph.nodes else None
-    events = [node.event for node in graph.nodes]
-    flagged = sum(
-        1 for e in events if e.risk_classification and e.risk_classification.has_any_flag()
-    )
-
-    result = AnalysisResult(
-        events=events,
-        graph=graph,
-        inflection_node=selection.node if selection is not None else None,
-        total_events=len(events),
-        flagged_events=flagged,
-        inflection_explanation=selection.explanation if selection is not None else None,
-        candidate_break_point=selection.candidate_break_point if selection is not None else None,
-    )
-
-    report_type = ReportType(request.report_type)
-    builder = ReportBuilder()
-    report_data = builder.build(domain_session, result, report_type=report_type)
-
-    md = render_markdown(report_data)
-    json_content = export_json(report_data)
-
-    report = ReportModel(
-        id=uuid.uuid4(),
+    del api_key
+    report, _ = _create_report_for_session(
         session_id=session_id,
-        generated_at=report_data.generated_at,
-        report_type=report_type.value,
-        content_markdown=md,
-        content_json=json_content,
-        generated_by="system",
+        report_type=_parse_report_type(request.report_type),
+        db=db,
     )
-    db.add(report)
-    db.flush()
-    service.upsert_forensic_case(domain_session, result, report=report)
-
     return {"id": report.id, "report_type": report.report_type}
+
+
+@router.post("/api/forensics/report", response_model=ForensicWorkflowResponse, status_code=201)
+def generate_forensic_report(
+    response: Response,
+    file: UploadFile = File(...),
+    format: str = Form(default="auto"),
+    report_type: str = Form(default="full"),
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+):
+    del api_key
+    requested_report_type = _parse_report_type(report_type)
+    raw_bytes = file.file.read()
+    outcome, _, parser_name = ingest_transcript_bytes(
+        db,
+        raw_bytes=raw_bytes,
+        format_name=format,
+        filename=file.filename,
+    )
+
+    report, forensic_case = _create_report_for_session(
+        session_id=outcome.session_id,
+        report_type=requested_report_type,
+        db=db,
+    )
+    db.commit()
+
+    if outcome.deduplicated:
+        response.status_code = 200
+
+    return ForensicWorkflowResponse(
+        session_id=outcome.session_id,
+        ingest_status=outcome.status,
+        deduplicated=outcome.deduplicated,
+        parser_name=parser_name,
+        source_path=file.filename,
+        report=_report_response(report),
+        forensic_case=_forensic_case_response(forensic_case),
+    )
 
 
 @router.get("/api/sessions/{session_id}/reports")
@@ -121,3 +127,86 @@ def get_report(
         "content_json": report.content_json,
         "generated_by": report.generated_by,
     }
+
+
+def _create_report_for_session(
+    *,
+    session_id: uuid.UUID,
+    report_type: ReportType,
+    db: DBSession,
+) -> tuple[ReportModel, ForensicCase]:
+    service = PersistenceService(db)
+    domain_session = service.load_session(session_id)
+    if domain_session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    graph = service.load_graph(session_id)
+    if graph is None:
+        raise HTTPException(status_code=404, detail="No graph data for session")
+
+    result = _analysis_result_from_graph(graph)
+    report_data = ReportBuilder().build(domain_session, result, report_type=report_type)
+
+    report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=session_id,
+        generated_at=report_data.generated_at,
+        report_type=report_type.value,
+        content_markdown=render_markdown(report_data),
+        content_json=export_json(report_data),
+        generated_by="system",
+    )
+    db.add(report)
+    db.flush()
+    forensic_case = service.upsert_forensic_case(domain_session, result, report=report)
+    return report, forensic_case
+
+
+def _analysis_result_from_graph(graph: LineageGraph) -> AnalysisResult:
+    selection = select_inflection_node(graph, graph.nodes[-1].id) if graph.nodes else None
+    events = [node.event for node in graph.nodes]
+    flagged = sum(
+        1 for event in events if event.risk_classification and event.risk_classification.has_any_flag()
+    )
+    return AnalysisResult(
+        events=events,
+        graph=graph,
+        inflection_node=selection.node if selection is not None else None,
+        total_events=len(events),
+        flagged_events=flagged,
+        inflection_explanation=selection.explanation if selection is not None else None,
+        candidate_break_point=selection.candidate_break_point if selection is not None else None,
+    )
+
+
+def _parse_report_type(value: str) -> ReportType:
+    try:
+        return ReportType(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"Unsupported report type: {value}") from exc
+
+
+def _report_response(report: ReportModel) -> GeneratedReportResponse:
+    return GeneratedReportResponse(
+        id=report.id,
+        session_id=report.session_id,
+        generated_at=report.generated_at,
+        report_type=report.report_type,
+        content_markdown=report.content_markdown,
+        content_json=report.content_json,
+        generated_by=report.generated_by,
+    )
+
+
+def _forensic_case_response(forensic_case: ForensicCase) -> ForensicCaseResponse:
+    return ForensicCaseResponse(
+        id=forensic_case.id,
+        session_id=forensic_case.session_id,
+        state=forensic_case.state.value,
+        report_id=forensic_case.report_id,
+        artifact_refs=[ref.to_dict() for ref in forensic_case.artifact_refs],
+        review_refs=list(forensic_case.review_refs),
+        audit_refs=list(forensic_case.audit_refs),
+        created_at=forensic_case.created_at,
+        updated_at=forensic_case.updated_at,
+    )

--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -65,15 +65,31 @@ def generate_forensic_report(
         filename=file.filename,
     )
 
+    if outcome.deduplicated:
+        existing_report = _load_existing_report_for_case(
+            session_id=outcome.session_id,
+            report_type=requested_report_type,
+            db=db,
+        )
+        if existing_report is not None:
+            report, forensic_case = existing_report
+            response.status_code = 200
+            return ForensicWorkflowResponse(
+                session_id=outcome.session_id,
+                ingest_status=outcome.status,
+                deduplicated=outcome.deduplicated,
+                parser_name=parser_name,
+                source_path=file.filename,
+                report=_report_response(report),
+                forensic_case=_forensic_case_response(forensic_case),
+            )
+
     report, forensic_case = _create_report_for_session(
         session_id=outcome.session_id,
         report_type=requested_report_type,
         db=db,
     )
     db.commit()
-
-    if outcome.deduplicated:
-        response.status_code = 200
 
     return ForensicWorkflowResponse(
         session_id=outcome.session_id,
@@ -159,6 +175,24 @@ def _create_report_for_session(
     db.add(report)
     db.flush()
     forensic_case = service.upsert_forensic_case(domain_session, result, report=report)
+    return report, forensic_case
+
+
+def _load_existing_report_for_case(
+    *,
+    session_id: uuid.UUID,
+    report_type: ReportType,
+    db: DBSession,
+) -> tuple[ReportModel, ForensicCase] | None:
+    service = PersistenceService(db)
+    forensic_case = service.load_case_for_session(session_id)
+    if forensic_case is None or forensic_case.report_id is None:
+        return None
+
+    report = db.get(ReportModel, forensic_case.report_id)
+    if report is None or report.report_type != report_type.value:
+        return None
+
     return report, forensic_case
 
 

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -114,6 +114,38 @@ class IngestResponse(BaseModel):
     deduplicated: bool = False
 
 
+class GeneratedReportResponse(BaseModel):
+    id: uuid.UUID
+    session_id: uuid.UUID
+    generated_at: datetime
+    report_type: str
+    content_markdown: str | None = None
+    content_json: dict[str, Any] | None = None
+    generated_by: str | None = None
+
+
+class ForensicCaseResponse(BaseModel):
+    id: uuid.UUID
+    session_id: uuid.UUID
+    state: str
+    report_id: uuid.UUID | None = None
+    artifact_refs: list[dict[str, Any]] = Field(default_factory=list)
+    review_refs: list[str] = Field(default_factory=list)
+    audit_refs: list[str] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class ForensicWorkflowResponse(BaseModel):
+    session_id: uuid.UUID
+    ingest_status: str
+    deduplicated: bool = False
+    parser_name: str
+    source_path: str | None = None
+    report: GeneratedReportResponse
+    forensic_case: ForensicCaseResponse
+
+
 class ConnectorResponse(BaseModel):
     id: uuid.UUID
     source_type: str

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException, UploadFile
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
@@ -12,6 +13,7 @@ from sqlalchemy.orm import Session as DBSession
 from sqlalchemy.pool import StaticPool
 
 from driftshield.api.app import create_app
+from driftshield.api.ingest_workflow import read_upload_bytes
 from driftshield.db.models import Base, DecisionNodeModel, SessionModel
 from driftshield.db.ingest_service import TranscriptIngestService
 from driftshield.db.persistence import IngestOutcome, PersistenceService
@@ -271,6 +273,28 @@ def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample
         "deduplicated": True,
     }
     assert emit_calls == []
+
+
+def test_read_upload_bytes_stops_once_payload_exceeds_limit(monkeypatch):
+    class TrackingStream(io.BytesIO):
+        def __init__(self, payload: bytes):
+            super().__init__(payload)
+            self.bytes_served = 0
+
+        def read(self, size=-1):
+            chunk = super().read(size)
+            self.bytes_served += len(chunk)
+            return chunk
+
+    monkeypatch.setenv("MAX_REQUEST_BYTES", "25")
+    stream = TrackingStream(b"x" * 100)
+    file = UploadFile(filename="oversized.jsonl", file=stream)
+
+    with pytest.raises(HTTPException) as exc_info:
+        read_upload_bytes(file, chunk_size=10)
+
+    assert exc_info.value.status_code == 413
+    assert stream.bytes_served == 30
 
 
 def test_ingest_crewai_transcript_with_explicit_parser(client, auth_headers):

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -250,9 +250,12 @@ def test_ingest_recovers_from_duplicate_commit_race(client, auth_headers, sample
         emit_calls.append(kwargs)
         return True
 
-    monkeypatch.setattr("driftshield.api.routes.ingest.TranscriptIngestService.ingest_bytes", fake_ingest_bytes)
+    monkeypatch.setattr("driftshield.api.ingest_workflow.TranscriptIngestService.ingest_bytes", fake_ingest_bytes)
     monkeypatch.setattr(PersistenceService, "get_ingest_outcome", fake_get_ingest_outcome)
-    monkeypatch.setattr("driftshield.api.routes.ingest.TelemetryService.record_analysis_event", fake_record_analysis_event)
+    monkeypatch.setattr(
+        "driftshield.api.ingest_workflow.TelemetryService.record_analysis_event",
+        fake_record_analysis_event,
+    )
 
     response = _post_ingest(client, auth_headers, sample_transcript)
 
@@ -426,7 +429,7 @@ def test_ingest_succeeds_even_when_post_commit_telemetry_emit_fails(client, auth
         raise OSError("disk full")
 
     monkeypatch.setattr(
-        "driftshield.api.routes.ingest.TelemetryService.record_analysis_event",
+        "driftshield.api.ingest_workflow.TelemetryService.record_analysis_event",
         fail_record_analysis_event,
     )
 

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -1,3 +1,5 @@
+import io
+import json
 import uuid
 from datetime import datetime, timezone
 
@@ -48,6 +50,42 @@ def auth_headers():
 
 
 @pytest.fixture
+def sample_transcript():
+    lines = [
+        {
+            "sessionId": "forensic-workflow-session-123",
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool_1",
+                        "name": "Read",
+                        "input": {"file_path": "/tmp/evidence.txt"},
+                    }
+                ]
+            },
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+        {
+            "sessionId": "forensic-workflow-session-123",
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool_1",
+                        "content": "contents",
+                    }
+                ]
+            },
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+    ]
+    return "\n".join(json.dumps(line) for line in lines).encode()
+
+
+@pytest.fixture
 def seeded_session(db_session):
     session_id = uuid.uuid4()
     s = SessionModel(
@@ -72,6 +110,94 @@ def test_generate_report(client, auth_headers, seeded_session):
     data = response.json()
     assert "id" in data
     assert data["report_type"] == "full"
+
+
+def test_generate_report_rejects_unknown_report_type(client, auth_headers, seeded_session):
+    response = client.post(
+        f"/api/sessions/{seeded_session}/report",
+        headers=auth_headers,
+        json={"report_type": "unknown"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Unsupported report type: unknown"
+
+
+def test_generate_forensic_report_from_transcript_returns_forensic_contract(
+    client,
+    auth_headers,
+    sample_transcript,
+):
+    response = client.post(
+        "/api/forensics/report",
+        headers=auth_headers,
+        files={"file": ("sample.jsonl", io.BytesIO(sample_transcript), "application/jsonl")},
+        data={"format": "claude_code", "report_type": "summary"},
+    )
+
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["ingest_status"] == "created"
+    assert data["deduplicated"] is False
+    assert data["parser_name"] == "claude_code"
+    assert data["report"]["report_type"] == "summary"
+    assert data["report"]["content_json"]["schema_version"] == "forensic_report.v1"
+    assert data["report"]["content_json"]["summary"]["what_happened"]
+    assert data["forensic_case"]["state"] == "reported"
+    assert data["forensic_case"]["report_id"] == data["report"]["id"]
+
+
+def test_generate_forensic_report_rejects_unknown_report_type_without_ingesting(
+    client,
+    auth_headers,
+    sample_transcript,
+    db_session,
+):
+    response = client.post(
+        "/api/forensics/report",
+        headers=auth_headers,
+        files={"file": ("sample.jsonl", io.BytesIO(sample_transcript), "application/jsonl")},
+        data={"format": "claude_code", "report_type": "unknown"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Unsupported report type: unknown"
+    assert db_session.query(SessionModel).count() == 0
+    assert db_session.query(ReportModel).count() == 0
+
+
+def test_generate_forensic_report_reuses_session_for_duplicate_upload(
+    client,
+    auth_headers,
+    sample_transcript,
+    db_session,
+):
+    first = client.post(
+        "/api/forensics/report",
+        headers=auth_headers,
+        files={"file": ("sample.jsonl", io.BytesIO(sample_transcript), "application/jsonl")},
+        data={"format": "claude_code", "report_type": "full"},
+    )
+    second = client.post(
+        "/api/forensics/report",
+        headers=auth_headers,
+        files={"file": ("sample.jsonl", io.BytesIO(sample_transcript), "application/jsonl")},
+        data={"format": "claude_code", "report_type": "full"},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+
+    first_data = first.json()
+    second_data = second.json()
+    assert second_data["deduplicated"] is True
+    assert second_data["ingest_status"] == "deduped"
+    assert second_data["session_id"] == first_data["session_id"]
+    assert second_data["report"]["id"] != first_data["report"]["id"]
+
+    assert db_session.query(SessionModel).count() == 1
+    assert db_session.query(ReportModel).count() == 2
 
 
 def test_list_reports_for_session(client, auth_headers, seeded_session, db_session):

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -194,10 +194,10 @@ def test_generate_forensic_report_reuses_session_for_duplicate_upload(
     assert second_data["deduplicated"] is True
     assert second_data["ingest_status"] == "deduped"
     assert second_data["session_id"] == first_data["session_id"]
-    assert second_data["report"]["id"] != first_data["report"]["id"]
+    assert second_data["report"]["id"] == first_data["report"]["id"]
 
     assert db_session.query(SessionModel).count() == 1
-    assert db_session.query(ReportModel).count() == 2
+    assert db_session.query(ReportModel).count() == 1
 
 
 def test_list_reports_for_session(client, auth_headers, seeded_session, db_session):

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -19,7 +19,7 @@ from driftshield.core.models import (
     Session as DomainSession,
     SessionStatus,
 )
-from driftshield.db.models import Base, SessionModel, DecisionNodeModel, ReportModel
+from driftshield.db.models import Base, DecisionNodeModel, ForensicCaseModel, ReportModel, SessionModel
 from driftshield.db.persistence import PersistenceService
 
 
@@ -198,6 +198,43 @@ def test_generate_forensic_report_reuses_session_for_duplicate_upload(
 
     assert db_session.query(SessionModel).count() == 1
     assert db_session.query(ReportModel).count() == 1
+
+
+def test_generate_forensic_report_rolls_back_ingest_when_report_build_fails(
+    client,
+    auth_headers,
+    sample_transcript,
+    db_session,
+    monkeypatch,
+):
+    def fail_build(self, session, result, report_type):
+        raise RuntimeError("report builder failed")
+
+    emit_calls = []
+
+    def fake_record_analysis_event(self, **kwargs):
+        emit_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr("driftshield.api.routes.reports.ReportBuilder.build", fail_build)
+    monkeypatch.setattr(
+        "driftshield.api.ingest_workflow.TelemetryService.record_analysis_event",
+        fake_record_analysis_event,
+    )
+
+    with pytest.raises(RuntimeError, match="report builder failed"):
+        client.post(
+            "/api/forensics/report",
+            headers=auth_headers,
+            files={"file": ("sample.jsonl", io.BytesIO(sample_transcript), "application/jsonl")},
+            data={"format": "claude_code", "report_type": "summary"},
+        )
+
+    assert db_session.query(SessionModel).count() == 0
+    assert db_session.query(DecisionNodeModel).count() == 0
+    assert db_session.query(ForensicCaseModel).count() == 0
+    assert db_session.query(ReportModel).count() == 0
+    assert emit_calls == []
 
 
 def test_list_reports_for_session(client, auth_headers, seeded_session, db_session):


### PR DESCRIPTION
## Summary
- add `/api/forensics/report` so one API call can ingest a transcript, generate a persisted forensic report, and return the `forensic_report.v1` payload
- extract shared ingest workflow handling so `/api/ingest` and the new forensic path stay aligned on format resolution, size checks, dedupe handling, and telemetry
- document the CLI and API smoke paths in the public docs and add focused API coverage for the new workflow

## Issue
- Refs tborys/driftshield-meta#44

## Verification
- `cd driftshield && uv run --extra dev pytest tests/api/test_ingest.py tests/api/test_reports.py -q`
- `cd driftshield && uv run --extra dev ruff check src/driftshield/api/ingest_workflow.py src/driftshield/api/routes/ingest.py src/driftshield/api/routes/reports.py tests/api/test_ingest.py tests/api/test_reports.py`
- `./scripts/check-public-scope.sh`
- `cd driftshield && source .venv/bin/activate && driftshield report tests/fixtures/transcripts/sample_claude_code_session.jsonl --format json`
- live API smoke against a temporary SQLite-backed local server:
  - first upload returned `201 created | false | forensic_report.v1 | reported`
  - repeat upload returned `200 | deduped | true` with the same `session_id`

## Notes
- local Postgres from `.env` was not available in this environment, so the live API smoke used a throwaway SQLite database created just for the verification run.