### PR TITLE
Align OSS result surfaces with mechanism-only contract

### DIFF
--- a/driftshield/docs/telemetry.md
+++ b/driftshield/docs/telemetry.md
@@ -53,12 +53,12 @@ Fields:
 - `payload.outcome_status`
 - `payload.classifiable`
 - `payload.match_count`
-- `payload.primary_family_id`
-- `payload.mixed_family`
+- `payload.primary_mechanism_id`
+- `payload.mixed_mechanism`
 - `payload.not_classifiable_reason`
 - `payload.event_inventory_version = phase-2a-v1`
 
-These fields intentionally mirror the required Phase 2a run-level inventory for outcome status, classifiability, match count, family rollup, and not-classifiable reasons without adding broader product analytics.
+These fields intentionally mirror the required Phase 2a run-level inventory for outcome status, classifiability, match count, mechanism rollup, and not-classifiable reasons without adding broader product analytics.
 
 Current OSS emission path:
 
@@ -82,7 +82,7 @@ DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry heartbeat
 DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry emit-analysis \
   --outcome-status matched \
   --match-count 1 \
-  --primary-family-id coverage_gap
+  --primary-mechanism-id coverage_gap
 ```
 
 ## Out of scope for Phase 2a

--- a/driftshield/frontend/src/pages/InvestigationPage.tsx
+++ b/driftshield/frontend/src/pages/InvestigationPage.tsx
@@ -17,7 +17,7 @@ function labelFromValue(value: string | null | undefined) {
   return value.replace(/[_-]/g, ' ')
 }
 
-function SignatureAndRecurrenceCard({
+function SignatureRecognitionCard({
   loading,
   session,
 }: {
@@ -25,22 +25,19 @@ function SignatureAndRecurrenceCard({
   session: ReturnType<typeof useSession>['data']
 }) {
   const signatureMatch = session?.signature_match ?? null
-  const recurrenceStatus = session?.recurrence_status ?? null
-  const matchedFamilies = signatureMatch?.matched_family_ids ?? []
+  const matchedMechanisms = signatureMatch?.matched_mechanism_ids ?? []
   const matchStatus = signatureMatch?.status ?? null
-  const recurrenceLabel = labelFromValue(recurrenceStatus?.status)
   const signatureLabel = labelFromValue(matchStatus)
   const hasSignatureData = signatureMatch !== null
-  const hasRecurrenceData = recurrenceStatus !== null
-  const showUnavailable = !loading && !hasSignatureData && !hasRecurrenceData
+  const showUnavailable = !loading && !hasSignatureData
   const showUnmatched = !loading && hasSignatureData && matchStatus === 'unmatched'
 
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-base">Signature and recurrence</CardTitle>
+        <CardTitle className="text-base">OSS signature recognition</CardTitle>
         <CardDescription>
-          Phase 2a classification output from the backend, with explicit unavailable states.
+          Phase 2a recognition output from the backend, limited to local OSS-safe signals.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 text-sm">
@@ -48,22 +45,16 @@ function SignatureAndRecurrenceCard({
           <div className="text-muted-foreground">Loading classification summary...</div>
         ) : showUnavailable ? (
           <div className="rounded-md border bg-muted/30 p-3 text-muted-foreground">
-            This session does not expose signature or recurrence data yet.
+            This session does not expose OSS signature recognition data yet.
           </div>
         ) : (
           <>
             <div className="flex flex-wrap gap-2">
               <Badge variant={matchStatus === 'matched' ? 'destructive' : 'outline'}>
-                Signature: {signatureLabel ?? 'unavailable'}
-              </Badge>
-              <Badge variant={recurrenceStatus?.status === 'recurring' ? 'destructive' : 'outline'}>
-                Recurrence: {recurrenceLabel ?? 'unavailable'}
+                Recognition: {signatureLabel ?? 'unavailable'}
               </Badge>
               {signatureMatch?.match_count !== null && signatureMatch?.match_count !== undefined && (
                 <Badge variant="outline">{signatureMatch.match_count} match{signatureMatch.match_count === 1 ? '' : 'es'}</Badge>
-              )}
-              {recurrenceStatus?.recurrence_count !== null && recurrenceStatus?.recurrence_count !== undefined && (
-                <Badge variant="outline">{recurrenceStatus.recurrence_count} related run{recurrenceStatus.recurrence_count === 1 ? '' : 's'}</Badge>
               )}
             </div>
 
@@ -71,28 +62,21 @@ function SignatureAndRecurrenceCard({
             {!signatureMatch?.summary && showUnmatched && (
               <p className="text-muted-foreground">No signature matches were returned for this session.</p>
             )}
-            {recurrenceStatus?.summary && <p>{recurrenceStatus.summary}</p>}
 
-            {matchedFamilies.length > 0 && (
+            {matchedMechanisms.length > 0 && (
               <div className="space-y-2">
-                <div className="text-xs font-medium text-muted-foreground">Matched families</div>
+                <div className="text-xs font-medium text-muted-foreground">Matched mechanisms</div>
                 <div className="flex flex-wrap gap-2">
-                  {matchedFamilies.map((familyId) => (
-                    <Badge key={familyId} variant="secondary">{labelFromValue(familyId) ?? familyId}</Badge>
+                  {matchedMechanisms.map((mechanismId) => (
+                    <Badge key={mechanismId} variant="secondary">{labelFromValue(mechanismId) ?? mechanismId}</Badge>
                   ))}
                 </div>
               </div>
             )}
 
-            {signatureMatch?.primary_family_id && (
+            {signatureMatch?.primary_mechanism_id && (
               <div className="text-muted-foreground">
-                Primary family: <span className="font-medium text-foreground">{labelFromValue(signatureMatch.primary_family_id)}</span>
-              </div>
-            )}
-
-            {recurrenceStatus?.cluster_id && (
-              <div className="text-muted-foreground">
-                Cluster: <span className="font-mono text-foreground">{recurrenceStatus.cluster_id}</span>
+                Primary mechanism: <span className="font-medium text-foreground">{labelFromValue(signatureMatch.primary_mechanism_id)}</span>
               </div>
             )}
           </>
@@ -204,7 +188,7 @@ export function InvestigationPage() {
         )}
         </div>
 
-        <SignatureAndRecurrenceCard loading={sessionLoading} session={session} />
+        <SignatureRecognitionCard loading={sessionLoading} session={session} />
       </div>
 
       <InvestigationView graph={graph} />

--- a/driftshield/frontend/src/types/session.ts
+++ b/driftshield/frontend/src/types/session.ts
@@ -19,17 +19,9 @@ export interface SessionSummary {
 
 export interface SignatureMatchSummary {
   status: string | null
-  primary_family_id: string | null
-  matched_family_ids: string[]
+  primary_mechanism_id: string | null
+  matched_mechanism_ids: string[]
   match_count: number | null
-  summary: string | null
-  raw: Record<string, unknown> | null
-}
-
-export interface RecurrenceStatus {
-  status: string | null
-  cluster_id: string | null
-  recurrence_count: number | null
   summary: string | null
   raw: Record<string, unknown> | null
 }
@@ -39,7 +31,6 @@ export interface SessionDetail extends SessionSummary {
   flagged_events: number
   risk_summary: Record<string, number>
   signature_match?: SignatureMatchSummary | null
-  recurrence_status?: RecurrenceStatus | null
 }
 
 export interface PaginatedResponse<T> {

--- a/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
+++ b/driftshield/frontend/tests/e2e/investigation-signature-summary.spec.ts
@@ -42,7 +42,7 @@ async function mockSessionArtifacts(page: Page) {
   })
 }
 
-test('shows matched signature and recurrence states from backend metadata', async ({ page }) => {
+test('shows matched OSS signature recognition states from backend metadata', async ({ page }) => {
   await page.route(`**/api/sessions/${sessionId}`, async (route) => {
     await route.fulfill({
       contentType: 'application/json',
@@ -67,17 +67,10 @@ test('shows matched signature and recurrence states from backend metadata', asyn
         explanations: { risk_explanations: {}, inflection_explanation: null },
         signature_match: {
           status: 'matched',
-          primary_family_id: 'coverage_gap',
-          matched_family_ids: ['coverage_gap', 'verification_failure'],
+          primary_mechanism_id: 'coverage_gap',
+          matched_mechanism_ids: ['coverage_gap', 'verification_failure'],
           match_count: 2,
-          summary: 'Matched two known failure families.',
-          raw: null,
-        },
-        recurrence_status: {
-          status: 'recurring',
-          cluster_id: 'cluster-42',
-          recurrence_count: 3,
-          summary: 'Seen in three related runs.',
+          summary: 'Matched two known failure mechanisms from local OSS-safe signals.',
           raw: null,
         },
       }),
@@ -105,15 +98,14 @@ test('shows matched signature and recurrence states from backend metadata', asyn
 
   await page.goto(`/sessions/${sessionId}`)
 
-  await expect(page.getByText('Signature: matched')).toBeVisible()
-  await expect(page.getByText('Recurrence: recurring')).toBeVisible()
-  await expect(page.getByText('Matched two known failure families.')).toBeVisible()
-  await expect(page.getByText('Seen in three related runs.')).toBeVisible()
-  await expect(page.getByText('Primary family:')).toBeVisible()
-  await expect(page.getByText('Cluster:')).toBeVisible()
+  await expect(page.getByText('Recognition: matched')).toBeVisible()
+  await expect(page.getByText('Matched two known failure mechanisms from local OSS-safe signals.')).toBeVisible()
+  await expect(page.getByText('Primary mechanism:')).toBeVisible()
+  await expect(page.getByText('Matched mechanisms')).toBeVisible()
+  await expect(page.getByText('Recurrence: recurring')).not.toBeVisible()
 })
 
-test('shows unavailable state when backend omits signature and recurrence fields', async ({ page }) => {
+test('shows unavailable state when backend omits OSS signature recognition fields', async ({ page }) => {
   await page.route(`**/api/sessions/${sessionId}`, async (route) => {
     await route.fulfill({
       contentType: 'application/json',
@@ -155,7 +147,7 @@ test('shows unavailable state when backend omits signature and recurrence fields
 
   await page.goto(`/sessions/${sessionId}`)
 
-  await expect(page.getByText('This session does not expose signature or recurrence data yet.')).toBeVisible()
+  await expect(page.getByText('This session does not expose OSS signature recognition data yet.')).toBeVisible()
 })
 
 test('keeps the investigation view alive when graph payload omits lineage fields', async ({ page }) => {
@@ -178,17 +170,10 @@ test('keeps the investigation view alive when graph payload omits lineage fields
         explanations: { risk_explanations: {}, inflection_explanation: null },
         signature_match: {
           status: 'matched',
-          primary_family_id: 'coverage_gap',
-          matched_family_ids: ['coverage_gap'],
+          primary_mechanism_id: 'coverage_gap',
+          matched_mechanism_ids: ['coverage_gap'],
           match_count: 1,
-          summary: 'Matched one known failure family.',
-          raw: null,
-        },
-        recurrence_status: {
-          status: 'new',
-          cluster_id: null,
-          recurrence_count: 0,
-          summary: 'No related runs yet.',
+          summary: 'Matched one known failure mechanism from local OSS-safe signals.',
           raw: null,
         },
       }),
@@ -226,7 +211,7 @@ test('keeps the investigation view alive when graph payload omits lineage fields
 
   await page.goto(`/sessions/${sessionId}`)
 
-  await expect(page.getByText('Signature: matched')).toBeVisible()
+  await expect(page.getByText('Recognition: matched')).toBeVisible()
   await expect(page.getByText('Investigation graph')).toBeVisible()
   await expect(page.getByText('Root node')).toBeVisible()
 })

--- a/driftshield/src/driftshield/api/ingest_workflow.py
+++ b/driftshield/src/driftshield/api/ingest_workflow.py
@@ -107,8 +107,8 @@ def record_analysis_telemetry(result: AnalysisResult) -> None:
         TelemetryService().record_analysis_event(
             outcome_status=metrics["outcome_status"],
             match_count=metrics["match_count"],
-            primary_family_id=metrics["primary_family_id"],
-            mixed_family=metrics["mixed_family"],
+            primary_mechanism_id=metrics["primary_family_id"],
+            mixed_mechanism=metrics["mixed_family"],
             not_classifiable_reason=metrics["not_classifiable_reason"],
         )
     except Exception:

--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -14,7 +14,6 @@ from driftshield.api.schemas import (
     GraphNodeResponse,
     GraphResponse,
     PaginatedResponse,
-    RecurrenceStatusResponse,
     SessionDetail,
     SessionExplanationItemResponse,
     SessionExplanationsResponse,
@@ -154,39 +153,40 @@ def _extract_signature_match(session: SessionModel) -> SignatureMatchSummaryResp
     if not isinstance(payload, dict):
         return None
 
-    matched_family_ids = payload.get("matched_family_ids")
-    if not isinstance(matched_family_ids, list):
-        matched_family_ids = []
+    matched_mechanism_ids = payload.get("matched_mechanism_ids")
+    if not isinstance(matched_mechanism_ids, list):
+        matched_mechanism_ids = payload.get("matched_family_ids")
+    if not isinstance(matched_mechanism_ids, list):
+        matched_mechanism_ids = []
 
     status = payload.get("status")
     if not isinstance(status, str):
         status = payload.get("outcome_status") if isinstance(payload.get("outcome_status"), str) else None
 
-    return SignatureMatchSummaryResponse(
-        status=status,
-        primary_family_id=(
+    primary_mechanism_id = payload.get("primary_mechanism_id")
+    if not isinstance(primary_mechanism_id, str):
+        primary_mechanism_id = (
             payload.get("primary_family_id")
             if isinstance(payload.get("primary_family_id"), str)
             else None
-        ),
-        matched_family_ids=[item for item in matched_family_ids if isinstance(item, str)],
+        )
+
+    summary = payload.get("summary") if isinstance(payload.get("summary"), str) else None
+    if summary is not None and "OSS-safe signals" not in summary:
+        rewritten = summary.replace("failure families", "failure mechanisms").replace(
+            "failure family", "failure mechanism"
+        )
+        if rewritten.startswith("Matched ") and rewritten.endswith("."):
+            summary = rewritten[:-1] + " from local OSS-safe signals."
+        else:
+            summary = rewritten
+
+    return SignatureMatchSummaryResponse(
+        status=status,
+        primary_mechanism_id=primary_mechanism_id,
+        matched_mechanism_ids=[item for item in matched_mechanism_ids if isinstance(item, str)],
         match_count=_optional_int(payload.get("match_count")),
-        summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
-        raw=payload,
-    )
-
-
-def _extract_recurrence_status(session: SessionModel) -> RecurrenceStatusResponse | None:
-    metadata = session.metadata_json or {}
-    payload = metadata.get("recurrence_status")
-    if not isinstance(payload, dict):
-        return None
-
-    return RecurrenceStatusResponse(
-        status=payload.get("status") if isinstance(payload.get("status"), str) else None,
-        cluster_id=payload.get("cluster_id") if isinstance(payload.get("cluster_id"), str) else None,
-        recurrence_count=_optional_int(payload.get("recurrence_count")),
-        summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
+        summary=summary,
         raw=payload,
     )
 
@@ -394,7 +394,6 @@ def get_session(
         risk_summary=_risk_summary(nodes),
         explanations=_session_explanations(nodes),
         signature_match=_extract_signature_match(session),
-        recurrence_status=_extract_recurrence_status(session),
     )
 
 

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -43,17 +43,9 @@ class SessionSummary(BaseModel):
 
 class SignatureMatchSummaryResponse(BaseModel):
     status: str | None = None
-    primary_family_id: str | None = None
-    matched_family_ids: list[str] = Field(default_factory=list)
+    primary_mechanism_id: str | None = None
+    matched_mechanism_ids: list[str] = Field(default_factory=list)
     match_count: int | None = None
-    summary: str | None = None
-    raw: dict[str, Any] | None = None
-
-
-class RecurrenceStatusResponse(BaseModel):
-    status: str | None = None
-    cluster_id: str | None = None
-    recurrence_count: int | None = None
     summary: str | None = None
     raw: dict[str, Any] | None = None
 
@@ -64,7 +56,6 @@ class SessionDetail(SessionSummary):
     risk_summary: dict[str, int] = Field(default_factory=dict)
     explanations: SessionExplanationsResponse | None = None
     signature_match: SignatureMatchSummaryResponse | None = None
-    recurrence_status: RecurrenceStatusResponse | None = None
 
 
 class GraphNodeResponse(BaseModel):

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -65,8 +65,8 @@ def telemetry_heartbeat() -> None:
 def telemetry_emit_analysis(
     outcome_status: str = typer.Option(..., "--outcome-status", help="matched, unclassified, or not_classifiable"),
     match_count: int = typer.Option(0, "--match-count", min=0),
-    primary_family_id: str | None = typer.Option(None, "--primary-family-id"),
-    mixed_family: bool = typer.Option(False, "--mixed-family"),
+    primary_mechanism_id: str | None = typer.Option(None, "--primary-mechanism-id"),
+    mixed_mechanism: bool = typer.Option(False, "--mixed-mechanism"),
     not_classifiable_reason: str | None = typer.Option(None, "--not-classifiable-reason"),
 ) -> None:
     """Emit one sample analysis-result telemetry event for smoke testing."""
@@ -79,8 +79,8 @@ def telemetry_emit_analysis(
     emitted = TelemetryService().record_analysis_event(
         outcome_status=validated_outcome_status,
         match_count=match_count,
-        primary_family_id=primary_family_id,
-        mixed_family=mixed_family,
+        primary_mechanism_id=primary_mechanism_id,
+        mixed_mechanism=mixed_mechanism,
         not_classifiable_reason=not_classifiable_reason,
     )
     if not emitted:

--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -331,12 +331,17 @@ class ReportBuilder:
         index: int,
     ) -> list[PatternMatch]:
         signature_id = _string_value(payload.get("signature_id"))
-        family_id = _string_value(payload.get("family_id") or payload.get("primary_family_id"))
-        family_ids = _ordered_family_ids(payload)
-        if family_id is not None and family_id not in family_ids:
-            family_ids.insert(0, family_id)
+        mechanism_id = _string_value(
+            payload.get("mechanism_id")
+            or payload.get("family_id")
+            or payload.get("primary_mechanism_id")
+            or payload.get("primary_family_id")
+        )
+        mechanism_ids = _ordered_mechanism_ids(payload)
+        if mechanism_id is not None and mechanism_id not in mechanism_ids:
+            mechanism_ids.insert(0, mechanism_id)
 
-        if signature_id is None and not family_ids:
+        if signature_id is None and not mechanism_ids:
             return []
 
         signature_layer = (
@@ -356,14 +361,14 @@ class ReportBuilder:
         match_id = _string_value(payload.get("match_id")) or f"pattern_match:{session.id}:{index}"
 
         if signature_id is not None:
-            resolved_family_id = family_id or (family_ids[0] if family_ids else None)
-            if resolved_family_id is None:
+            resolved_mechanism_id = mechanism_id or (mechanism_ids[0] if mechanism_ids else None)
+            if resolved_mechanism_id is None:
                 return []
             return [
                 PatternMatch(
                     match_id=match_id,
                     signature_id=signature_id,
-                    family_id=resolved_family_id,
+                    mechanism_id=resolved_mechanism_id,
                     signature_layer=signature_layer,
                     scope_ref=scope_ref,
                     evidence_refs=evidence_refs,
@@ -374,12 +379,12 @@ class ReportBuilder:
             ]
 
         matches: list[PatternMatch] = []
-        for family_offset, derived_family_id in enumerate(family_ids, start=1):
+        for mechanism_offset, derived_mechanism_id in enumerate(mechanism_ids, start=1):
             matches.append(
                 PatternMatch(
-                    match_id=f"{match_id}:{family_offset}",
-                    signature_id=f"family:{derived_family_id}",
-                    family_id=derived_family_id,
+                    match_id=f"{match_id}:{mechanism_offset}",
+                    signature_id=f"mechanism:{derived_mechanism_id}",
+                    mechanism_id=derived_mechanism_id,
                     signature_layer=dict(signature_layer),
                     scope_ref=scope_ref,
                     evidence_refs=evidence_refs,
@@ -396,8 +401,8 @@ class ReportBuilder:
         result: AnalysisResult,
     ) -> str:
         if pattern_matches:
-            families = ", ".join(match.family_id for match in pattern_matches)
-            return f"Local OSS-safe pattern signals resemble: {families}."
+            mechanisms = ", ".join(match.mechanism_id for match in pattern_matches)
+            return f"Local OSS-safe pattern signals resemble: {mechanisms}."
 
         active_flags = self._active_risk_flags(result)
         if active_flags:
@@ -588,27 +593,31 @@ def _plural(noun: str, count: int) -> str:
     return noun if count == 1 else f"{noun}s"
 
 
-def _ordered_family_ids(payload: Mapping[str, Any]) -> list[str]:
+def _ordered_mechanism_ids(payload: Mapping[str, Any]) -> list[str]:
     ordered: list[str] = []
 
-    primary_family_id = _string_value(payload.get("primary_family_id"))
-    if primary_family_id is not None:
-        ordered.append(primary_family_id)
+    primary_mechanism_id = _string_value(
+        payload.get("primary_mechanism_id") or payload.get("primary_family_id")
+    )
+    if primary_mechanism_id is not None:
+        ordered.append(primary_mechanism_id)
 
-    matched_family_ids = payload.get("matched_family_ids")
-    if isinstance(matched_family_ids, list):
-        for item in matched_family_ids:
-            family_id = _string_value(item)
-            if family_id is not None and family_id not in ordered:
-                ordered.append(family_id)
+    matched_mechanism_ids = payload.get("matched_mechanism_ids")
+    if not isinstance(matched_mechanism_ids, list):
+        matched_mechanism_ids = payload.get("matched_family_ids")
+    if isinstance(matched_mechanism_ids, list):
+        for item in matched_mechanism_ids:
+            mechanism_id = _string_value(item)
+            if mechanism_id is not None and mechanism_id not in ordered:
+                ordered.append(mechanism_id)
 
     return ordered
 
 
 def _pattern_resemblance_finding_summary(match: PatternMatch) -> str:
-    if match.signature_id.startswith("family:"):
-        return f"Local OSS-safe signals resemble {match.family_id}."
-    return f"Local OSS-safe signals resemble {match.family_id} via {match.signature_id}."
+    if match.signature_id.startswith("mechanism:"):
+        return f"Local OSS-safe signals resemble {match.mechanism_id}."
+    return f"Local OSS-safe signals resemble {match.mechanism_id} via {match.signature_id}."
 
 
 def _lineage_excerpt(result: AnalysisResult) -> str:

--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -26,6 +26,18 @@ OSS_SAFETY_NOTE = (
 )
 
 
+def _rewrite_legacy_mechanism_summary(summary: str) -> str:
+    if "OSS-safe signals" in summary:
+        return summary
+
+    rewritten = summary.replace("failure families", "failure mechanisms").replace(
+        "failure family", "failure mechanism"
+    )
+    if rewritten.startswith("Matched ") and rewritten.endswith("."):
+        return rewritten[:-1] + " from local OSS-safe signals."
+    return rewritten
+
+
 class ReportBuilder:
     def build(
         self,
@@ -350,6 +362,8 @@ class ReportBuilder:
             else {}
         )
         rationale = _string_value(payload.get("rationale") or payload.get("summary")) or ""
+        if rationale:
+            rationale = _rewrite_legacy_mechanism_summary(rationale)
         if rationale and "symptom" not in signature_layer:
             signature_layer["symptom"] = rationale
         evidence_refs = _string_list(

--- a/driftshield/src/driftshield/reports/json_export.py
+++ b/driftshield/src/driftshield/reports/json_export.py
@@ -39,7 +39,7 @@ def export_json(report: ReportData) -> dict[str, Any]:
             {
                 "match_id": match.match_id,
                 "signature_id": match.signature_id,
-                "family_id": match.family_id,
+                "mechanism_id": match.mechanism_id,
                 "signature_layer": dict(match.signature_layer),
                 "scope_ref": match.scope_ref,
                 "evidence_refs": list(match.evidence_refs),

--- a/driftshield/src/driftshield/reports/models.py
+++ b/driftshield/src/driftshield/reports/models.py
@@ -66,7 +66,7 @@ class ReportFinding:
 class PatternMatch:
     match_id: str
     signature_id: str
-    family_id: str
+    mechanism_id: str
     signature_layer: dict[str, Any]
     scope_ref: str
     evidence_refs: list[str] = field(default_factory=list)

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -116,8 +116,8 @@ class TelemetryService:
         *,
         outcome_status: str,
         match_count: int,
-        primary_family_id: str | None = None,
-        mixed_family: bool = False,
+        primary_mechanism_id: str | None = None,
+        mixed_mechanism: bool = False,
         not_classifiable_reason: str | None = None,
     ) -> bool:
         validated_outcome_status = validate_outcome_status(outcome_status)
@@ -133,8 +133,8 @@ class TelemetryService:
                     "outcome_status": validated_outcome_status,
                     "classifiable": validated_outcome_status in {"matched", "unclassified"},
                     "match_count": match_count,
-                    "primary_family_id": primary_family_id,
-                    "mixed_family": mixed_family,
+                    "primary_mechanism_id": primary_mechanism_id,
+                    "mixed_mechanism": mixed_mechanism,
                     "not_classifiable_reason": not_classifiable_reason,
                     "event_inventory_version": "phase-2a-v1",
                 },

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -383,10 +383,10 @@ def test_ingest_emits_unclassified_phase_2a_metrics_when_telemetry_is_enabled(cl
         "classifiable": True,
         "event_inventory_version": "phase-2a-v1",
         "match_count": 0,
-        "mixed_family": False,
+        "mixed_mechanism": False,
         "not_classifiable_reason": None,
         "outcome_status": "unclassified",
-        "primary_family_id": None,
+        "primary_mechanism_id": None,
     }
 
 
@@ -426,10 +426,10 @@ def test_ingest_emits_matched_phase_2a_metrics_when_analysis_flags_risk(client, 
         "classifiable": True,
         "event_inventory_version": "phase-2a-v1",
         "match_count": 1,
-        "mixed_family": False,
+        "mixed_mechanism": False,
         "not_classifiable_reason": None,
         "outcome_status": "matched",
-        "primary_family_id": "coverage_gap",
+        "primary_mechanism_id": "coverage_gap",
     }
 
 

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -465,11 +465,11 @@ def test_generate_report_projects_legacy_family_only_signature_summary(
 
     report = db_session.get(ReportModel, uuid.UUID(response.json()["id"]))
     assert report is not None
-    assert [match["family_id"] for match in report.content_json["pattern_matches"]] == [
+    assert [match["mechanism_id"] for match in report.content_json["pattern_matches"]] == [
         "coverage_gap",
         "verification_failure",
     ]
-    assert report.content_json["pattern_matches"][0]["signature_id"] == "family:coverage_gap"
+    assert report.content_json["pattern_matches"][0]["signature_id"] == "mechanism:coverage_gap"
 
 
 def test_generate_report_ignores_signature_only_payload_without_family_fields(

--- a/driftshield/tests/api/test_sessions.py
+++ b/driftshield/tests/api/test_sessions.py
@@ -159,10 +159,10 @@ def test_get_session_detail(client, auth_headers, seeded_session):
     }
     assert data["signature_match"] == {
         "status": "matched",
-        "primary_family_id": "coverage_gap",
-        "matched_family_ids": ["coverage_gap", "verification_failure"],
+        "primary_mechanism_id": "coverage_gap",
+        "matched_mechanism_ids": ["coverage_gap", "verification_failure"],
         "match_count": 2,
-        "summary": "Matched two known failure families.",
+        "summary": "Matched two known failure mechanisms from local OSS-safe signals.",
         "raw": {
             "status": "matched",
             "primary_family_id": "coverage_gap",
@@ -171,18 +171,7 @@ def test_get_session_detail(client, auth_headers, seeded_session):
             "summary": "Matched two known failure families.",
         },
     }
-    assert data["recurrence_status"] == {
-        "status": "recurring",
-        "cluster_id": "cluster-42",
-        "recurrence_count": 3,
-        "summary": "Seen in three related runs.",
-        "raw": {
-            "status": "recurring",
-            "cluster_id": "cluster-42",
-            "recurrence_count": 3,
-            "summary": "Seen in three related runs.",
-        },
-    }
+    assert "recurrence_status" not in data
 
 
 def test_get_session_detail_falls_back_to_legacy_outcome_status(client, auth_headers, db_session):
@@ -220,7 +209,8 @@ def test_get_session_detail_falls_back_to_legacy_outcome_status(client, auth_hea
     assert response.status_code == 200
     payload = response.json()
     assert payload["signature_match"]["status"] == "matched"
-    assert payload["signature_match"]["primary_family_id"] == "coverage_gap"
+    assert payload["signature_match"]["primary_mechanism_id"] == "coverage_gap"
+    assert "recurrence_status" not in payload
 
 
 def test_get_session_detail_orders_explanations_by_sequence(client, auth_headers, db_session):

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -62,7 +62,7 @@ def test_emit_analysis_uses_phase_2a_metric_fields(tmp_path, monkeypatch):
             "matched",
             "--match-count",
             "2",
-            "--primary-family-id",
+            "--primary-mechanism-id",
             "verification_failure",
         ],
     )
@@ -75,10 +75,10 @@ def test_emit_analysis_uses_phase_2a_metric_fields(tmp_path, monkeypatch):
         "classifiable": True,
         "event_inventory_version": "phase-2a-v1",
         "match_count": 2,
-        "mixed_family": False,
+        "mixed_mechanism": False,
         "not_classifiable_reason": None,
         "outcome_status": "matched",
-        "primary_family_id": "verification_failure",
+        "primary_mechanism_id": "verification_failure",
     }
 
 

--- a/driftshield/tests/reports/test_builder.py
+++ b/driftshield/tests/reports/test_builder.py
@@ -155,7 +155,7 @@ def test_report_v1_can_describe_local_pattern_resemblance_from_metadata(sample_r
 
     assert report.pattern_matches
     assert report.pattern_matches[0].signature_id == "SIG-COMM-001"
-    assert report.pattern_matches[0].family_id == "coverage_gap"
+    assert report.pattern_matches[0].mechanism_id == "coverage_gap"
     assert "coverage_gap" in report.summary.pattern_resemblance
 
 
@@ -173,12 +173,12 @@ def test_report_v1_accepts_legacy_family_only_signature_summary(sample_result):
 
     report = ReportBuilder().build(session, result, report_type=ReportType.FULL)
 
-    assert [match.family_id for match in report.pattern_matches] == [
+    assert [match.mechanism_id for match in report.pattern_matches] == [
         "coverage_gap",
         "verification_failure",
     ]
-    assert report.pattern_matches[0].signature_id == "family:coverage_gap"
-    assert report.pattern_matches[0].rationale == "Matched two known failure families."
+    assert report.pattern_matches[0].signature_id == "mechanism:coverage_gap"
+    assert report.pattern_matches[0].rationale == "Matched two known failure mechanisms from local OSS-safe signals."
     assert "coverage_gap" in report.summary.pattern_resemblance
     assert "verification_failure" in report.summary.pattern_resemblance
 


### PR DESCRIPTION
## Summary
- remove OSS session-detail recurrence exposure and keep the investigation surface recognition-only
- rename public-facing result fields from family to mechanism across API, reports, UI, and telemetry smoke-path docs
- rewrite legacy signature-summary rationale text so migrated OSS outputs stay consistent with the corrected contract

## Validation
- `. .venv/bin/activate && pytest tests/api/test_sessions.py tests/api/test_reports.py tests/api/test_ingest.py tests/reports/test_builder.py tests/cli/test_telemetry.py -q`
  - result: `54 passed`
- `cd frontend && npm run build`
  - result: passed
- `cd frontend && npx playwright test tests/e2e/investigation-signature-summary.spec.ts --reporter=list`
  - result: `5 passed`

Closes #47
