### PR TITLE
Add structured forensic feedback API

### DIFF
--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -34,6 +34,13 @@ from driftshield.db.persistence import PersistenceService
 from driftshield.db.validation_service import ValidationService
 
 router = APIRouter()
+_REPORT_BOUND_FEEDBACK_TARGET_KINDS = {
+    "classification",
+    "finding",
+    "pattern_match",
+    "candidate_break_point",
+    "evidence_gap",
+}
 
 
 def _count_risks(nodes: list[DecisionNodeModel]) -> int:
@@ -243,6 +250,12 @@ def _load_report_for_feedback(
             raise HTTPException(status_code=422, detail="report_id must match report target_ref")
         report_id = target_report_id
 
+    if report_id is None and payload.target_kind in _REPORT_BOUND_FEEDBACK_TARGET_KINDS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"report_id is required for {payload.target_kind} feedback",
+        )
+
     if report_id is None:
         return None
 
@@ -263,6 +276,10 @@ def _validate_report_feedback_target(
         findings = content.get("findings") if isinstance(content, dict) else None
         if not _contains_ref(findings, "finding_id", payload.target_ref):
             raise HTTPException(status_code=422, detail="Finding target_ref not found in report")
+    elif payload.target_kind == "evidence_gap":
+        findings = content.get("findings") if isinstance(content, dict) else None
+        if not _contains_finding_kind(findings, payload.target_ref, "evidence_gap"):
+            raise HTTPException(status_code=422, detail="Evidence gap target_ref not found in report")
     elif payload.target_kind == "pattern_match":
         matches = content.get("pattern_matches") if isinstance(content, dict) else None
         if not _contains_ref(matches, "match_id", payload.target_ref):
@@ -279,6 +296,17 @@ def _contains_ref(items: object, key: str, value: str) -> bool:
     if not isinstance(items, list):
         return False
     return any(isinstance(item, dict) and item.get(key) == value for item in items)
+
+
+def _contains_finding_kind(items: object, finding_id: str, finding_kind: str) -> bool:
+    if not isinstance(items, list):
+        return False
+    return any(
+        isinstance(item, dict)
+        and item.get("finding_id") == finding_id
+        and item.get("finding_kind") == finding_kind
+        for item in items
+    )
 
 
 @router.get("/api/sessions")

--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -8,6 +8,8 @@ from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
 from driftshield.api.schemas import (
     ExplanationPayloadResponse,
+    ForensicFeedbackCreateRequest,
+    ForensicFeedbackResponse,
     GraphEdgeResponse,
     GraphNodeResponse,
     GraphResponse,
@@ -25,6 +27,7 @@ from driftshield.api.schemas import (
 from driftshield.core.models import RiskClassification
 from driftshield.db.models import (
     DecisionNodeModel,
+    ReportModel,
     SessionModel,
 )
 from driftshield.db.persistence import PersistenceService
@@ -179,6 +182,103 @@ def _extract_recurrence_status(session: SessionModel) -> RecurrenceStatusRespons
         summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
         raw=payload,
     )
+
+
+def _feedback_response(row) -> ForensicFeedbackResponse:
+    metadata = row.metadata_json if isinstance(row.metadata_json, dict) else {}
+    feedback = metadata.get("forensic_feedback") if isinstance(metadata, dict) else None
+    if not isinstance(feedback, dict):
+        feedback = {}
+
+    report_id = None
+    if isinstance(feedback.get("report_id"), str):
+        try:
+            report_id = uuid.UUID(feedback["report_id"])
+        except ValueError:
+            report_id = None
+
+    return ForensicFeedbackResponse(
+        id=row.id,
+        session_id=row.session_id,
+        target_kind=str(feedback.get("target_kind") or ""),
+        target_ref=row.target_ref,
+        category=str(feedback.get("category") or ""),
+        outcome=str(feedback.get("outcome") or ""),
+        verdict=row.verdict,
+        reviewer=row.reviewer,
+        report_id=report_id,
+        confidence=row.confidence,
+        notes=row.notes,
+        suggested_failure_family=(
+            feedback.get("suggested_failure_family")
+            if isinstance(feedback.get("suggested_failure_family"), str)
+            else None
+        ),
+        problem_detail=(
+            feedback.get("problem_detail")
+            if isinstance(feedback.get("problem_detail"), str)
+            else None
+        ),
+        shareable=row.shareable,
+        created_at=row.created_at,
+    )
+
+
+def _load_report_for_feedback(
+    *,
+    session_id: uuid.UUID,
+    payload: ForensicFeedbackCreateRequest,
+    db: DBSession,
+) -> ReportModel | None:
+    report_id = payload.report_id
+    if payload.target_kind == "report":
+        try:
+            target_report_id = uuid.UUID(payload.target_ref)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail="target_ref must be a report UUID when target_kind is report",
+            ) from exc
+        if report_id is not None and report_id != target_report_id:
+            raise HTTPException(status_code=422, detail="report_id must match report target_ref")
+        report_id = target_report_id
+
+    if report_id is None:
+        return None
+
+    report = db.get(ReportModel, report_id)
+    if report is None or report.session_id != session_id:
+        raise HTTPException(status_code=404, detail="Report not found for session")
+
+    _validate_report_feedback_target(report, payload)
+    return report
+
+
+def _validate_report_feedback_target(
+    report: ReportModel,
+    payload: ForensicFeedbackCreateRequest,
+) -> None:
+    content = report.content_json if isinstance(report.content_json, dict) else {}
+    if payload.target_kind == "finding":
+        findings = content.get("findings") if isinstance(content, dict) else None
+        if not _contains_ref(findings, "finding_id", payload.target_ref):
+            raise HTTPException(status_code=422, detail="Finding target_ref not found in report")
+    elif payload.target_kind == "pattern_match":
+        matches = content.get("pattern_matches") if isinstance(content, dict) else None
+        if not _contains_ref(matches, "match_id", payload.target_ref):
+            raise HTTPException(status_code=422, detail="Pattern match target_ref not found in report")
+    elif payload.target_kind == "candidate_break_point":
+        if not isinstance(content.get("candidate_break_point"), dict):
+            raise HTTPException(status_code=422, detail="Report has no candidate break point target")
+    elif payload.target_kind == "classification":
+        if not isinstance(content.get("classification"), str):
+            raise HTTPException(status_code=422, detail="Report has no classification target")
+
+
+def _contains_ref(items: object, key: str, value: str) -> bool:
+    if not isinstance(items, list):
+        return False
+    return any(isinstance(item, dict) and item.get(key) == value for item in items)
 
 
 @router.get("/api/sessions")
@@ -414,3 +514,63 @@ def create_session_validation(
         created_at=row.created_at,
     )
     return created.model_dump(mode="json")
+
+
+@router.get("/api/sessions/{session_id}/forensic-feedback")
+def list_session_forensic_feedback(
+    session_id: uuid.UUID,
+    report_id: uuid.UUID | None = Query(default=None),
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+):
+    session = db.get(SessionModel, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    if report_id is not None:
+        report = db.get(ReportModel, report_id)
+        if report is None or report.session_id != session_id:
+            raise HTTPException(status_code=404, detail="Report not found for session")
+
+    rows = ValidationService(db).list_forensic_feedback(
+        session_id=session_id,
+        report_id=report_id,
+    )
+    return [_feedback_response(row).model_dump(mode="json") for row in rows]
+
+
+@router.post("/api/sessions/{session_id}/forensic-feedback", status_code=201)
+def create_session_forensic_feedback(
+    session_id: uuid.UUID,
+    payload: ForensicFeedbackCreateRequest,
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+):
+    session = db.get(SessionModel, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    report = _load_report_for_feedback(session_id=session_id, payload=payload, db=db)
+
+    service = ValidationService(db)
+    try:
+        row = service.record_forensic_feedback(
+            session_id=session_id,
+            target_kind=payload.target_kind,
+            target_ref=payload.target_ref,
+            category=payload.category,
+            outcome=payload.outcome,
+            reviewer=payload.reviewer,
+            report_id=report.id if report is not None else payload.report_id,
+            confidence=payload.confidence,
+            notes=payload.notes,
+            suggested_failure_family=payload.suggested_failure_family,
+            problem_detail=payload.problem_detail,
+            shareable=payload.shareable,
+        )
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return _feedback_response(row).model_dump(mode="json")

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -218,6 +218,38 @@ class ValidationResponse(BaseModel):
     created_at: datetime
 
 
+class ForensicFeedbackCreateRequest(BaseModel):
+    target_kind: str
+    target_ref: str
+    category: str
+    outcome: str
+    reviewer: str
+    report_id: uuid.UUID | None = None
+    confidence: float | None = Field(default=None, ge=0, le=1)
+    notes: str | None = None
+    suggested_failure_family: str | None = None
+    problem_detail: str | None = None
+    shareable: bool = False
+
+
+class ForensicFeedbackResponse(BaseModel):
+    id: uuid.UUID
+    session_id: uuid.UUID
+    target_kind: str
+    target_ref: str
+    category: str
+    outcome: str
+    verdict: str
+    reviewer: str
+    report_id: uuid.UUID | None = None
+    confidence: float | None = None
+    notes: str | None = None
+    suggested_failure_family: str | None = None
+    problem_detail: str | None = None
+    shareable: bool = False
+    created_at: datetime
+
+
 class ErrorResponse(BaseModel):
     detail: str
     code: str | None = None

--- a/driftshield/src/driftshield/db/validation_service.py
+++ b/driftshield/src/driftshield/db/validation_service.py
@@ -20,6 +20,33 @@ _ALLOWED_REVIEW_OUTCOMES = {
     "wrong_inflection",
     "needs_follow_up",
 }
+_ALLOWED_FORENSIC_FEEDBACK_TARGET_KINDS = {
+    "classification",
+    "report",
+    "finding",
+    "pattern_match",
+    "candidate_break_point",
+    "evidence_gap",
+}
+_ALLOWED_FORENSIC_FEEDBACK_OUTCOMES = {
+    "classification": {"correct", "incorrect", "unresolved"},
+    "evidence": {"sufficient", "missing", "unconvincing", "unresolved"},
+    "failure_family": {"correct", "different_family", "unresolved"},
+    "report_quality": {"useful", "unclear", "not_useful", "unresolved"},
+    "candidate_break_point": {"correct", "incorrect", "unresolved"},
+}
+_FORENSIC_FEEDBACK_VERDICTS = {
+    "correct": "accept",
+    "sufficient": "accept",
+    "useful": "accept",
+    "incorrect": "reject",
+    "missing": "reject",
+    "unconvincing": "reject",
+    "different_family": "reject",
+    "not_useful": "reject",
+    "unclear": "needs_review",
+    "unresolved": "needs_review",
+}
 _REVIEW_OUTCOME_VERDICTS = {
     "useful_failure": "accept",
     "true_inflection": "accept",
@@ -183,6 +210,65 @@ class ValidationService:
             shareable=shareable,
         )
 
+    def record_forensic_feedback(
+        self,
+        *,
+        session_id: uuid.UUID,
+        target_kind: str,
+        target_ref: str,
+        category: str,
+        outcome: str,
+        reviewer: str,
+        report_id: uuid.UUID | None = None,
+        confidence: float | None = None,
+        notes: str | None = None,
+        suggested_failure_family: str | None = None,
+        problem_detail: str | None = None,
+        shareable: bool = False,
+    ) -> AnalystValidationModel:
+        """Record bounded OSS-safe feedback about a forensic report result."""
+        if target_kind not in _ALLOWED_FORENSIC_FEEDBACK_TARGET_KINDS:
+            allowed = ", ".join(sorted(_ALLOWED_FORENSIC_FEEDBACK_TARGET_KINDS))
+            raise ValueError(f"target_kind must be one of: {allowed}")
+
+        allowed_outcomes = _ALLOWED_FORENSIC_FEEDBACK_OUTCOMES.get(category)
+        if allowed_outcomes is None:
+            allowed = ", ".join(sorted(_ALLOWED_FORENSIC_FEEDBACK_OUTCOMES))
+            raise ValueError(f"category must be one of: {allowed}")
+        if outcome not in allowed_outcomes:
+            allowed = ", ".join(sorted(allowed_outcomes))
+            raise ValueError(f"outcome for category {category!r} must be one of: {allowed}")
+
+        if category == "failure_family" and outcome == "different_family":
+            if not suggested_failure_family:
+                raise ValueError(
+                    "suggested_failure_family is required when outcome is different_family"
+                )
+
+        metadata_json = {
+            "forensic_feedback": {
+                "schema_version": "forensic_feedback.v1",
+                "target_kind": target_kind,
+                "category": category,
+                "outcome": outcome,
+                "report_id": str(report_id) if report_id is not None else None,
+                "suggested_failure_family": suggested_failure_family,
+                "problem_detail": problem_detail,
+            }
+        }
+
+        return self._record(
+            session_id=session_id,
+            target_type="forensic_feedback",
+            target_ref=target_ref,
+            verdict=_FORENSIC_FEEDBACK_VERDICTS[outcome],
+            reviewer=reviewer,
+            confidence=confidence,
+            notes=notes,
+            metadata_json=metadata_json,
+            shareable=shareable,
+        )
+
     def list_validations(
         self,
         *,
@@ -209,6 +295,29 @@ class ValidationService:
                 created_at=row.created_at,
             )
             for row in query.all()
+        ]
+
+    def list_forensic_feedback(
+        self,
+        *,
+        session_id: uuid.UUID,
+        report_id: uuid.UUID | None = None,
+    ) -> list[ValidationRecord]:
+        rows = [
+            row
+            for row in self.list_validations(session_id=session_id)
+            if row.target_type == "forensic_feedback"
+        ]
+        if report_id is None:
+            return rows
+
+        report_id_value = str(report_id)
+        return [
+            row
+            for row in rows
+            if isinstance(row.metadata_json, dict)
+            and isinstance(row.metadata_json.get("forensic_feedback"), dict)
+            and row.metadata_json["forensic_feedback"].get("report_id") == report_id_value
         ]
 
     def export_training_dataset_jsonl(self, path: Path) -> int:

--- a/driftshield/tests/api/test_validations.py
+++ b/driftshield/tests/api/test_validations.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session as DBSession
 from sqlalchemy.pool import StaticPool
 
 from driftshield.api.app import create_app
-from driftshield.db.models import Base, SessionModel
+from driftshield.db.models import Base, ReportModel, SessionModel
 
 
 @pytest.fixture
@@ -51,6 +51,42 @@ def seeded_session(db_session):
     )
     db_session.commit()
     return session_id
+
+
+@pytest.fixture
+def seeded_report(db_session, seeded_session):
+    report_id = uuid.uuid4()
+    db_session.add(
+        ReportModel(
+            id=report_id,
+            session_id=seeded_session,
+            generated_at=datetime.now(timezone.utc),
+            report_type="full",
+            content_markdown="# Report",
+            content_json={
+                "classification": "Multiple visible risk points (2 flagged events).",
+                "candidate_break_point": {
+                    "status": "identified",
+                    "summary": "Visible break point at event #2.",
+                },
+                "findings": [
+                    {
+                        "finding_id": f"finding:candidate_break_point:{seeded_session}",
+                        "finding_kind": "candidate_break_point",
+                    }
+                ],
+                "pattern_matches": [
+                    {
+                        "match_id": "pattern_match:session-1:0",
+                        "family_id": "coverage_gap",
+                    }
+                ],
+            },
+            generated_by="system",
+        )
+    )
+    db_session.commit()
+    return report_id
 
 
 def test_create_and_list_validations(client, auth_headers, seeded_session):
@@ -178,3 +214,93 @@ def test_create_validation_for_missing_session_returns_404(client, auth_headers)
         json=payload,
     )
     assert resp.status_code == 404
