### PR TITLE
Implement behaviour event tracking for issue #55

### DIFF
--- a/driftshield/docs/behaviour-events.md
+++ b/driftshield/docs/behaviour-events.md
@@ -1,0 +1,54 @@
+# Phase 3e behaviour events
+
+This is the OSS-safe v1 behaviour-event layer for intelligence surfaces.
+
+It is **not** the older generic telemetry work from `#15` / `#17`.
+
+## Separate from telemetry
+
+Telemetry remains the opt-in local NDJSON stream for registration, heartbeat, and analysis-result smoke-path events.
+
+Behaviour events are different:
+
+- they model explicit intelligence-surface subjects
+- they record user interaction with trusted intelligence surfaces
+- they make bounded pattern-to-action proxy metrics computable later
+- they can work even when generic telemetry is disabled
+
+## V1 subject model
+
+Each subject persists:
+
+- `subject_id`
+- `subject_type` = `trusted_pattern | report | linked_run_set`
+- `session_id` when the subject came from a specific investigated run
+- `pattern_reference`
+- `trust_band`
+- `surface` = `api | ui | report`
+- `first_exposed_at`
+
+## V1 event model
+
+Each event persists:
+
+- `event_id`
+- `occurred_at`
+- `event_type`
+- `subject_id`
+- `actor_id` where available
+- `originating_session_id` where applicable
+- `metadata_json`
+
+Supported v1 event types:
+
+- `pattern_viewed`
+- `pattern_expanded`
+- `pattern_revisited`
+- `pattern_linked_runs_viewed`
+- `new_run_after_pattern_view`
+
+## Follow-up linkage
+
+For trusted pattern subjects, OSS v1 can automatically attach `new_run_after_pattern_view` when a later run is ingested within the default 24-hour window and can be linked by the available local actor surrogate.
+
+This remains an observable behaviour signal, not a confirmed outcome metric.

--- a/driftshield/src/driftshield/api/app.py
+++ b/driftshield/src/driftshield/api/app.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from driftshield.api.routes.behaviour import router as behaviour_router
 from driftshield.api.routes.connectors import router as connectors_router
 from driftshield.api.routes.health import router as health_router
 from driftshield.api.routes.ingest import router as ingest_router
@@ -20,6 +21,7 @@ def create_app() -> FastAPI:
         version="0.1.0",
     )
     app.add_middleware(RequestSizeLimitMiddleware)
+    app.include_router(behaviour_router)
     app.include_router(connectors_router)
     app.include_router(health_router)
     app.include_router(ingest_router)

--- a/driftshield/src/driftshield/api/ingest_workflow.py
+++ b/driftshield/src/driftshield/api/ingest_workflow.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session as DBSession
 from driftshield.api.security import get_max_request_bytes
 from driftshield.cli.parsers import PARSERS
 from driftshield.core.analysis.session import AnalysisResult
+from driftshield.db.behaviour_service import BehaviourEventService
 from driftshield.db.ingest_service import TranscriptIngestService, metrics_payload_from_analysis_result
 from driftshield.db.persistence import IngestOutcome, IngestProvenance, PersistenceService
 from driftshield.telemetry import TelemetryService
@@ -46,6 +47,8 @@ def ingest_transcript_bytes(
             parser_name=normalised,
             source_path=filename,
         )
+        if not outcome.deduplicated and analysis_result is not None and analysis_result.events:
+            BehaviourEventService(db).link_new_run_after_pattern_view(session_id=outcome.session_id)
         if commit:
             db.commit()
             if not outcome.deduplicated and analysis_result is not None:

--- a/driftshield/src/driftshield/api/routes/behaviour.py
+++ b/driftshield/src/driftshield/api/routes/behaviour.py
@@ -13,6 +13,7 @@ from driftshield.api.schemas import (
     BehaviourSubjectResponse,
 )
 from driftshield.db.behaviour_service import BehaviourEventService
+from driftshield.db.models import SessionModel
 
 router = APIRouter()
 
@@ -45,6 +46,7 @@ def create_behaviour_subject(
 ):
     del api_key
     _validate_subject_payload(payload)
