### PR TITLE
feat: add integrity dashboard metric summaries

### DIFF
--- a/driftshield/src/driftshield/api/app.py
+++ b/driftshield/src/driftshield/api/app.py
@@ -1,11 +1,13 @@
 import os
 from pathlib import Path
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from driftshield.api.routes.connectors import router as connectors_router
+from driftshield.api.routes.dashboard import router as dashboard_router
 from driftshield.api.routes.health import router as health_router
 from driftshield.api.routes.ingest import router as ingest_router
 from driftshield.api.routes.reports import router as reports_router
@@ -21,6 +23,7 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(RequestSizeLimitMiddleware)
     app.include_router(connectors_router)
+    app.include_router(dashboard_router)
     app.include_router(health_router)
     app.include_router(ingest_router)
     app.include_router(sessions_router)
@@ -34,7 +37,7 @@ def create_app() -> FastAPI:
         app.mount("/assets", StaticFiles(directory=str(static_dir / "assets")), name="assets")
 
         @app.get("/{path:path}")
-        async def serve_spa(path: str):
+        async def serve_spa(path: str) -> Any:
             """Serve React SPA. All non-API routes fall through to index.html."""
             file_path = static_dir / path
             if file_path.exists() and file_path.is_file():

--- a/driftshield/src/driftshield/api/routes/dashboard.py
+++ b/driftshield/src/driftshield/api/routes/dashboard.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session as DBSession
+
+from driftshield.api.auth import require_api_key
+from driftshield.api.dependencies import get_db
+from driftshield.dashboard.integrity import IntegrityDashboardService
+
+router = APIRouter()
+
+
+@router.get("/api/dashboard/integrity")
+def get_integrity_dashboard(
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+) -> dict[str, dict[str, object]]:
+    del api_key
+    return IntegrityDashboardService(db).build_dashboard_payload()

--- a/driftshield/src/driftshield/dashboard/__init__.py
+++ b/driftshield/src/driftshield/dashboard/__init__.py
@@ -1,0 +1,1 @@
+# Dashboard package