+
+
+def test_create_and_list_forensic_feedback(client, auth_headers, seeded_session, seeded_report):
+    payload = {
+        "target_kind": "pattern_match",
+        "target_ref": "pattern_match:session-1:0",
+        "category": "failure_family",
+        "outcome": "different_family",
+        "reviewer": "demo",
+        "report_id": str(seeded_report),
+        "confidence": 0.64,
+        "suggested_failure_family": "verification_failure",
+        "problem_detail": "visible failure fits verification output better",
+        "notes": "Bounded review note",
+    }
+
+    post = client.post(
+        f"/api/sessions/{seeded_session}/forensic-feedback",
+        headers=auth_headers,
+        json=payload,
+    )
+    assert post.status_code == 201
+    created = post.json()
+    assert created["target_kind"] == "pattern_match"
+    assert created["category"] == "failure_family"
+    assert created["outcome"] == "different_family"
+    assert created["verdict"] == "reject"
+    assert created["report_id"] == str(seeded_report)
+    assert created["suggested_failure_family"] == "verification_failure"
+
+    get_resp = client.get(
+        f"/api/sessions/{seeded_session}/forensic-feedback",
+        headers=auth_headers,
+        params={"report_id": str(seeded_report)},
+    )
+    assert get_resp.status_code == 200
+    rows = get_resp.json()
+    assert len(rows) == 1
+    assert rows[0]["id"] == created["id"]
+
+
+def test_create_forensic_feedback_rejects_unknown_report_target(
+    client,
+    auth_headers,
+    seeded_session,
+    seeded_report,
+):
+    payload = {
+        "target_kind": "pattern_match",
+        "target_ref": "pattern_match:missing",
+        "category": "failure_family",
+        "outcome": "different_family",
+        "reviewer": "demo",
+        "report_id": str(seeded_report),
+        "suggested_failure_family": "verification_failure",
+    }
+
+    resp = client.post(
+        f"/api/sessions/{seeded_session}/forensic-feedback",
+        headers=auth_headers,
+        json=payload,
+    )
+
+    assert resp.status_code == 422
+    assert "Pattern match target_ref not found" in resp.json()["detail"]
+
+
+def test_create_forensic_feedback_rejects_vague_family_redirect(
+    client,
+    auth_headers,
+    seeded_session,
+    seeded_report,
+):
+    payload = {
+        "target_kind": "pattern_match",
+        "target_ref": "pattern_match:session-1:0",
+        "category": "failure_family",
+        "outcome": "different_family",
+        "reviewer": "demo",
+        "report_id": str(seeded_report),
+    }
+
+    resp = client.post(
+        f"/api/sessions/{seeded_session}/forensic-feedback",
+        headers=auth_headers,
+        json=payload,
+    )
+
+    assert resp.status_code == 400
+    assert "suggested_failure_family is required" in resp.json()["detail"]

