### PR TITLE
fix: keep integrity snapshots in forensic workflow reports

### DIFF
--- a/driftshield/src/driftshield/api/routes/reports.py
+++ b/driftshield/src/driftshield/api/routes/reports.py
@@ -74,13 +74,7 @@ def generate_report(
     )
 
     report_type = _parse_report_type(request.report_type)
-    metadata = session_model.metadata_json or {}
-    integrity_snapshot = None
-    if isinstance(metadata.get("integrity_summary"), dict):
-        integrity_snapshot = {
-            "summary": metadata.get("integrity_summary"),
-            "provenance": metadata.get("integrity_provenance"),
-        }
+    integrity_snapshot = _integrity_snapshot_for_session(session_model)
 
     report_data = ReportBuilder().build(
         domain_session,
@@ -222,12 +216,21 @@ def _create_report_for_session(
     if domain_session is None:
         raise HTTPException(status_code=404, detail="Session not found")
 
+    session_model = db.get(SessionModel, session_id)
+    if session_model is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
     graph = service.load_graph(session_id)
     if graph is None:
         raise HTTPException(status_code=404, detail="No graph data for session")
 
     result = _analysis_result_from_graph(graph)
-    report_data = ReportBuilder().build(domain_session, result, report_type=report_type)
+    report_data = ReportBuilder().build(
+        domain_session,
+        result,
+        report_type=report_type,
+        integrity_snapshot=_integrity_snapshot_for_session(session_model),
+    )
 
     report = ReportModel(
         id=uuid.uuid4(),
@@ -242,6 +245,18 @@ def _create_report_for_session(
     db.flush()
     forensic_case = service.upsert_forensic_case(domain_session, result, report=report)
     return report, forensic_case
+
+
+def _integrity_snapshot_for_session(
+    session_model: SessionModel,
+) -> dict[str, object] | None:
+    metadata = session_model.metadata_json or {}
+    if not isinstance(metadata.get("integrity_summary"), dict):
+        return None
+    return {
+        "summary": metadata.get("integrity_summary"),
+        "provenance": metadata.get("integrity_provenance"),
+    }
 
 
 def _load_existing_report_for_case(

--- a/driftshield/tests/api/test_reports.py
+++ b/driftshield/tests/api/test_reports.py
@@ -176,6 +176,8 @@ def test_generate_forensic_report_from_transcript_returns_forensic_contract(
     assert data["report"]["report_type"] == "summary"
     assert data["report"]["content_json"]["schema_version"] == "forensic_report.v1"
     assert data["report"]["content_json"]["summary"]["what_happened"]
+    assert data["report"]["content_json"]["integrity_snapshot"]["summary"]["trust_band"] == "trusted"
+    assert "**Integrity:** trusted" in data["report"]["content_markdown"]
     assert data["forensic_case"]["state"] == "reported"
     assert data["forensic_case"]["report_id"] == data["report"]["id"]
 
@@ -227,6 +229,7 @@ def test_generate_forensic_report_reuses_session_for_duplicate_upload(
     assert second_data["ingest_status"] == "deduped"
     assert second_data["session_id"] == first_data["session_id"]
     assert second_data["report"]["id"] == first_data["report"]["id"]
+    assert second_data["report"]["content_json"]["integrity_snapshot"]["summary"]["trust_band"] == "trusted"
 
     assert db_session.query(SessionModel).count() == 1
     assert db_session.query(ReportModel).count() == 1
@@ -239,7 +242,7 @@ def test_generate_forensic_report_rolls_back_ingest_when_report_build_fails(
     db_session,
     monkeypatch,
 ):
-    def fail_build(self, session, result, report_type):
+    def fail_build(self, session, result, report_type, **kwargs):
         raise RuntimeError("report builder failed")
 
     emit_calls = []


### PR DESCRIPTION
$## Summary\n- pass the persisted integrity snapshot through the `/api/forensics/report` report-builder path\n- keep deduped forensic report reuse consistent with the session report endpoint\n- add regression coverage for both the primary forensic workflow and deduped reuse\n\n## Why\nCodex correctly flagged that merged PR `#56` left `_create_report_for_session` on the older path, so forensic workflow reports could omit `content_json.integrity_snapshot` and the markdown integrity section even though `/api/sessions/{session_id}/report` included them.\n\n## Links\n- Closes #57\n- Follow-up to #51\n- Addresses Codex review on #56: https://github.com/tborys/driftshield/pull/56#pullrequestreview-4195381005\n\n## Verification\n- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 pytest tests/api/test_reports.py -q`\n- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 ruff check src/driftshield/api/routes/reports.py tests/api/test_reports.py`\n- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 mypy src/driftshield/api/routes/reports.py`