+    _require_session_exists(db, payload.session_id, detail="Behaviour subject session not found")
 
     service = BehaviourEventService(db)
     subject = service.create_subject(
@@ -84,6 +86,11 @@ def create_behaviour_event(
     del api_key
     if payload.event_type not in _ALLOWED_EVENT_TYPES:
         raise HTTPException(status_code=422, detail="Unsupported behaviour event type")
+    _require_session_exists(
+        db,
+        payload.linked_session_id,
+        detail="Linked behaviour event session not found",
+    )
 
     service = BehaviourEventService(db)
     try:
@@ -122,6 +129,18 @@ def _validate_subject_payload(payload: BehaviourSubjectCreateRequest) -> None:
             status_code=422,
             detail="Only trusted_pattern subjects can be marked trusted in OSS v1",
         )
+
+
+def _require_session_exists(
+    db: DBSession,
+    session_id: uuid.UUID | None,
+    *,
+    detail: str,
+) -> None:
+    if session_id is None:
+        return
+    if db.get(SessionModel, session_id) is None:
+        raise HTTPException(status_code=404, detail=detail)
 
 
 def _subject_response(snapshot) -> BehaviourSubjectResponse:

--- a/driftshield/src/driftshield/api/routes/behaviour.py
+++ b/driftshield/src/driftshield/api/routes/behaviour.py
@@ -1,0 +1,141 @@
+import uuid
+from typing import Literal, cast
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session as DBSession
+
+from driftshield.api.auth import require_api_key
+from driftshield.api.dependencies import get_db
+from driftshield.api.schemas import (
+    BehaviourEventCreateRequest,
+    BehaviourEventResponse,
+    BehaviourSubjectCreateRequest,
+    BehaviourSubjectResponse,
+)
+from driftshield.db.behaviour_service import BehaviourEventService
+
+router = APIRouter()
+
+SubjectType = Literal["trusted_pattern", "report", "linked_run_set"]
+SurfaceType = Literal["api", "ui", "report"]
+EventType = Literal[
+    "pattern_viewed",
+    "pattern_expanded",
+    "pattern_revisited",
+    "pattern_linked_runs_viewed",
+    "new_run_after_pattern_view",
+]
+
+_ALLOWED_SUBJECT_TYPES = {"trusted_pattern", "report", "linked_run_set"}
+_ALLOWED_SURFACES = {"api", "ui", "report"}
+_ALLOWED_EVENT_TYPES = {
+    "pattern_viewed",
+    "pattern_expanded",
+    "pattern_revisited",
+    "pattern_linked_runs_viewed",
+    "new_run_after_pattern_view",
+}
+
+
+@router.post("/api/behaviour/subjects", response_model=BehaviourSubjectResponse, status_code=201)
+def create_behaviour_subject(
+    payload: BehaviourSubjectCreateRequest,
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+):
+    del api_key
+    _validate_subject_payload(payload)
+
+    service = BehaviourEventService(db)
+    subject = service.create_subject(
+        subject_type=cast(SubjectType, payload.subject_type),
+        pattern_reference=payload.pattern_reference,
+        trust_band=payload.trust_band,
+        surface=cast(SurfaceType, payload.surface),
+        session_id=payload.session_id,
+        first_exposed_at=payload.first_exposed_at,
+        metadata_json=payload.metadata_json,
+    )
+    snapshot = service.get_subject_snapshot(subject.id)
+    assert snapshot is not None
+    db.commit()
+    return _subject_response(snapshot)
+
+
+@router.get("/api/behaviour/subjects/{subject_id}", response_model=BehaviourSubjectResponse)
+def get_behaviour_subject(
+    subject_id: uuid.UUID,
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+):
+    del api_key
+    snapshot = BehaviourEventService(db).get_subject_snapshot(subject_id)
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="Behaviour subject not found")
+    return _subject_response(snapshot)
+
+
+@router.post("/api/behaviour/events", response_model=BehaviourEventResponse, status_code=201)
+def create_behaviour_event(
+    payload: BehaviourEventCreateRequest,
+    api_key: str = Depends(require_api_key),
+    db: DBSession = Depends(get_db),
+):
+    del api_key
+    if payload.event_type not in _ALLOWED_EVENT_TYPES:
+        raise HTTPException(status_code=422, detail="Unsupported behaviour event type")
+
+    service = BehaviourEventService(db)
+    try:
+        event = service.record_event(
+            subject_id=payload.subject_id,
+            event_type=cast(EventType, payload.event_type),
+            actor_id=payload.actor_id,
+            originating_session_id=payload.originating_session_id,
+            linked_session_id=payload.linked_session_id,
+            occurred_at=payload.occurred_at,
+            metadata_json=payload.metadata_json,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    db.commit()
+    return BehaviourEventResponse(
+        id=event.id,
+        subject_id=event.subject_id,
+        occurred_at=event.occurred_at,
+        event_type=event.event_type,
+        actor_id=event.actor_id,
+        originating_session_id=event.originating_session_id,
+        linked_session_id=event.linked_session_id,
+        metadata_json=event.metadata_json or {},
+    )
+
+
+def _validate_subject_payload(payload: BehaviourSubjectCreateRequest) -> None:
+    if payload.subject_type not in _ALLOWED_SUBJECT_TYPES:
+        raise HTTPException(status_code=422, detail="Unsupported behaviour subject type")
+    if payload.surface not in _ALLOWED_SURFACES:
+        raise HTTPException(status_code=422, detail="Unsupported behaviour surface")
+    if payload.subject_type != "trusted_pattern" and payload.trust_band == "trusted":
+        raise HTTPException(
+            status_code=422,
+            detail="Only trusted_pattern subjects can be marked trusted in OSS v1",
+        )
+
+
+def _subject_response(snapshot) -> BehaviourSubjectResponse:
+    subject = snapshot.subject
+    return BehaviourSubjectResponse(
+        id=subject.id,
+        session_id=subject.session_id,
+        subject_type=subject.subject_type,
+        pattern_reference=subject.pattern_reference,
+        trust_band=subject.trust_band,
+        surface=subject.surface,
+        first_exposed_at=subject.first_exposed_at,
+        metadata_json=subject.metadata_json or {},
+        tracking_status=snapshot.tracking_status,
+        follow_up_status=snapshot.follow_up_status,
+        event_counts=snapshot.event_counts,
+    )

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -127,6 +127,51 @@ class IngestResponse(BaseModel):
     deduplicated: bool = False
 
 
+class BehaviourSubjectCreateRequest(BaseModel):
+    subject_type: str
+    pattern_reference: str
+    trust_band: str
+    surface: str
+    session_id: uuid.UUID | None = None
+    first_exposed_at: datetime | None = None
+    metadata_json: dict[str, Any] | None = None
+
+
+class BehaviourEventCreateRequest(BaseModel):
+    subject_id: uuid.UUID
+    event_type: str
+    actor_id: str | None = None
+    originating_session_id: str | None = None
+    linked_session_id: uuid.UUID | None = None
+    occurred_at: datetime | None = None
+    metadata_json: dict[str, Any] | None = None
+
+
+class BehaviourSubjectResponse(BaseModel):
+    id: uuid.UUID
+    session_id: uuid.UUID | None = None
+    subject_type: str
+    pattern_reference: str
+    trust_band: str
+    surface: str
+    first_exposed_at: datetime
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+    tracking_status: str
+    follow_up_status: str
+    event_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class BehaviourEventResponse(BaseModel):
+    id: uuid.UUID
+    subject_id: uuid.UUID
+    occurred_at: datetime
+    event_type: str
+    actor_id: str | None = None
+    originating_session_id: str | None = None
+    linked_session_id: uuid.UUID | None = None
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+
+
 class GeneratedReportResponse(BaseModel):
     id: uuid.UUID
     session_id: uuid.UUID

--- a/driftshield/src/driftshield/db/behaviour_service.py
+++ b/driftshield/src/driftshield/db/behaviour_service.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session as DBSession
+
+from driftshield.db.models import BehaviourEventModel, BehaviourEventSubjectModel, SessionModel
+
+BehaviourSubjectType = Literal["trusted_pattern", "report", "linked_run_set"]
+BehaviourSurface = Literal["api", "ui", "report"]
+BehaviourEventType = Literal[
+    "pattern_viewed",
+    "pattern_expanded",
+    "pattern_revisited",
+    "pattern_linked_runs_viewed",
+    "new_run_after_pattern_view",
+]
+
+TRACKABLE_TRUST_BAND = "trusted"
+DEFAULT_PATTERN_ACTION_WINDOW_HOURS = 24
+
+
+@dataclass(frozen=True)
+class BehaviourSubjectSnapshot:
+    subject: BehaviourEventSubjectModel
+    event_counts: dict[str, int]
+    tracking_status: str
+    follow_up_status: str
+
+
+class BehaviourEventService:
+    def __init__(self, db: DBSession):
+        self._db = db
+
+    def create_subject(
+        self,
+        *,
+        subject_type: BehaviourSubjectType,
+        pattern_reference: str,
+        trust_band: str,
+        surface: BehaviourSurface,
+        session_id: uuid.UUID | None = None,
+        first_exposed_at: datetime | None = None,
+        metadata_json: dict[str, Any] | None = None,
+    ) -> BehaviourEventSubjectModel:
+        first_exposed_at = _ensure_utc(first_exposed_at) or _utc_now()
+        subject = BehaviourEventSubjectModel(
+            id=uuid.uuid4(),
+            session_id=session_id,
+            subject_type=subject_type,
+            pattern_reference=pattern_reference,
+            trust_band=trust_band,
+            surface=surface,
+            first_exposed_at=first_exposed_at,
+            metadata_json=dict(metadata_json or {}),
+        )
+        self._db.add(subject)
+        self._db.flush()
+        return subject
+
+    def record_event(
+        self,
+        *,
+        subject_id: uuid.UUID,
+        event_type: BehaviourEventType,
+        actor_id: str | None = None,
+        originating_session_id: str | None = None,
+        linked_session_id: uuid.UUID | None = None,
+        occurred_at: datetime | None = None,
+        metadata_json: dict[str, Any] | None = None,
+    ) -> BehaviourEventModel:
+        subject = self._db.get(BehaviourEventSubjectModel, subject_id)
+        if subject is None:
+            raise LookupError("Behaviour subject not found")
+
+        event = BehaviourEventModel(
+            id=uuid.uuid4(),
+            subject_id=subject_id,
+            occurred_at=_ensure_utc(occurred_at) or _utc_now(),
+            event_type=event_type,
+            actor_id=actor_id,
+            originating_session_id=originating_session_id,
+            linked_session_id=linked_session_id,
+            metadata_json=dict(metadata_json or {}),
+        )
+        self._db.add(event)
+        self._db.flush()
+        return event
+
+    def get_subject_snapshot(self, subject_id: uuid.UUID) -> BehaviourSubjectSnapshot | None:
+        subject = self._db.get(BehaviourEventSubjectModel, subject_id)
+        if subject is None:
+            return None
+
+        counts = self._event_counts(subject_id)
+        tracking_status = "live" if subject.trust_band == TRACKABLE_TRUST_BAND else "unavailable"
+        if tracking_status != "live" or counts.get("pattern_viewed", 0) == 0:
+            follow_up_status = "unavailable"
+        elif counts.get("new_run_after_pattern_view", 0) > 0:
+            follow_up_status = "linked"
+        else:
+            follow_up_status = "no_follow_up_observed"
+
+        return BehaviourSubjectSnapshot(
+            subject=subject,
+            event_counts=counts,
+            tracking_status=tracking_status,
+            follow_up_status=follow_up_status,
+        )
+
+    def link_new_run_after_pattern_view(
+        self,
+        *,
+        session_id: uuid.UUID,
+        window_hours: int = DEFAULT_PATTERN_ACTION_WINDOW_HOURS,
+    ) -> int:
+        session = self._db.get(SessionModel, session_id)
+        if session is None or not session.agent_id:
+            return 0
+
+        if session.started_at.tzinfo is None:
+            session_started_at = session.started_at.replace(tzinfo=UTC)
+        else:
+            session_started_at = session.started_at.astimezone(UTC)
+
+        window_start = session_started_at - timedelta(hours=window_hours)
+
+        subject_rows = self._db.execute(
+            select(BehaviourEventSubjectModel)
+            .join(
+                BehaviourEventModel,
+                BehaviourEventModel.subject_id == BehaviourEventSubjectModel.id,
+            )
+            .where(BehaviourEventSubjectModel.trust_band == TRACKABLE_TRUST_BAND)
+            .where(BehaviourEventModel.event_type == "pattern_viewed")
+            .where(BehaviourEventModel.actor_id == session.agent_id)
+            .where(BehaviourEventModel.occurred_at >= window_start)
+            .where(BehaviourEventModel.occurred_at <= session_started_at)
+            .distinct()
+        ).scalars()
+
+        linked_count = 0
+        for subject in subject_rows:
+            existing = self._db.execute(
+                select(BehaviourEventModel.id)
+                .where(BehaviourEventModel.subject_id == subject.id)
+                .where(BehaviourEventModel.event_type == "new_run_after_pattern_view")
+                .where(BehaviourEventModel.linked_session_id == session.id)
+            ).scalar_one_or_none()
+            if existing is not None:
+                continue
+
+            self.record_event(
+                subject_id=subject.id,
+                event_type="new_run_after_pattern_view",
+                actor_id=session.agent_id,
+                originating_session_id=session.source_session_id,
+                linked_session_id=session.id,
+                occurred_at=session_started_at,
+                metadata_json={
+                    "window_hours": window_hours,
+                    "linked_via": "agent_id",
+                    "tracking_boundary": "behaviour_events_v1",
+                },
+            )
+            linked_count += 1
+
+        return linked_count
+
+    def _event_counts(self, subject_id: uuid.UUID) -> dict[str, int]:
+        rows = self._db.execute(
+            select(BehaviourEventModel.event_type, func.count(BehaviourEventModel.id))
+            .where(BehaviourEventModel.subject_id == subject_id)
+            .group_by(BehaviourEventModel.event_type)
+        ).all()
+        return {event_type: count for event_type, count in rows}
+
+
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/driftshield/src/driftshield/db/migrations/versions/c3d9e4f1a2b5_add_behaviour_event_tables.py
+++ b/driftshield/src/driftshield/db/migrations/versions/c3d9e4f1a2b5_add_behaviour_event_tables.py
@@ -1,0 +1,89 @@
+"""add behaviour event tables
+
+Revision ID: c3d9e4f1a2b5
+Revises: b7c1e3d5f6a2
+Create Date: 2026-04-29 18:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "c3d9e4f1a2b5"
+down_revision: str | None = "b7c1e3d5f6a2"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "behaviour_event_subjects",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("subject_type", sa.String(), nullable=False),
+        sa.Column("pattern_reference", sa.String(), nullable=False),
+        sa.Column("trust_band", sa.String(), nullable=False),
+        sa.Column("surface", sa.String(), nullable=False),
+        sa.Column("first_exposed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["session_id"], ["sessions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_behaviour_event_subjects_pattern_reference",
+        "behaviour_event_subjects",
+        ["pattern_reference"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_behaviour_event_subjects_session_id",
+        "behaviour_event_subjects",
+        ["session_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "behaviour_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("subject_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("actor_id", sa.String(), nullable=True),
+        sa.Column("originating_session_id", sa.String(), nullable=True),
+        sa.Column("linked_session_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["linked_session_id"], ["sessions.id"]),
+        sa.ForeignKeyConstraint(["subject_id"], ["behaviour_event_subjects.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_behaviour_events_event_type_linked_session",
+        "behaviour_events",
+        ["event_type", "linked_session_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_behaviour_events_subject_id_occurred_at",
+        "behaviour_events",
+        ["subject_id", "occurred_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_behaviour_events_subject_id_occurred_at", table_name="behaviour_events")
+    op.drop_index("ix_behaviour_events_event_type_linked_session", table_name="behaviour_events")
+    op.drop_table("behaviour_events")
+
+    op.drop_index(
+        "ix_behaviour_event_subjects_session_id",
+        table_name="behaviour_event_subjects",
+    )
+    op.drop_index(
+        "ix_behaviour_event_subjects_pattern_reference",
+        table_name="behaviour_event_subjects",
+    )
+    op.drop_table("behaviour_event_subjects")

--- a/driftshield/src/driftshield/db/models.py
+++ b/driftshield/src/driftshield/db/models.py
@@ -209,3 +209,51 @@ class AnalystValidationModel(Base):
     metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     shareable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class BehaviourEventSubjectModel(Base):
+    __tablename__ = "behaviour_event_subjects"
+    __table_args__ = (
+        Index("ix_behaviour_event_subjects_session_id", "session_id"),
+        Index("ix_behaviour_event_subjects_pattern_reference", "pattern_reference"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    session_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("sessions.id"), nullable=True
+    )
+    subject_type: Mapped[str] = mapped_column(String, nullable=False)
+    pattern_reference: Mapped[str] = mapped_column(String, nullable=False)
+    trust_band: Mapped[str] = mapped_column(String, nullable=False)
+    surface: Mapped[str] = mapped_column(String, nullable=False)
+    first_exposed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+
+class BehaviourEventModel(Base):
+    __tablename__ = "behaviour_events"
+    __table_args__ = (
+        Index("ix_behaviour_events_subject_id_occurred_at", "subject_id", "occurred_at"),
+        Index(
+            "ix_behaviour_events_event_type_linked_session",
+            "event_type",
+            "linked_session_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    subject_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("behaviour_event_subjects.id"), nullable=False
+    )
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    actor_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    originating_session_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    linked_session_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("sessions.id"), nullable=True
+    )
+    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)

--- a/driftshield/tests/api/test_behaviour.py
+++ b/driftshield/tests/api/test_behaviour.py
@@ -1,0 +1,162 @@
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as DBSession
+from sqlalchemy.pool import StaticPool
+
+from driftshield.api.app import create_app
+from driftshield.db.models import Base, SessionModel
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with DBSession(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def client(db_session, monkeypatch):
+    monkeypatch.setenv("API_KEY", "test-key")
+    app = create_app()
+    from driftshield.api.dependencies import get_db
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers():
+    return {"X-API-Key": "test-key"}
+
+
+def test_create_behaviour_subject_and_event(client, auth_headers, db_session):
+    session_id = uuid.uuid4()
+    db_session.add(SessionModel(id=session_id, started_at=datetime.now(UTC), status="completed"))
+    db_session.commit()
+
+    subject_response = client.post(
+        "/api/behaviour/subjects",
+        headers=auth_headers,
+        json={
+            "subject_type": "trusted_pattern",
+            "pattern_reference": "pattern:coverage-gap",
+            "trust_band": "trusted",
+            "surface": "api",
+            "session_id": str(session_id),
+        },
+    )
+    assert subject_response.status_code == 201
+    subject = subject_response.json()
+    assert subject["tracking_status"] == "live"
+    assert subject["follow_up_status"] == "unavailable"
+
+    event_response = client.post(
+        "/api/behaviour/events",
+        headers=auth_headers,
+        json={
+            "subject_id": subject["id"],
+            "event_type": "pattern_viewed",
+            "actor_id": "acct-1",
+        },
+    )
+    assert event_response.status_code == 201
+    event = event_response.json()
+    assert event["event_type"] == "pattern_viewed"
+
+    subject_after_view = client.get(
+        f"/api/behaviour/subjects/{subject['id']}",
+        headers=auth_headers,
+    )
+    assert subject_after_view.status_code == 200
+    payload = subject_after_view.json()
+    assert payload["event_counts"] == {"pattern_viewed": 1}
+    assert payload["follow_up_status"] == "no_follow_up_observed"
+
+
+def test_non_trusted_subjects_stay_unavailable_for_follow_up_metrics(client, auth_headers):
+    response = client.post(
+        "/api/behaviour/subjects",
+        headers=auth_headers,
+        json={
+            "subject_type": "report",
+            "pattern_reference": "report:session-1",
+            "trust_band": "directional",
+            "surface": "report",
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["tracking_status"] == "unavailable"
+    assert payload["follow_up_status"] == "unavailable"
+
+
+def test_ingest_creates_new_run_after_pattern_view_without_touching_telemetry(client, auth_headers, monkeypatch):
+    viewed_at = "2026-04-29T16:30:00+00:00"
+    subject_response = client.post(
+        "/api/behaviour/subjects",
+        headers=auth_headers,
+        json={
+            "subject_type": "trusted_pattern",
+            "pattern_reference": "pattern:coverage-gap",
+            "trust_band": "trusted",
+            "surface": "ui",
+            "first_exposed_at": viewed_at,
+        },
+    )
+    assert subject_response.status_code == 201
+    subject_id = subject_response.json()["id"]
+
+    view_response = client.post(
+        "/api/behaviour/events",
+        headers=auth_headers,
+        json={
+            "subject_id": subject_id,
+            "event_type": "pattern_viewed",
+            "actor_id": "claude",
+            "occurred_at": viewed_at,
+        },
+    )
+    assert view_response.status_code == 201
+
+    telemetry_calls: list[dict[str, object]] = []
+
+    def fake_record_analysis_event(self, **kwargs):
+        telemetry_calls.append(kwargs)
+        return False
+
+    monkeypatch.setattr(
+        "driftshield.api.ingest_workflow.TelemetryService.record_analysis_event",
+        fake_record_analysis_event,
+    )
+
+    transcript = "\n".join(
+        [
+            '{"sessionId":"behaviour-follow-up","type":"assistant","message":{"content":[{"type":"tool_use","id":"tool_1","name":"Read","input":{"file_path":"/tmp/test.txt"}}]},"timestamp":"2026-04-29T17:00:00+00:00"}',
+            '{"sessionId":"behaviour-follow-up","type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool_1","content":"ok"}]},"timestamp":"2026-04-29T17:00:01+00:00"}',
+        ]
+    ).encode()
+
+    ingest_response = client.post(
+        "/api/ingest",
+        headers=auth_headers,
+        files={"file": ("follow-up.jsonl", transcript, "application/jsonl")},
+        data={"format": "claude_code"},
+    )
+    assert ingest_response.status_code == 201
+    assert telemetry_calls
+
+    subject_after_ingest = client.get(f"/api/behaviour/subjects/{subject_id}", headers=auth_headers)
+    assert subject_after_ingest.status_code == 200
+    payload = subject_after_ingest.json()
+    assert payload["event_counts"]["pattern_viewed"] == 1
+    assert payload["event_counts"]["new_run_after_pattern_view"] == 1
+    assert payload["follow_up_status"] == "linked"

--- a/driftshield/tests/api/test_behaviour.py
+++ b/driftshield/tests/api/test_behaviour.py
@@ -99,6 +99,49 @@ def test_non_trusted_subjects_stay_unavailable_for_follow_up_metrics(client, aut
     assert payload["follow_up_status"] == "unavailable"
 
 
+def test_create_behaviour_subject_rejects_unknown_session_id(client, auth_headers):
+    response = client.post(
+        "/api/behaviour/subjects",
+        headers=auth_headers,
+        json={
+            "subject_type": "trusted_pattern",
+            "pattern_reference": "pattern:coverage-gap",
+            "trust_band": "trusted",
+            "surface": "api",
+            "session_id": str(uuid.uuid4()),
+        },
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Behaviour subject session not found"
+
+
+def test_create_behaviour_event_rejects_unknown_linked_session_id(client, auth_headers):
+    subject_response = client.post(
+        "/api/behaviour/subjects",
+        headers=auth_headers,
+        json={
+            "subject_type": "trusted_pattern",
+            "pattern_reference": "pattern:coverage-gap",
+            "trust_band": "trusted",
+            "surface": "api",
+        },
+    )
+    assert subject_response.status_code == 201
+    subject_id = subject_response.json()["id"]
+
+    response = client.post(
+        "/api/behaviour/events",
+        headers=auth_headers,
+        json={
+            "subject_id": subject_id,
+            "event_type": "new_run_after_pattern_view",
+            "linked_session_id": str(uuid.uuid4()),
+        },
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Linked behaviour event session not found"
+
+
 def test_ingest_creates_new_run_after_pattern_view_without_touching_telemetry(client, auth_headers, monkeypatch):
     viewed_at = "2026-04-29T16:30:00+00:00"
     subject_response = client.post(

--- a/driftshield/tests/db/test_behaviour_service.py
+++ b/driftshield/tests/db/test_behaviour_service.py
@@ -1,0 +1,134 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from driftshield.db.behaviour_service import BehaviourEventService
+from driftshield.db.models import Base, BehaviourEventModel, BehaviourEventSubjectModel, SessionModel
+
+
+def _db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_behaviour_subject_creation_and_persistence():
+    with _db_session() as db:
+        service = BehaviourEventService(db)
+        session_id = uuid.uuid4()
+        db.add(SessionModel(id=session_id, started_at=datetime.now(UTC), status="completed"))
+        db.flush()
+
+        subject = service.create_subject(
+            subject_type="trusted_pattern",
+            pattern_reference="pattern:coverage-gap",
+            trust_band="trusted",
+            surface="api",
+            session_id=session_id,
+        )
+        db.commit()
+
+        loaded = db.get(BehaviourEventSubjectModel, subject.id)
+        assert loaded is not None
+        assert loaded.subject_type == "trusted_pattern"
+        assert loaded.pattern_reference == "pattern:coverage-gap"
+        assert loaded.trust_band == "trusted"
+        assert loaded.surface == "api"
+        assert loaded.session_id == session_id
+
+
+def test_behaviour_event_persists_all_v1_event_types():
+    with _db_session() as db:
+        service = BehaviourEventService(db)
+        subject = service.create_subject(
+            subject_type="trusted_pattern",
+            pattern_reference="pattern:coverage-gap",
+            trust_band="trusted",
+            surface="ui",
+        )
+
+        event_types = [
+            "pattern_viewed",
+            "pattern_expanded",
+            "pattern_revisited",
+            "pattern_linked_runs_viewed",
+            "new_run_after_pattern_view",
+        ]
+        for event_type in event_types:
+            service.record_event(subject_id=subject.id, event_type=event_type, actor_id="acct-1")
+        db.commit()
+
+        rows = db.query(BehaviourEventModel).filter(BehaviourEventModel.subject_id == subject.id).all()
+        assert {row.event_type for row in rows} == set(event_types)
+
+
+def test_trusted_pattern_view_links_to_new_run_after_follow_up_ingest():
+    with _db_session() as db:
+        service = BehaviourEventService(db)
+        viewed_at = datetime.now(UTC) - timedelta(hours=2)
+        subject = service.create_subject(
+            subject_type="trusted_pattern",
+            pattern_reference="pattern:verification-failure",
+            trust_band="trusted",
+            surface="report",
+            first_exposed_at=viewed_at,
+        )
+        service.record_event(
+            subject_id=subject.id,
+            event_type="pattern_viewed",
+            actor_id="claude-code",
+            occurred_at=viewed_at,
+        )
+
+        new_session_id = uuid.uuid4()
+        db.add(
+            SessionModel(
+                id=new_session_id,
+                agent_id="claude-code",
+                started_at=datetime.now(UTC),
+                status="completed",
+                source_session_id="follow-up-run-1",
+            )
+        )
+        db.flush()
+
+        linked_count = service.link_new_run_after_pattern_view(session_id=new_session_id)
+        db.commit()
+
+        assert linked_count == 1
+        linked = (
+            db.query(BehaviourEventModel)
+            .filter(BehaviourEventModel.subject_id == subject.id)
+            .filter(BehaviourEventModel.event_type == "new_run_after_pattern_view")
+            .one()
+        )
+        assert linked.actor_id == "claude-code"
+        assert linked.originating_session_id == "follow-up-run-1"
+        assert linked.linked_session_id == new_session_id
+
+
+def test_behaviour_events_do_not_depend_on_generic_telemetry_state():
+    with _db_session() as db:
+        service = BehaviourEventService(db)
+        subject = service.create_subject(
+            subject_type="trusted_pattern",
+            pattern_reference="pattern:coverage-gap",
+            trust_band="trusted",
+            surface="api",
+            metadata_json={"distinction": "not telemetry"},
+        )
+        event = service.record_event(
+            subject_id=subject.id,
+            event_type="pattern_viewed",
+            actor_id="acct-2",
+            metadata_json={"source": "behaviour_events_v1"},
+        )
+        db.commit()
+
+        assert event.metadata_json == {"source": "behaviour_events_v1"}
+        snapshot = service.get_subject_snapshot(subject.id)
+        assert snapshot is not None
+        assert snapshot.tracking_status == "live"
+        assert snapshot.follow_up_status == "no_follow_up_observed"


### PR DESCRIPTION
## Summary
- add an OSS-safe behaviour-event subject and event persistence layer, separate from generic telemetry
- add minimal authenticated behaviour subject/event API routes and auto-link `new_run_after_pattern_view` during follow-up ingest
- document the v1 model and cover subject persistence, event persistence, linkage, and telemetry-boundary behaviour with tests

## Issue
- Part of #55

## Verification
- `.venv/bin/pytest -q`

## Notes
- Keeps this work distinct from the older `#15` / `#17` telemetry path
- Tracks trusted-pattern follow-up as observable behaviour only, with a default 24-hour window