--- a/driftshield/tests/api/test_validations.py
+++ b/driftshield/tests/api/test_validations.py
@@ -73,6 +73,10 @@ def seeded_report(db_session, seeded_session):
                     {
                         "finding_id": f"finding:candidate_break_point:{seeded_session}",
                         "finding_kind": "candidate_break_point",
+                    },
+                    {
+                        "finding_id": f"finding:evidence_gap:{seeded_session}",
+                        "finding_kind": "evidence_gap",
                     }
                 ],
                 "pattern_matches": [
@@ -279,6 +283,57 @@ def test_create_forensic_feedback_rejects_unknown_report_target(
 
     assert resp.status_code == 422
     assert "Pattern match target_ref not found" in resp.json()["detail"]
+
+
+def test_create_forensic_feedback_requires_report_for_report_scoped_target(
+    client,
+    auth_headers,
+    seeded_session,
+):
+    payload = {
+        "target_kind": "pattern_match",
+        "target_ref": "pattern_match:session-1:0",
+        "category": "failure_family",
+        "outcome": "different_family",
+        "reviewer": "demo",
+        "suggested_failure_family": "verification_failure",
+    }
+
+    resp = client.post(
+        f"/api/sessions/{seeded_session}/forensic-feedback",
+        headers=auth_headers,
+        json=payload,
+    )
+
+    assert resp.status_code == 422
+    assert "report_id is required for pattern_match feedback" in resp.json()["detail"]
+
+
+def test_create_forensic_feedback_validates_evidence_gap_target(
+    client,
+    auth_headers,
+    seeded_session,
+    seeded_report,
+):
+    payload = {
+        "target_kind": "evidence_gap",
+        "target_ref": f"finding:evidence_gap:{seeded_session}",
+        "category": "evidence",
+        "outcome": "missing",
+        "reviewer": "demo",
+        "report_id": str(seeded_report),
+        "problem_detail": "The report should cite the failed tool result.",
+    }
+
+    resp = client.post(
+        f"/api/sessions/{seeded_session}/forensic-feedback",
+        headers=auth_headers,
+        json=payload,
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["target_kind"] == "evidence_gap"
+    assert resp.json()["verdict"] == "reject"
 
 
 def test_create_forensic_feedback_rejects_vague_family_redirect(

--- a/driftshield/tests/db/test_validation_service.py
+++ b/driftshield/tests/db/test_validation_service.py
@@ -87,6 +87,51 @@ def test_record_validation_accepts_review_outcome_metadata(db_session):
     assert row.metadata_json["review_outcome"]["label"] == "useful_failure"
 
 
+def test_record_forensic_feedback_is_structured_and_retrievable(db_session):
+    session_id = _seed_session(db_session)
+    report_id = uuid.uuid4()
+    service = ValidationService(db_session)
+
+    row = service.record_forensic_feedback(
+        session_id=session_id,
+        target_kind="pattern_match",
+        target_ref="pattern_match:session-1:0",
+        category="failure_family",
+        outcome="different_family",
+        reviewer="demo",
+        report_id=report_id,
+        confidence=0.67,
+        suggested_failure_family="verification_failure",
+        problem_detail="visible output fits verification failure better",
+    )
+
+    assert row.target_type == "forensic_feedback"
+    assert row.verdict == "reject"
+    feedback = row.metadata_json["forensic_feedback"]
+    assert feedback["schema_version"] == "forensic_feedback.v1"
+    assert feedback["target_kind"] == "pattern_match"
+    assert feedback["category"] == "failure_family"
+    assert feedback["suggested_failure_family"] == "verification_failure"
+
+    rows = service.list_forensic_feedback(session_id=session_id, report_id=report_id)
+    assert [item.id for item in rows] == [row.id]
+
+
+def test_record_forensic_feedback_requires_specific_family_for_redirect(db_session):
+    session_id = _seed_session(db_session)
+    service = ValidationService(db_session)
+
+    with pytest.raises(ValueError, match="suggested_failure_family is required"):
+        service.record_forensic_feedback(
+            session_id=session_id,
+            target_kind="pattern_match",
+            target_ref="pattern_match:session-1:0",
+            category="failure_family",
+            outcome="different_family",
+            reviewer="demo",
+        )
+
+
 def test_export_validations_filters_private_records_and_keeps_provenance(db_session, tmp_path):
     session_id = _seed_session(db_session)
     service = ValidationService(db_session)


### PR DESCRIPTION
Refs tborys/driftshield-meta#72

## Summary
- add session-level `/api/sessions/{session_id}/forensic-feedback` create/list endpoints
- persist bounded OSS-safe feedback through the existing validation table using a `forensic_feedback.v1` metadata shape
- validate feedback categories/outcomes and report target refs for findings, pattern matches, classification, and candidate break points
- add API and service tests for record/retrieve and structured rejection paths

## Verification
- `uv run --extra dev ruff check src/driftshield/db/validation_service.py src/driftshield/api/schemas.py src/driftshield/api/routes/sessions.py tests/db/test_validation_service.py tests/api/test_validations.py`
- `uv run --extra dev pytest tests/db/test_validation_service.py tests/api/test_validations.py -q`
- `uv run --extra dev pytest tests/api/test_reports.py tests/api/test_sessions.py tests/api/test_validations.py tests/db/test_validation_service.py -q`
- `uv run --extra dev pytest tests -q`
- `npm run build`

## Notes
- Issue 44 is merged into `main`, so this PR now contains only the issue-72 feedback slice.
- No frontend files changed; no browser flow was added for this backend-only API surface.
