### PR TITLE
feat: add the OSS session integrity contract

### DIFF
--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -20,7 +20,7 @@ from driftshield.core.analysis.inflection import select_inflection_node
 from driftshield.core.analysis.session import AnalysisResult
 from driftshield.core.graph.models import LineageGraph
 from driftshield.core.models import ForensicCase
-from driftshield.db.models import ReportModel
+from driftshield.db.models import ReportModel, SessionModel
 from driftshield.db.persistence import PersistenceService
 from driftshield.reports.builder import ReportBuilder
 from driftshield.reports.json_export import export_json
@@ -40,13 +40,66 @@ def generate_report(
     request: GenerateReportRequest,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> dict[str, object]:
     del api_key
-    report, _ = _create_report_for_session(
-        session_id=session_id,
-        report_type=_parse_report_type(request.report_type),
-        db=db,
+    session_model = db.get(SessionModel, session_id)
+    if session_model is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    service = PersistenceService(db)
+    domain_session = service.load_session(session_id)
+    graph = service.load_graph(session_id)
+
+    if domain_session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    if graph is None:
+        raise HTTPException(status_code=404, detail="No graph data for session")
+
+    selection = select_inflection_node(graph, graph.nodes[-1].id) if graph.nodes else None
+    events = [node.event for node in graph.nodes]
+    flagged = sum(
+        1 for event in events if event.risk_classification and event.risk_classification.has_any_flag()
     )
+    result = AnalysisResult(
+        events=events,
+        graph=graph,
+        inflection_node=selection.node if selection is not None else None,
+        total_events=len(events),
+        flagged_events=flagged,
+        inflection_explanation=selection.explanation if selection is not None else None,
+        candidate_break_point=(
+            selection.candidate_break_point if selection is not None else None
+        ),
+    )
+
+    report_type = _parse_report_type(request.report_type)
+    metadata = session_model.metadata_json or {}
+    integrity_snapshot = None
+    if isinstance(metadata.get("integrity_summary"), dict):
+        integrity_snapshot = {
+            "summary": metadata.get("integrity_summary"),
+            "provenance": metadata.get("integrity_provenance"),
+        }
+
+    report_data = ReportBuilder().build(
+        domain_session,
+        result,
+        report_type=report_type,
+        integrity_snapshot=integrity_snapshot,
+    )
+    report = ReportModel(
+        id=uuid.uuid4(),
+        session_id=session_id,
+        generated_at=report_data.generated_at,
+        report_type=report_type.value,
+        content_markdown=render_markdown(report_data),
+        content_json=export_json(report_data),
+        generated_by="system",
+    )
+    db.add(report)
+    db.flush()
+    service.upsert_forensic_case(domain_session, result, report=report)
     return {"id": report.id, "report_type": report.report_type}
 
 
@@ -58,7 +111,7 @@ def generate_forensic_report(
     report_type: str = Form(default="full"),
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> ForensicWorkflowResponse:
     del api_key
     requested_report_type = _parse_report_type(report_type)
     raw_bytes = read_upload_bytes(file)
@@ -120,7 +173,7 @@ def list_session_reports(
     session_id: uuid.UUID,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> list[dict[str, object]]:
     reports = (
         db.query(ReportModel)
         .filter(ReportModel.session_id == session_id)
@@ -143,7 +196,7 @@ def get_report(
     report_id: uuid.UUID,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> dict[str, object]:
     report = db.get(ReportModel, report_id)
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found")

--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -1,5 +1,6 @@
 import math
 import uuid
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session as DBSession
@@ -13,6 +14,7 @@ from driftshield.api.schemas import (
     GraphEdgeResponse,
     GraphNodeResponse,
     GraphResponse,
+    IntegrityStatusResponse,
     PaginatedResponse,
     SessionDetail,
     SessionExplanationItemResponse,
@@ -25,12 +27,13 @@ from driftshield.api.schemas import (
 )
 from driftshield.core.models import RiskClassification
 from driftshield.db.models import (
+    AnalystValidationModel,
     DecisionNodeModel,
     ReportModel,
     SessionModel,
 )
 from driftshield.db.persistence import PersistenceService
-from driftshield.db.validation_service import ValidationService
+from driftshield.db.validation_service import ValidationRecord, ValidationService
 
 router = APIRouter()
 _REPORT_BOUND_FEEDBACK_TARGET_KINDS = {
@@ -82,10 +85,10 @@ def _risk_flags_for_node(node: DecisionNodeModel) -> list[str]:
     return flags
 
 
-def _explanation_payload(payload: dict | None) -> ExplanationPayloadResponse | None:
+def _explanation_payload(payload: dict[str, object] | None) -> ExplanationPayloadResponse | None:
     if payload is None:
         return None
-    return ExplanationPayloadResponse(**payload)
+    return ExplanationPayloadResponse(**cast(dict[str, Any], payload))
 
 
 def _risk_explanations_for_node(node: DecisionNodeModel) -> dict[str, ExplanationPayloadResponse]:
@@ -97,6 +100,11 @@ def _risk_explanations_for_node(node: DecisionNodeModel) -> dict[str, Explanatio
 
 
 def _session_provenance(session: SessionModel) -> SessionProvenanceResponse | None:
+    metadata = session.metadata_json or {}
+    integrity_provenance = metadata.get("integrity_provenance")
+    if isinstance(integrity_provenance, dict):
+        return SessionProvenanceResponse(**integrity_provenance)
+
     if not any(
         [
             session.source_session_id,
@@ -114,8 +122,17 @@ def _session_provenance(session: SessionModel) -> SessionProvenanceResponse | No
         source_session_id=session.source_session_id,
         source_path=session.source_path,
         parser_version=session.parser_version,
+        transcript_hash=session.transcript_hash,
         ingested_at=session.ingested_at,
     )
+
+
+def _extract_integrity_status(session: SessionModel) -> IntegrityStatusResponse | None:
+    metadata = session.metadata_json or {}
+    payload = metadata.get("integrity_summary")
+    if not isinstance(payload, dict):
+        return None
+    return IntegrityStatusResponse(**payload)
 
 
 def _session_explanations(nodes: list[DecisionNodeModel]) -> SessionExplanationsResponse:
@@ -191,7 +208,9 @@ def _extract_signature_match(session: SessionModel) -> SignatureMatchSummaryResp
     )
 
 
-def _feedback_response(row) -> ForensicFeedbackResponse:
+def _feedback_response(
+    row: ValidationRecord | AnalystValidationModel,
+) -> ForensicFeedbackResponse:
     metadata = row.metadata_json if isinstance(row.metadata_json, dict) else {}
     feedback = metadata.get("forensic_feedback") if isinstance(metadata, dict) else None
     if not isinstance(feedback, dict):
@@ -319,7 +338,7 @@ def list_sessions(
     since_hours: int | None = Query(default=None, ge=1),
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> PaginatedResponse:
     service = PersistenceService(db)
     try:
         sessions, total = service.list_sessions(
@@ -352,6 +371,7 @@ def list_sessions(
                 risk_flag_count=risk_count,
                 has_inflection=has_inflection,
                 provenance=_session_provenance(session),
+                integrity_status=_extract_integrity_status(session),
             )
         )
 
@@ -369,7 +389,7 @@ def get_session(
     session_id: uuid.UUID,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> SessionDetail:
     session = db.get(SessionModel, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -389,6 +409,7 @@ def get_session(
         risk_flag_count=risk_count,
         has_inflection=any(node.is_inflection_node for node in nodes),
         provenance=_session_provenance(session),
+        integrity_status=_extract_integrity_status(session),
         total_events=len(nodes),
         flagged_events=risk_count,
         risk_summary=_risk_summary(nodes),
@@ -402,7 +423,7 @@ def get_session_graph(
     session_id: uuid.UUID,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> GraphResponse:
     session = db.get(SessionModel, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -473,7 +494,7 @@ def list_session_validations(
     session_id: uuid.UUID,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> list[dict[str, object]]:
     session = db.get(SessionModel, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -504,7 +525,7 @@ def create_session_validation(
     payload: ValidationCreateRequest,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> dict[str, object]:
     session = db.get(SessionModel, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -549,7 +570,7 @@ def list_session_forensic_feedback(
     report_id: uuid.UUID | None = Query(default=None),
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> list[dict[str, object]]:
     session = db.get(SessionModel, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -572,7 +593,7 @@ def create_session_forensic_feedback(
     payload: ForensicFeedbackCreateRequest,
     api_key: str = Depends(require_api_key),
     db: DBSession = Depends(get_db),
-):
+) -> dict[str, object]:
     session = db.get(SessionModel, session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -16,7 +16,28 @@ class SessionProvenanceResponse(BaseModel):
     source_session_id: str | None = None
     source_path: str | None = None
     parser_version: str | None = None
+    transcript_hash: str | None = None
     ingested_at: datetime | None = None
+    integrity_policy_version: str | None = None
+    integrity_schema_version: str | None = None
+    integrity_evaluated_at: datetime | None = None
+    evidence_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class IntegrityStatusResponse(BaseModel):
+    integrity_schema_version: str | None = None
+    trust_band: str | None = None
+    structural_score: float | None = None
+    semantic_score: float | None = None
+    source_factor: float | None = None
+    pattern_integrity_score: float | None = None
+    final_learning_weight: float | None = None
+    integrity_reasons: list[str] = Field(default_factory=list)
+    requires_review: bool | None = None
+    integrity_evaluated_at: datetime | None = None
+    integrity_policy_version: str | None = None
+    evidence_counts: dict[str, int] = Field(default_factory=dict)
+    pattern_integrity_note: str | None = None
 
 
 class SessionExplanationItemResponse(BaseModel):
@@ -39,6 +60,7 @@ class SessionSummary(BaseModel):
     risk_flag_count: int = 0
     has_inflection: bool = False
     provenance: SessionProvenanceResponse | None = None
+    integrity_status: IntegrityStatusResponse | None = None
 
 
 class SignatureMatchSummaryResponse(BaseModel):

--- a/driftshield/src/driftshield/core/integrity.py
+++ b/driftshield/src/driftshield/core/integrity.py
@@ -1,0 +1,177 @@
+"""OSS-safe integrity scoring for stored investigation sessions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from driftshield.core.analysis.session import AnalysisResult
+from driftshield.core.models import Session as DomainSession
+
+if TYPE_CHECKING:
+    from driftshield.db.persistence import IngestProvenance
+
+INTEGRITY_SCHEMA_VERSION = "phase3e.v1"
+INTEGRITY_POLICY_VERSION = "phase3e.v1.default"
+OSS_V1_PATTERN_INTEGRITY_PLACEHOLDER = 0.95
+
+
+def build_integrity_summary(
+    session: DomainSession,
+    result: AnalysisResult,
+    provenance: IngestProvenance | None,
+) -> dict[str, Any]:
+    """Build the persisted OSS-safe integrity summary for one investigated run."""
+
+    total_events = result.total_events
+    flagged_events = result.flagged_events
+
+    structural_score, structural_reasons = _structural_score(result)
+    semantic_score, semantic_reasons = _semantic_score(result)
+    source_factor, source_reasons = _source_factor(session, provenance)
+
+    final_learning_weight = round(
+        structural_score
+        * semantic_score
+        * source_factor
+        * OSS_V1_PATTERN_INTEGRITY_PLACEHOLDER,
+        4,
+    )
+
+    trust_band = _trust_band(final_learning_weight)
+    integrity_reasons = [
+        *structural_reasons,
+        *semantic_reasons,
+        *source_reasons,
+        "pattern_integrity_placeholder_oss_v1",
+    ]
+
+    return {
+        "integrity_schema_version": INTEGRITY_SCHEMA_VERSION,
+        "trust_band": trust_band,
+        "structural_score": structural_score,
+        "semantic_score": semantic_score,
+        "source_factor": source_factor,
+        "pattern_integrity_score": OSS_V1_PATTERN_INTEGRITY_PLACEHOLDER,
+        "final_learning_weight": final_learning_weight,
+        "integrity_reasons": integrity_reasons,
+        "requires_review": trust_band != "trusted",
+        "integrity_evaluated_at": _evaluated_at(session, provenance).isoformat(),
+        "integrity_policy_version": INTEGRITY_POLICY_VERSION,
+        "evidence_counts": {
+            "total_events": total_events,
+            "flagged_events": flagged_events,
+        },
+        "pattern_integrity_note": (
+            "OSS v1 uses a conservative placeholder because private Pattern Object "
+            "promotion and recurrence logic are out of scope."
+        ),
+    }
+
+
+def build_integrity_provenance(
+    summary: dict[str, Any],
+    provenance: IngestProvenance | None,
+) -> dict[str, Any]:
+    """Build the public provenance payload for the integrity decision."""
+
+    parser_version = provenance.parser_version if provenance else None
+    return {
+        "source_type": _source_type(parser_version),
+        "source_session_id": provenance.source_session_id if provenance else None,
+        "source_path": provenance.source_path if provenance else None,
+        "parser_version": parser_version,
+        "transcript_hash": provenance.transcript_hash if provenance else None,
+        "ingested_at": provenance.ingested_at.isoformat() if provenance else None,
+        "integrity_policy_version": summary["integrity_policy_version"],
+        "integrity_schema_version": summary["integrity_schema_version"],
+        "integrity_evaluated_at": summary["integrity_evaluated_at"],
+        "evidence_counts": summary["evidence_counts"],
+    }
+
+
+def _structural_score(result: AnalysisResult) -> tuple[float, list[str]]:
+    if result.total_events == 0:
+        return 0.0, ["no_events"]
+
+    missing_actions = sum(1 for event in result.events if not event.action)
+    missing_timestamps = sum(1 for event in result.events if event.timestamp is None)
+    completeness = 1 - ((missing_actions + missing_timestamps) / (2 * result.total_events))
+    score = round(max(0.0, min(1.0, completeness)), 4)
+
+    reasons: list[str] = []
+    if missing_actions:
+        reasons.append("missing_event_actions")
+    if missing_timestamps:
+        reasons.append("missing_event_timestamps")
+    return score, reasons
+
+
+def _semantic_score(result: AnalysisResult) -> tuple[float, list[str]]:
+    if result.total_events == 0:
+        return 0.0, ["no_events"]
+
+    evidence_rich_events = sum(
+        1
+        for event in result.events
+        if event.inputs or event.outputs or event.metadata
+    )
+    coverage = evidence_rich_events / result.total_events
+    score = round(0.6 + (0.4 * coverage), 4)
+
+    reasons: list[str] = []
+    if coverage < 0.75:
+        reasons.append("sparse_event_evidence")
+    return score, reasons
+
+
+def _source_factor(
+    session: DomainSession,
+    provenance: IngestProvenance | None,
+) -> tuple[float, list[str]]:
+    score = 0.4
+    reasons: list[str] = []
+
+    if provenance and provenance.transcript_hash:
+        score += 0.25
+    else:
+        reasons.append("missing_transcript_hash")
+
+    if provenance and provenance.parser_version:
+        score += 0.2
+    else:
+        reasons.append("missing_parser_version")
+
+    if provenance and provenance.source_session_id:
+        score += 0.1
+    if provenance and provenance.source_path:
+        score += 0.05
+    if not provenance or (not provenance.source_session_id and not provenance.source_path):
+        reasons.append("missing_source_locator")
+
+    if session.external_id:
+        score += 0.05
+
+    return round(min(score, 1.0), 4), reasons
+
+
+def _trust_band(final_learning_weight: float) -> str:
+    if final_learning_weight >= 0.70:
+        return "trusted"
+    if final_learning_weight >= 0.40:
+        return "provisional"
+    return "quarantined"
+
+
+def _evaluated_at(session: DomainSession, provenance: IngestProvenance | None) -> datetime:
+    if provenance is not None:
+        return provenance.ingested_at
+    if session.ended_at is not None:
+        return session.ended_at
+    return session.started_at or datetime.now(timezone.utc)
+
+
+def _source_type(parser_version: str | None) -> str | None:
+    if not parser_version:
+        return None
+    return parser_version.split("@", 1)[0]

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session as DBSession
 from driftshield.core.analysis.session import AnalysisResult
 from driftshield.core.graph.builder import build_graph
 from driftshield.core.graph.models import DecisionNode, LineageGraph
+from driftshield.core.integrity import build_integrity_provenance, build_integrity_summary
 from driftshield.core.models import (
     CanonicalEvent,
     EventType,
@@ -116,6 +117,7 @@ class PersistenceService:
         self._apply_session_fields(
             session_model,
             session=session,
+            result=result,
             provenance=provenance,
         )
         self._db.add(session_model)
@@ -137,6 +139,7 @@ class PersistenceService:
         self._apply_session_fields(
             session_model,
             session=session,
+            result=result,
             provenance=provenance,
         )
         self._replace_session_result(session.id)
@@ -149,14 +152,20 @@ class PersistenceService:
         session_model: SessionModel,
         *,
         session: DomainSession,
+        result: AnalysisResult,
         provenance: IngestProvenance | None,
     ) -> None:
+        metadata = dict(getattr(session, "metadata", None) or {})
+        integrity_summary = build_integrity_summary(session, result, provenance)
+        metadata["integrity_summary"] = integrity_summary
+        metadata["integrity_provenance"] = build_integrity_provenance(integrity_summary, provenance)
+
         session_model.external_id = getattr(session, "external_id", None)
         session_model.agent_id = session.agent_id
         session_model.started_at = session.started_at
         session_model.ended_at = getattr(session, "ended_at", None)
         session_model.status = session.status.value
-        session_model.metadata_json = getattr(session, "metadata", None)
+        session_model.metadata_json = metadata
         session_model.transcript_hash = provenance.transcript_hash if provenance else None
         session_model.source_session_id = provenance.source_session_id if provenance else None
         session_model.source_path = provenance.source_path if provenance else None
@@ -436,11 +445,13 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
     metadata = dict(node.metadata_json or {})
     if node.inflection_explanation is not None:
         metadata["inflection_explanation"] = node.inflection_explanation
-    lineage = metadata.get("lineage") if isinstance(metadata.get("lineage"), dict) else {}
-    normalized_event = (
-        metadata.get("normalized_event")
-        if isinstance(metadata.get("normalized_event"), dict)
-        else {}
+
+    lineage_value = metadata.get("lineage")
+    lineage: dict[str, object] = dict(lineage_value) if isinstance(lineage_value, dict) else {}
+
+    normalized_event_value = metadata.get("normalized_event")
+    normalized_event: dict[str, object] = (
+        dict(normalized_event_value) if isinstance(normalized_event_value, dict) else {}
     )
 
     parent_refs: list[uuid.UUID] = []
@@ -457,41 +468,42 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
     if node.parent_node_id is not None and node.parent_node_id not in parent_refs:
         parent_refs.insert(0, node.parent_node_id)
 
-    ambiguities = [
-        str(item)
-        for item in lineage.get("lineage_ambiguities", [])
-        if isinstance(item, str)
-    ]
-    for item in normalized_event.get("ambiguities", []):
-        if isinstance(item, str) and item not in ambiguities:
-            ambiguities.append(item)
+    lineage_ambiguities_value = lineage.get("lineage_ambiguities")
+    ambiguities = (
+        [str(item) for item in lineage_ambiguities_value if isinstance(item, str)]
+        if isinstance(lineage_ambiguities_value, list)
+        else []
+    )
+
+    normalized_ambiguities_value = normalized_event.get("ambiguities")
+    if isinstance(normalized_ambiguities_value, list):
+        for item in normalized_ambiguities_value:
+            if isinstance(item, str) and item not in ambiguities:
+                ambiguities.append(item)
+
+    ordinal_value = normalized_event.get("ordinal")
+    actor_value = normalized_event.get("actor")
+    lineage_summary_value = lineage.get("summary")
+    normalized_summary_value = normalized_event.get("summary")
 
     return CanonicalEvent(
         id=node.id,
         session_id=str(session_id),
-        timestamp=node.timestamp,
-        ordinal=(
-            normalized_event.get("ordinal")
-            if isinstance(normalized_event.get("ordinal"), int)
-            else node.sequence_num
-        ),
+        timestamp=node.timestamp or datetime.now(timezone.utc),
+        ordinal=ordinal_value if isinstance(ordinal_value, int) else node.sequence_num,
         event_type=EventType(node.event_type),
         agent_id="",
-        action=node.action,
+        action=node.action or "",
         parent_event_id=node.parent_node_id,
-        inputs=node.inputs,
-        outputs=node.outputs,
+        inputs=node.inputs or {},
+        outputs=node.outputs or {},
         metadata=metadata,
-        actor=(
-            dict(normalized_event.get("actor"))
-            if isinstance(normalized_event.get("actor"), dict)
-            else None
-        ),
+        actor=dict(actor_value) if isinstance(actor_value, dict) else None,
         summary=(
-            lineage.get("summary")
-            if isinstance(lineage.get("summary"), str)
-            else normalized_event.get("summary")
-            if isinstance(normalized_event.get("summary"), str)
+            lineage_summary_value
+            if isinstance(lineage_summary_value, str)
+            else normalized_summary_value
+            if isinstance(normalized_summary_value, str)
             else None
         ),
         parent_event_refs=parent_refs,
@@ -499,13 +511,13 @@ def _node_model_to_event(node: DecisionNodeModel, session_id: uuid.UUID) -> Cano
         artifact_refs=_normalized_event_refs(normalized_event.get("artifact_refs")),
         constraints=_normalized_event_refs(normalized_event.get("constraints")),
         tool_activity=(
-            dict(normalized_event.get("tool_activity"))
-            if isinstance(normalized_event.get("tool_activity"), dict)
+            dict(tool_activity_value)
+            if isinstance((tool_activity_value := normalized_event.get("tool_activity")), dict)
             else None
         ),
         failure_context=(
-            dict(normalized_event.get("failure_context"))
-            if isinstance(normalized_event.get("failure_context"), dict)
+            dict(failure_context_value)
+            if isinstance((failure_context_value := normalized_event.get("failure_context")), dict)
             else None
         ),
         ambiguities=ambiguities,

--- a/driftshield/src/driftshield/reports/builder.py
+++ b/driftshield/src/driftshield/reports/builder.py
@@ -44,6 +44,7 @@ class ReportBuilder:
         session: DomainSession,
         result: AnalysisResult,
         report_type: ReportType = ReportType.FULL,
+        integrity_snapshot: dict[str, object] | None = None,
     ) -> ReportData:
         pattern_matches = self._build_pattern_matches(session)
         findings = self._build_findings(session, result, pattern_matches)
@@ -82,6 +83,7 @@ class ReportBuilder:
             findings=findings,
             pattern_matches=pattern_matches,
             evidence_index=evidence_index,
+            integrity_snapshot=integrity_snapshot,
         )
 
     def _build_lineage_section(self, result: AnalysisResult) -> ReportSection:
@@ -356,9 +358,10 @@ class ReportBuilder:
         if signature_id is None and not mechanism_ids:
             return []
 
+        signature_layer_value = payload.get("signature_layer")
         signature_layer = (
-            dict(payload.get("signature_layer"))
-            if isinstance(payload.get("signature_layer"), Mapping)
+            dict(signature_layer_value)
+            if isinstance(signature_layer_value, Mapping)
             else {}
         )
         rationale = _string_value(payload.get("rationale") or payload.get("summary")) or ""

--- a/driftshield/src/driftshield/reports/json_export.py
+++ b/driftshield/src/driftshield/reports/json_export.py
@@ -68,6 +68,7 @@ def export_json(report: ReportData) -> dict[str, Any]:
         "inflection_node_id": str(report.inflection_node_id) if report.inflection_node_id else None,
         "inflection_action": report.inflection_action,
         "classification": report.classification,
+        "integrity_snapshot": report.integrity_snapshot,
         "sections": [
             {
                 "title": s.title,

--- a/driftshield/src/driftshield/reports/models.py
+++ b/driftshield/src/driftshield/reports/models.py
@@ -103,3 +103,4 @@ class ReportData:
     findings: list[ReportFinding] = field(default_factory=list)
     pattern_matches: list[PatternMatch] = field(default_factory=list)
     evidence_index: list[EvidenceRef] = field(default_factory=list)
+    integrity_snapshot: dict[str, object] | None = None

--- a/driftshield/src/driftshield/reports/templates/full.md.j2
+++ b/driftshield/src/driftshield/reports/templates/full.md.j2
@@ -5,6 +5,10 @@
 **Agent:** {{ report.agent_id }}
 **Generated:** {{ report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}
 **Events:** {{ report.total_events }} total, {{ report.flagged_events }} flagged
+{% if report.integrity_snapshot and report.integrity_snapshot.summary %}
+**Integrity:** {{ report.integrity_snapshot.summary.trust_band }} (weight {{ report.integrity_snapshot.summary.final_learning_weight }})
+**Integrity reasons:** {{ report.integrity_snapshot.summary.integrity_reasons | join(', ') }}
+{% endif %}
 
 > OSS safety: {{ report.summary.oss_safety_note }}
 

--- a/driftshield/src/driftshield/reports/templates/summary.md.j2
+++ b/driftshield/src/driftshield/reports/templates/summary.md.j2
@@ -4,6 +4,9 @@
 **Session:** {{ report.session_id }}
 **Agent:** {{ report.agent_id }}
 **Generated:** {{ report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+{% if report.integrity_snapshot and report.integrity_snapshot.summary %}
+**Integrity:** {{ report.integrity_snapshot.summary.trust_band }} (weight {{ report.integrity_snapshot.summary.final_learning_weight }})
+{% endif %}
 
 > OSS safety: {{ report.summary.oss_safety_note }}
 

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -89,7 +89,39 @@ def sample_transcript():
 def seeded_session(db_session):
     session_id = uuid.uuid4()
     s = SessionModel(
-        id=session_id, agent_id="test", started_at=datetime.now(timezone.utc), status="completed"
+        id=session_id,
+        agent_id="test",
+        started_at=datetime.now(timezone.utc),
+        status="completed",
+        metadata_json={
+            "integrity_summary": {
+                "integrity_schema_version": "phase3e.v1",
+                "trust_band": "trusted",
+                "structural_score": 1.0,
+                "semantic_score": 1.0,
+                "source_factor": 0.9,
+                "pattern_integrity_score": 0.95,
+                "final_learning_weight": 0.855,
+                "integrity_reasons": ["pattern_integrity_placeholder_oss_v1"],
+                "requires_review": False,
+                "integrity_evaluated_at": "2026-04-29T07:58:00+00:00",
+                "integrity_policy_version": "phase3e.v1.default",
+                "evidence_counts": {"total_events": 1, "flagged_events": 0},
+                "pattern_integrity_note": "OSS v1 uses a conservative placeholder because private Pattern Object promotion and recurrence logic are out of scope.",
+            },
+            "integrity_provenance": {
+                "source_type": "claude_code",
+                "source_session_id": "source-session-report",
+                "source_path": "uploads/report-session.jsonl",
+                "parser_version": "claude_code@1",
+                "transcript_hash": "report-hash",
+                "ingested_at": "2026-04-29T07:57:00+00:00",
+                "integrity_policy_version": "phase3e.v1.default",
+                "integrity_schema_version": "phase3e.v1",
+                "integrity_evaluated_at": "2026-04-29T07:58:00+00:00",
+                "evidence_counts": {"total_events": 1, "flagged_events": 0},
+            },
+        },
     )
     node = DecisionNodeModel(
         id=uuid.uuid4(), session_id=session_id, sequence_num=1,
@@ -300,6 +332,8 @@ def test_generated_report_has_real_content(client, auth_headers, seeded_session,
     assert data["content_json"]["findings"]
     assert data["content_json"]["evidence_index"]
     assert data["content_json"]["candidate_break_point"]["status"] == "no_clear_break_point"
+    assert data["content_json"]["integrity_snapshot"]["summary"]["trust_band"] == "trusted"
+    assert "**Integrity:** trusted (weight 0.855)" in data["content_markdown"]
     assert "recurrence_probability" not in data["content_json"]
 
 

--- a/driftshield/tests/api/test_sessions.py
+++ b/driftshield/tests/api/test_sessions.py
@@ -55,6 +55,33 @@ def seeded_session(db_session):
         parser_version="claude_code@1",
         ingested_at=datetime.now(timezone.utc),
         metadata_json={
+            "integrity_summary": {
+                "integrity_schema_version": "phase3e.v1",
+                "trust_band": "trusted",
+                "structural_score": 1.0,
+                "semantic_score": 0.9,
+                "source_factor": 0.95,
+                "pattern_integrity_score": 0.95,
+                "final_learning_weight": 0.8123,
+                "integrity_reasons": ["pattern_integrity_placeholder_oss_v1"],
+                "requires_review": False,
+                "integrity_evaluated_at": "2026-04-29T07:58:00+00:00",
+                "integrity_policy_version": "phase3e.v1.default",
+                "evidence_counts": {"total_events": 1, "flagged_events": 1},
+                "pattern_integrity_note": "OSS v1 uses a conservative placeholder because private Pattern Object promotion and recurrence logic are out of scope.",
+            },
+            "integrity_provenance": {
+                "source_type": "claude_code",
+                "source_session_id": "source-session-1",
+                "source_path": "uploads/daily/test-agent.jsonl",
+                "parser_version": "claude_code@1",
+                "transcript_hash": "abc123",
+                "ingested_at": "2026-04-29T07:57:00+00:00",
+                "integrity_policy_version": "phase3e.v1.default",
+                "integrity_schema_version": "phase3e.v1",
+                "integrity_evaluated_at": "2026-04-29T07:58:00+00:00",
+                "evidence_counts": {"total_events": 1, "flagged_events": 1},
+            },
             "signature_match": {
                 "status": "matched",
                 "primary_family_id": "coverage_gap",
@@ -108,7 +135,27 @@ def test_list_sessions(client, auth_headers, seeded_session):
         "source_session_id": "source-session-1",
         "source_path": "uploads/daily/test-agent.jsonl",
         "parser_version": "claude_code@1",
+        "transcript_hash": "abc123",
         "ingested_at": data["items"][0]["provenance"]["ingested_at"],
+        "integrity_policy_version": "phase3e.v1.default",
+        "integrity_schema_version": "phase3e.v1",
+        "integrity_evaluated_at": data["items"][0]["provenance"]["integrity_evaluated_at"],
+        "evidence_counts": {"total_events": 1, "flagged_events": 1},
+    }
+    assert data["items"][0]["integrity_status"] == {
+        "integrity_schema_version": "phase3e.v1",
+        "trust_band": "trusted",
+        "structural_score": 1.0,
+        "semantic_score": 0.9,
+        "source_factor": 0.95,
+        "pattern_integrity_score": 0.95,
+        "final_learning_weight": 0.8123,
+        "integrity_reasons": ["pattern_integrity_placeholder_oss_v1"],
+        "requires_review": False,
+        "integrity_evaluated_at": data["items"][0]["integrity_status"]["integrity_evaluated_at"],
+        "integrity_policy_version": "phase3e.v1.default",
+        "evidence_counts": {"total_events": 1, "flagged_events": 1},
+        "pattern_integrity_note": "OSS v1 uses a conservative placeholder because private Pattern Object promotion and recurrence logic are out of scope.",
     }
     assert "recurrence_level" not in data["items"][0]
 
@@ -136,7 +183,11 @@ def test_get_session_detail(client, auth_headers, seeded_session):
     assert data["agent_id"] == "test-agent"
     assert data["provenance"]["source_type"] == "claude_code"
     assert data["provenance"]["source_session_id"] == "source-session-1"
+    assert data["provenance"]["transcript_hash"] == "abc123"
     assert data["risk_summary"]["coverage_gap"] == 1
+    assert data["integrity_status"]["trust_band"] == "trusted"
+    assert data["integrity_status"]["final_learning_weight"] == 0.8123
+    assert data["integrity_status"]["integrity_reasons"] == ["pattern_integrity_placeholder_oss_v1"]
     assert data["explanations"]["risk_explanations"] == {
         "coverage_gap": [
             {
@@ -211,6 +262,38 @@ def test_get_session_detail_falls_back_to_legacy_outcome_status(client, auth_hea
     assert payload["signature_match"]["status"] == "matched"
     assert payload["signature_match"]["primary_mechanism_id"] == "coverage_gap"
     assert "recurrence_status" not in payload
+
+
+def test_get_session_detail_keeps_backward_compat_for_missing_integrity_payload(client, auth_headers, db_session):
+    session_id = uuid.uuid4()
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            agent_id="legacy-agent",
+            started_at=datetime.now(timezone.utc),
+            status="completed",
+            source_session_id="legacy-source",
+            source_path="uploads/legacy.jsonl",
+            parser_version="claude_code@1",
+        )
+    )
+    db_session.add(
+        DecisionNodeModel(
+            id=uuid.uuid4(),
+            session_id=session_id,
+            sequence_num=1,
+            event_type="TOOL_CALL",
+            action="legacy-review",
+        )
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/sessions/{session_id}", headers=auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["integrity_status"] is None
+    assert payload["provenance"]["transcript_hash"] is None
 
 
 def test_get_session_detail_orders_explanations_by_sequence(client, auth_headers, db_session):
@@ -372,7 +455,12 @@ def test_graph_endpoint_returns_risk_and_inflection_explanations(client, auth_he
         "source_session_id": "source-session-graph",
         "source_path": "uploads/graph-session.jsonl",
         "parser_version": "claude_code@1",
+        "transcript_hash": None,
         "ingested_at": payload["provenance"]["ingested_at"],
+        "integrity_policy_version": None,
+        "integrity_schema_version": None,
+        "integrity_evaluated_at": None,
+        "evidence_counts": {},
     }
     assert payload["nodes"][0]["risk_flags"] == ["coverage_gap"]
     assert payload["nodes"][0]["risk_explanations"] == {

--- a/driftshield/tests/db/test_persistence.py
+++ b/driftshield/tests/db/test_persistence.py
@@ -465,6 +465,26 @@ def test_ingest_persists_transcript_provenance(db_session, sample_ingest_payload
     assert stored.parser_version == provenance.parser_version
     assert stored.ingested_at is not None
     assert stored.ingested_at.replace(tzinfo=timezone.utc) == provenance.ingested_at
+    assert stored.metadata_json is not None
+    assert stored.metadata_json["integrity_summary"]["integrity_schema_version"] == "phase3e.v1"
+    assert stored.metadata_json["integrity_summary"]["trust_band"] == "trusted"
+    assert stored.metadata_json["integrity_summary"]["final_learning_weight"] == 0.95
+    assert stored.metadata_json["integrity_summary"]["evidence_counts"] == {
+        "total_events": 2,
+        "flagged_events": 0,
+    }
+    assert stored.metadata_json["integrity_provenance"] == {
+        "source_type": "claude_code",
+        "source_session_id": "source-session-123",
+        "source_path": "fixtures/source-session-123.jsonl",
+        "parser_version": "claude_code@1",
+        "transcript_hash": provenance.transcript_hash,
+        "ingested_at": provenance.ingested_at.isoformat(),
+        "integrity_policy_version": "phase3e.v1.default",
+        "integrity_schema_version": "phase3e.v1",
+        "integrity_evaluated_at": provenance.ingested_at.isoformat(),
+        "evidence_counts": {"total_events": 2, "flagged_events": 0},
+    }
 
 
 def test_ingest_is_idempotent_and_returns_explicit_dedupe(db_session, sample_ingest_payload):


### PR DESCRIPTION
## Summary
- persist an OSS-safe `metadata_json.integrity_summary` and integrity provenance payload for each ingested session
- expose integrity status through session list/detail APIs and include an integrity snapshot in generated reports
- add focused API and persistence coverage for the new contract, backward compatibility, and OSS-safe boundaries

## Verification
- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 pytest tests/api tests/db -q`
- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 ruff check src/driftshield/core/integrity.py src/driftshield/db/persistence.py src/driftshield/api/schemas.py src/driftshield/api/routes/sessions.py src/driftshield/api/routes/reports.py src/driftshield/reports/models.py src/driftshield/reports/builder.py src/driftshield/reports/json_export.py tests/api/test_sessions.py tests/api/test_reports.py tests/db/test_persistence.py tests/db/test_models.py`
- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 mypy src/driftshield/core/integrity.py src/driftshield/db/persistence.py src/driftshield/api/schemas.py src/driftshield/api/routes/sessions.py src/driftshield/api/routes/reports.py src/driftshield/reports/models.py src/driftshield/reports/builder.py src/driftshield/reports/json_export.py`
- `./scripts/check-public-scope.sh`

Closes #51