--- a/driftshield/src/driftshield/dashboard/integrity.py
+++ b/driftshield/src/driftshield/dashboard/integrity.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from statistics import median
+from typing import Any
+
+from sqlalchemy.orm import Session as DBSession
+
+from driftshield.db.models import AnalystValidationModel, SessionModel
+
+STALE_THRESHOLD_HOURS = 24
+
+
+@dataclass(slots=True)
+class IntegrityRecord:
+    trust_band: str
+    structural_score: float
+    semantic_score: float
+    source_factor: float
+    pattern_integrity_score: float
+    final_learning_weight: float
+    integrity_reasons: list[str]
+    requires_review: bool
+    integrity_evaluated_at: datetime | None
+    ingested_at: datetime | None
+    source_session_id: str | None
+    source_path: str | None
+
+
+class IntegrityDashboardService:
+    def __init__(self, db: DBSession):
+        self._db = db
+
+    def build_dashboard_payload(self) -> dict[str, dict[str, Any]]:
+        computed_at = datetime.now(timezone.utc)
+        records = self._load_records()
+
+        return {
+            "integrity_intake_summary": self._integrity_intake_summary(records, computed_at),
+            "learning_weight_breakdown": self._learning_weight_breakdown(records, computed_at),
+            "quarantine_review_summary": self._quarantine_review_summary(records, computed_at),
+            "integrity_freshness_summary": self._integrity_freshness_summary(records, computed_at),
+            "source_integrity_summary": self._source_integrity_summary(records, computed_at),
+            "recurrence_quality_summary": self._gated_summary(
+                computed_at,
+                blocked_by=["private_recurrence_engine", "cross_run_learning_store"],
+                caveats=[
+                    "Recurrence quality is gated in OSS v1 because recurrence engines and cross-run learning remain out of scope."
+                ],
+            ),
+            "pattern_promotion_summary": self._gated_summary(
+                computed_at,
+                blocked_by=["private_pattern_promotion", "private_pattern_suppression"],
+                caveats=[
+                    "Pattern promotion and suppression remain private-layer concerns and are not live OSS metrics."
+                ],
+            ),
+            "threshold_calibration_summary": self._threshold_calibration_summary(records, computed_at),
+        }
+
+    def _load_records(self) -> list[IntegrityRecord]:
+        rows = self._db.query(SessionModel).all()
+        records: list[IntegrityRecord] = []
+        for row in rows:
+            metadata = row.metadata_json or {}
+            payload = metadata.get("integrity_summary")
+            if not isinstance(payload, dict):
+                continue
+            evaluated_at = _parse_datetime(payload.get("integrity_evaluated_at"))
+            records.append(
+                IntegrityRecord(
+                    trust_band=str(payload.get("trust_band") or "unknown"),
+                    structural_score=_float_value(payload.get("structural_score")),
+                    semantic_score=_float_value(payload.get("semantic_score")),
+                    source_factor=_float_value(payload.get("source_factor")),
+                    pattern_integrity_score=_float_value(payload.get("pattern_integrity_score")),
+                    final_learning_weight=_float_value(payload.get("final_learning_weight")),
+                    integrity_reasons=_string_list(payload.get("integrity_reasons")),
+                    requires_review=bool(payload.get("requires_review")),
+                    integrity_evaluated_at=_normalize_datetime(evaluated_at),
+                    ingested_at=_normalize_datetime(row.ingested_at),
+                    source_session_id=row.source_session_id,
+                    source_path=row.source_path,
+                )
+            )
+        return records
+
+    def _integrity_intake_summary(
+        self, records: list[IntegrityRecord], computed_at: datetime
+    ) -> dict[str, Any]:
+        weights = sorted(record.final_learning_weight for record in records)
+        trust_counts = Counter(record.trust_band for record in records)
+        latest_freshness = max(
+            (record.integrity_evaluated_at for record in records if record.integrity_evaluated_at),
+            default=None,
+        )
+        return _artifact(
+            status="live",
+            computed_at=computed_at,
+            metrics={
+                "total_runs_ingested": len(records),
+                "trusted_count": trust_counts.get("trusted", 0),
+                "provisional_count": trust_counts.get("provisional", 0),
+                "quarantined_count": trust_counts.get("quarantined", 0),
+                "average_structural_score": _average(record.structural_score for record in records),
+                "average_semantic_score": _average(record.semantic_score for record in records),
+                "final_learning_weight_percentiles": {
+                    "p10": _percentile(weights, 10),
+                    "p50": _percentile(weights, 50),
+                    "p90": _percentile(weights, 90),
+                },
+                "latest_freshness_timestamp": _isoformat(latest_freshness),
+            },
+        )
+
+    def _learning_weight_breakdown(
+        self, records: list[IntegrityRecord], computed_at: datetime
+    ) -> dict[str, Any]:
+        reason_counts = Counter(
+            reason
+            for record in records
+            for reason in record.integrity_reasons
+        )
+        return _artifact(
+            status="live",
+            computed_at=computed_at,
+            metrics={
+                "average_structural_score": _average(record.structural_score for record in records),
+                "average_semantic_score": _average(record.semantic_score for record in records),
+                "average_source_factor": _average(record.source_factor for record in records),
+                "average_pattern_integrity_score": _average(
+                    record.pattern_integrity_score for record in records
+                ),
+                "final_learning_weight_buckets": _weight_buckets(records),
+                "top_downgrade_reasons": [
+                    {"reason": reason, "count": count}
+                    for reason, count in reason_counts.most_common(5)
+                ],
+            },
+        )
+
+    def _quarantine_review_summary(
+        self, records: list[IntegrityRecord], computed_at: datetime
+    ) -> dict[str, Any]:
+        quarantined_records = [record for record in records if record.trust_band == "quarantined"]
+        reviewed_ids = {
+            row.session_id
+            for row in self._db.query(AnalystValidationModel).filter(
+                AnalystValidationModel.target_type == "forensic_feedback"
+            )
+        }
+        session_rows = self._db.query(SessionModel.id, SessionModel.metadata_json).all()
+        quarantined_ids = {
+            row_id
+            for row_id, metadata in session_rows
+            if isinstance(metadata, dict)
+            and isinstance(metadata.get("integrity_summary"), dict)
+            and metadata["integrity_summary"].get("trust_band") == "quarantined"
+        }
+        reviewed_count = len(quarantined_ids & reviewed_ids)
+        return _artifact(
+            status="live",
+            computed_at=computed_at,
+            metrics={
+                "quarantined_count": len(quarantined_records),
+                "quarantine_reason_counts": [
+                    {"reason": reason, "count": count}
+                    for reason, count in Counter(
+                        reason
+                        for record in quarantined_records
+                        for reason in record.integrity_reasons
+                    ).most_common()
+                ],
+                "requires_review_count": sum(1 for record in records if record.requires_review),
+                "reviewed_count": reviewed_count,
+                "unreviewed_count": max(len(quarantined_ids) - reviewed_count, 0),
+                "freshness_timestamp": _isoformat(
+                    max(
+                        (record.integrity_evaluated_at for record in quarantined_records if record.integrity_evaluated_at),
+                        default=None,
+                    )
+                ),
+            },
+        )
+
+    def _integrity_freshness_summary(
+        self, records: list[IntegrityRecord], computed_at: datetime
+    ) -> dict[str, Any]:
+        latest_freshness = max(
+            (record.integrity_evaluated_at for record in records if record.integrity_evaluated_at),
+            default=None,
+        )
+        average_latency = _average(
+            (
+                (record.integrity_evaluated_at - record.ingested_at).total_seconds()
+                for record in records
+                if record.integrity_evaluated_at and record.ingested_at
+            )
+        )
+        stale = True
+        if latest_freshness is not None:
+            stale = (computed_at - latest_freshness) > _stale_delta()
+        return _artifact(
+            status="live",
+            computed_at=computed_at,
+            metrics={
+                "last_successful_dashboard_update_time": computed_at.isoformat(),
+                "latest_freshness_timestamp": _isoformat(latest_freshness),
+                "average_ingestion_to_integrity_latency_seconds": average_latency,
+                "stale_data": stale,
+                "stale_threshold_hours": STALE_THRESHOLD_HOURS,
+            },
+        )
+
+    def _source_integrity_summary(
+        self, records: list[IntegrityRecord], computed_at: datetime
+    ) -> dict[str, Any]:
+        locator_count = sum(
+            1 for record in records if record.source_session_id is not None or record.source_path is not None
+        )
+        if records and locator_count != len(records):
+            return _artifact(
+                status="gated",
+                computed_at=computed_at,
+                metrics={"runs_with_source_locator": locator_count, "total_runs": len(records)},
+                blocked_by=["source_session_id", "source_path"],
+                caveats=[
+                    "Source integrity summary is gated until source identifier granularity is present in an OSS-safe way for all runs in scope."
+                ],
+            )
+        return _artifact(
+            status="live",
+            computed_at=computed_at,
+            metrics={
+                "runs_with_source_locator": locator_count,
+                "total_runs": len(records),
+                "source_coverage_ratio": round(locator_count / len(records), 4) if records else 0.0,
+            },
+        )
+
+    def _threshold_calibration_summary(
+        self, records: list[IntegrityRecord], computed_at: datetime
+    ) -> dict[str, Any]:
+        if not records:
+            status = "gated"
+            caveats = ["No integrity history is available yet."]
+            blocked_by = ["integrity_history"]
+        else:
+            status = "directional"
+            caveats = [
+                "Threshold calibration remains directional until reviewed outcomes accumulate across enough live integrity history."
+            ]
+            blocked_by = ["reviewed_outcomes_volume"]
+        return _artifact(
+            status=status,
+            computed_at=computed_at,
+            metrics={
+                "observed_run_count": len(records),
+                "current_thresholds": {
+                    "trusted": 0.70,
+                    "provisional": 0.40,
+                    "quarantined_below": 0.40,
+                },
+                "median_final_learning_weight": median(
+                    [record.final_learning_weight for record in records]
+                )
+                if records
+                else None,
+            },
+            blocked_by=blocked_by,
+            caveats=caveats,
+        )
+
+    def _gated_summary(
+        self,
+        computed_at: datetime,
+        *,
+        blocked_by: list[str],
+        caveats: list[str],
+    ) -> dict[str, Any]:
+        return _artifact(
+            status="gated",
+            computed_at=computed_at,
+            metrics={},
+            blocked_by=blocked_by,
+            caveats=caveats,
+        )
+
+
+def _artifact(
+    *,
+    status: str,
+    computed_at: datetime,
+    metrics: dict[str, Any],
+    blocked_by: list[str] | None = None,
+    caveats: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "computed_at": computed_at.isoformat(),
+        "time_window": "all_time",
+        "metrics": metrics,
+        "blocked_by": blocked_by or [],
+        "caveats": caveats or [],
+    }
+
+
+def _float_value(value: object) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return _normalize_datetime(value)
+    if isinstance(value, str):
+        try:
+            return _normalize_datetime(datetime.fromisoformat(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _normalize_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _average(values: Any) -> float | None:
+    collected = [float(value) for value in values]
+    if not collected:
+        return None
+    return round(sum(collected) / len(collected), 4)
+
+
+def _percentile(values: list[float], percentile: int) -> float | None:
+    if not values:
+        return None
+    if percentile <= 0:
+        return values[0]
+    if percentile >= 100:
+        return values[-1]
+    index = round((len(values) - 1) * (percentile / 100))
+    return values[index]
+
+
+def _weight_buckets(records: list[IntegrityRecord]) -> list[dict[str, Any]]:
+    bounds = [
+        ("0.00-0.24", 0.0, 0.25),
+        ("0.25-0.39", 0.25, 0.40),
+        ("0.40-0.69", 0.40, 0.70),
+        ("0.70-1.00", 0.70, 1.01),
+    ]
+    result = []
+    for label, lower, upper in bounds:
+        result.append(
+            {
+                "bucket": label,
+                "count": sum(
+                    1
+                    for record in records
+                    if lower <= record.final_learning_weight < upper
+                ),
+            }
+        )
+    return result
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _stale_delta() -> timedelta:
+    return timedelta(hours=STALE_THRESHOLD_HOURS)

--- a/driftshield/tests/api/test_dashboard.py
+++ b/driftshield/tests/api/test_dashboard.py
@@ -1,0 +1,274 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as DBSession
+from sqlalchemy.pool import StaticPool
+
+from driftshield.api.app import create_app
+from driftshield.db.models import AnalystValidationModel, Base, SessionModel
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with DBSession(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def client(db_session, monkeypatch):
+    monkeypatch.setenv("API_KEY", "test-key")
+    app = create_app()
+    from driftshield.api.dependencies import get_db
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers():
+    return {"X-API-Key": "test-key"}
+
+
+def _make_session(
+    *,
+    trust_band: str,
+    final_learning_weight: float,
+    structural_score: float,
+    semantic_score: float,
+    source_factor: float,
+    reason_codes: list[str],
+    requires_review: bool,
+    evaluated_at: datetime,
+    ingested_at: datetime,
+    source_session_id: str | None = "source-session",
+    source_path: str | None = "uploads/session.jsonl",
+) -> SessionModel:
+    session_id = uuid.uuid4()
+    return SessionModel(
+        id=session_id,
+        agent_id="test-agent",
+        started_at=ingested_at - timedelta(minutes=1),
+        status="completed",
+        source_session_id=source_session_id,
+        source_path=source_path,
+        parser_version="claude_code@1",
+        transcript_hash=f"hash-{session_id}",
+        ingested_at=ingested_at,
+        metadata_json={
+            "integrity_summary": {
+                "integrity_schema_version": "phase3e.v1",
+                "trust_band": trust_band,
+                "structural_score": structural_score,
+                "semantic_score": semantic_score,
+                "source_factor": source_factor,
+                "pattern_integrity_score": 0.95,
+                "final_learning_weight": final_learning_weight,
+                "integrity_reasons": reason_codes,
+                "requires_review": requires_review,
+                "integrity_evaluated_at": evaluated_at.isoformat(),
+                "integrity_policy_version": "phase3e.v1.default",
+                "evidence_counts": {"total_events": 3, "flagged_events": 1},
+                "pattern_integrity_note": "OSS v1 uses a conservative placeholder because private Pattern Object promotion and recurrence logic are out of scope.",
+            },
+            "integrity_provenance": {
+                "source_type": "claude_code",
+                "source_session_id": source_session_id,
+                "source_path": source_path,
+                "parser_version": "claude_code@1",
+                "transcript_hash": f"hash-{session_id}",
+                "ingested_at": ingested_at.isoformat(),
+                "integrity_policy_version": "phase3e.v1.default",
+                "integrity_schema_version": "phase3e.v1",
+                "integrity_evaluated_at": evaluated_at.isoformat(),
+                "evidence_counts": {"total_events": 3, "flagged_events": 1},
+            },
+        },
+    )
+
+
+def test_get_integrity_dashboard_metrics(client, auth_headers, db_session):
+    now = datetime(2026, 4, 29, 9, 0, tzinfo=timezone.utc)
+    trusted = _make_session(
+        trust_band="trusted",
+        final_learning_weight=0.9,
+        structural_score=1.0,
+        semantic_score=0.9,
+        source_factor=1.0,
+        reason_codes=["pattern_integrity_placeholder_oss_v1"],
+        requires_review=False,
+        evaluated_at=now - timedelta(minutes=10),
+        ingested_at=now - timedelta(minutes=12),
+    )
+    provisional = _make_session(
+        trust_band="provisional",
+        final_learning_weight=0.55,
+        structural_score=0.8,
+        semantic_score=0.7,
+        source_factor=0.85,
+        reason_codes=["missing_source_locator"],
+        requires_review=True,
+        evaluated_at=now - timedelta(minutes=20),
+        ingested_at=now - timedelta(minutes=30),
+    )
+    quarantined = _make_session(
+        trust_band="quarantined",
+        final_learning_weight=0.2,
+        structural_score=0.4,
+        semantic_score=0.6,
+        source_factor=0.5,
+        reason_codes=["missing_parser_version", "missing_source_locator"],
+        requires_review=True,
+        evaluated_at=now - timedelta(minutes=40),
+        ingested_at=now - timedelta(minutes=60),
+    )
+    db_session.add_all([trusted, provisional, quarantined])
+    db_session.flush()
+    db_session.add(
+        AnalystValidationModel(
+            id=uuid.uuid4(),
+            session_id=quarantined.id,
+            target_type="forensic_feedback",
+            target_ref="classification",
+            verdict="needs_review",
+            confidence=0.8,
+            reviewer="tester",
+            notes="Queued",
+            metadata_json={"forensic_feedback": {"report_id": None}},
+            shareable=False,
+            created_at=now - timedelta(minutes=5),
+        )
+    )
+    db_session.commit()
+
+    response = client.get("/api/dashboard/integrity", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    intake = data["integrity_intake_summary"]
+    assert intake["status"] == "live"
+    assert intake["time_window"] == "all_time"
+    assert intake["metrics"]["total_runs_ingested"] == 3
+    assert intake["metrics"]["trusted_count"] == 1
+    assert intake["metrics"]["provisional_count"] == 1
+    assert intake["metrics"]["quarantined_count"] == 1
+    assert intake["metrics"]["latest_freshness_timestamp"] == trusted.metadata_json["integrity_summary"]["integrity_evaluated_at"]
+    assert intake["metrics"]["final_learning_weight_percentiles"] == {"p10": 0.2, "p50": 0.55, "p90": 0.9}
+
+    breakdown = data["learning_weight_breakdown"]
+    assert breakdown["status"] == "live"
+    assert breakdown["metrics"]["average_pattern_integrity_score"] == pytest.approx(0.95)
+    assert breakdown["metrics"]["top_downgrade_reasons"][0] == {"reason": "missing_source_locator", "count": 2}
+    assert sum(bucket["count"] for bucket in breakdown["metrics"]["final_learning_weight_buckets"]) == 3
+
+    quarantine = data["quarantine_review_summary"]
+    assert quarantine["status"] == "live"
+    assert quarantine["metrics"]["quarantined_count"] == 1
+    assert quarantine["metrics"]["requires_review_count"] == 2
+    assert quarantine["metrics"]["reviewed_count"] == 1
+    assert quarantine["metrics"]["unreviewed_count"] == 0
+
+    freshness = data["integrity_freshness_summary"]
+    assert freshness["status"] == "live"
+    assert freshness["metrics"]["stale_data"] is False
+    assert freshness["metrics"]["latest_freshness_timestamp"] == trusted.metadata_json["integrity_summary"]["integrity_evaluated_at"]
+    assert freshness["metrics"]["average_ingestion_to_integrity_latency_seconds"] == pytest.approx((2 * 60 + 10 * 60 + 20 * 60) / 3)
+
+    source_summary = data["source_integrity_summary"]
+    assert source_summary["status"] == "live"
+    assert source_summary["metrics"]["runs_with_source_locator"] == 3
+
+    assert data["recurrence_quality_summary"]["status"] == "gated"
+    assert data["pattern_promotion_summary"]["status"] == "gated"
+    assert data["threshold_calibration_summary"]["status"] == "directional"
+
+
+def test_dashboard_gated_payloads_are_explicit_when_source_granularity_is_missing(client, auth_headers, db_session):
+    now = datetime(2026, 4, 29, 9, 0, tzinfo=timezone.utc)
+    db_session.add(
+        _make_session(
+            trust_band="trusted",
+            final_learning_weight=0.88,
+            structural_score=0.95,
+            semantic_score=0.9,
+            source_factor=0.95,
+            reason_codes=["pattern_integrity_placeholder_oss_v1"],
+            requires_review=False,
+            evaluated_at=now,
+            ingested_at=now - timedelta(minutes=5),
+            source_session_id=None,
+            source_path=None,
+        )
+    )
+    db_session.commit()
+
+    response = client.get("/api/dashboard/integrity", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["source_integrity_summary"]["status"] == "gated"
+    assert data["source_integrity_summary"]["blocked_by"] == ["source_session_id", "source_path"]
+    assert data["recurrence_quality_summary"]["blocked_by"]
+    assert data["pattern_promotion_summary"]["blocked_by"]
+
+
+def test_dashboard_uses_persisted_integrity_fields_without_recomputing(client, auth_headers, db_session):
+    now = datetime(2026, 4, 29, 9, 0, tzinfo=timezone.utc)
+    session = _make_session(
+        trust_band="trusted",
+        final_learning_weight=0.77,
+        structural_score=0.11,
+        semantic_score=0.22,
+        source_factor=0.33,
+        reason_codes=["manual_override_for_test"],
+        requires_review=False,
+        evaluated_at=now,
+        ingested_at=now - timedelta(minutes=5),
+    )
+    db_session.add(session)
+    db_session.commit()
+
+    response = client.get("/api/dashboard/integrity", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["integrity_intake_summary"]["metrics"]["trusted_count"] == 1
+    assert data["integrity_intake_summary"]["metrics"]["final_learning_weight_percentiles"]["p50"] == 0.77
+    assert data["learning_weight_breakdown"]["metrics"]["average_structural_score"] == 0.11
+    assert data["learning_weight_breakdown"]["metrics"]["top_downgrade_reasons"] == [
+        {"reason": "manual_override_for_test", "count": 1}
+    ]
+
+
+def test_dashboard_marks_stale_data_when_freshness_exceeds_threshold(client, auth_headers, db_session):
+    now = datetime.now(timezone.utc)
+    db_session.add(
+        _make_session(
+            trust_band="quarantined",
+            final_learning_weight=0.1,
+            structural_score=0.2,
+            semantic_score=0.3,
+            source_factor=0.4,
+            reason_codes=["missing_parser_version"],
+            requires_review=True,
+            evaluated_at=now - timedelta(days=3),
+            ingested_at=now - timedelta(days=3, minutes=15),
+        )
+    )
+    db_session.commit()
+
+    response = client.get("/api/dashboard/integrity", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["integrity_freshness_summary"]["metrics"]["stale_data"] is True
+    assert data["integrity_freshness_summary"]["metrics"]["stale_threshold_hours"] == 24


### PR DESCRIPTION
$## Summary\n- add an OSS integrity dashboard endpoint with explicit live, directional, and gated artefacts\n- compute intake, learning-weight, quarantine, freshness, and source-integrity summaries directly from the persisted `#51` integrity contract\n- add focused regression coverage for live artefacts, gated payloads, stale-data signalling, and reading persisted integrity values without recomputing them\n\n## Links\n- Closes #52\n- Parent: #110\n\n## Verification\n- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 pytest tests/api/test_dashboard.py tests/api/test_sessions.py tests/api/test_reports.py -q`\n- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 ruff check src/driftshield/api/app.py src/driftshield/api/routes/dashboard.py src/driftshield/dashboard/integrity.py tests/api/test_dashboard.py`\n- `UV_PYTHON_INSTALL_DIR=$PWD/.uv-python UV_CACHE_DIR=$PWD/.uv-cache uv run --extra dev --python 3.12 mypy src/driftshield/api/app.py src/driftshield/api/routes/dashboard.py src/driftshield/dashboard/integrity.py`