### PR TITLE
feat: add OSS signature-pack pull cache fallback

### DIFF
--- a/driftshield/src/driftshield/cli/commands/signatures.py
+++ b/driftshield/src/driftshield/cli/commands/signatures.py
@@ -10,7 +10,7 @@ from rich.console import Console
 
 from driftshield.signatures.distribution import (
     DEFAULT_COMMUNITY_REPOSITORY,
-    build_github_raw_pack_url,
+    build_github_raw_manifest_url,
     describe_pack_source,
     install_community_pack,
 )
@@ -42,7 +42,7 @@ def pull_signature_pack(
     source_url: str | None = typer.Option(
         None,
         "--url",
-        help="Explicit manifest URL. Overrides --repository/--ref when supplied.",
+        help="Explicit distribution-manifest or legacy pack URL. Overrides --repository/--ref when supplied.",
     ),
     output: Path | None = typer.Option(
         None,
@@ -57,14 +57,14 @@ def pull_signature_pack(
         raise typer.Exit(1)
 
     try:
-        resolved_source_url = source_url or build_github_raw_pack_url(
+        resolved_source_url = source_url or build_github_raw_manifest_url(
             repository=_validate_repository(repository),
             ref=ref or "",
-            pack_name=pack_name,
         )
         pulled = install_community_pack(
             source_url=resolved_source_url,
             destination=output,
+            pack_name_hint=pack_name,
         )
     except Exception as exc:
         console.print(f"[red]Error:[/red] Could not pull pack: {exc}")
@@ -75,18 +75,22 @@ def pull_signature_pack(
         "pack_version": pulled.manifest.metadata.version,
         "schema_version": pulled.manifest.schema_version,
         "source_url": describe_pack_source(pulled.source_url),
+        "manifest_url": describe_pack_source(pulled.manifest_url) if pulled.manifest_url else None,
         "installed_path": str(pulled.installed_path),
         "signature_count": len(pulled.manifest.signatures),
         "family_coverage": list(pulled.manifest.family_coverage),
+        "used_cached_pack": pulled.used_cached_pack,
     }
     if json_output:
         typer.echo(json.dumps(payload))
         return
 
     console.print(
-        "[green]Pulled community pack[/green] "
+        f"[green]{'Using cached community pack' if pulled.used_cached_pack else 'Pulled community pack'}[/green] "
         f"{payload['pack_name']}@{payload['pack_version']} "
         f"(schema {payload['schema_version']}, signatures={payload['signature_count']})."
     )
+    if payload["manifest_url"]:
+        console.print(f"Manifest: {payload['manifest_url']}")
     console.print(f"Source: {payload['source_url']}")
     console.print(f"Installed: {payload['installed_path']}")

--- a/driftshield/src/driftshield/signatures/distribution.py
+++ b/driftshield/src/driftshield/signatures/distribution.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path, PurePath
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 from urllib.request import urlopen
 
 from driftshield.signatures.community import CommunityPackManifest, parse_community_pack
 
 DEFAULT_COMMUNITY_REPOSITORY = "tborys/driftshield"
 DEFAULT_COMMUNITY_PACK_PATH = "driftshield/src/driftshield/signatures/packs"
+DEFAULT_DISTRIBUTION_MANIFEST_NAME = "signature-pack-manifest.json"
+DEFAULT_DISTRIBUTION_PACK_NAME = "signature-pack.json"
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,6 +20,20 @@ class PulledCommunityPack:
     source_url: str
     installed_path: Path
     manifest: CommunityPackManifest
+    manifest_url: str | None = None
+    used_cached_pack: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class DistributionManifest:
+    manifest_version: str
+    schema_version: str
+    pack_name: str
+    pack_version: str
+    minimum_oss_version: str
+    signature_count: int
+    artifact_checksum: str
+    artifact_url: str | None = None
 
 
 def build_github_raw_pack_url(
@@ -32,12 +49,38 @@ def build_github_raw_pack_url(
     return f"https://raw.githubusercontent.com/{owner}/{repo}/{encoded_ref}/{relative_pack_path}"
 
 
+def build_github_raw_manifest_url(
+    *,
+    repository: str = DEFAULT_COMMUNITY_REPOSITORY,
+    ref: str,
+    manifest_name: str = DEFAULT_DISTRIBUTION_MANIFEST_NAME,
+    pack_path: str = DEFAULT_COMMUNITY_PACK_PATH,
+) -> str:
+    owner, repo = repository.split("/", maxsplit=1)
+    encoded_ref = quote(ref, safe="")
+    relative_manifest_path = "/".join(part.strip("/") for part in (pack_path, manifest_name))
+    return f"https://raw.githubusercontent.com/{owner}/{repo}/{encoded_ref}/{relative_manifest_path}"
+
+
 def install_community_pack(
     *,
     source_url: str,
     destination: Path | None = None,
+    pack_name_hint: str | None = None,
 ) -> PulledCommunityPack:
-    payload = _download_manifest_payload(source_url)
+    try:
+        payload = _download_json_payload(source_url)
+    except OSError:
+        return _load_cached_pack(pack_name=pack_name_hint or "", destination=destination)
+
+    if _looks_like_distribution_manifest(payload):
+        return _install_from_distribution_manifest(
+            source_url=source_url,
+            payload=payload,
+            destination=destination,
+            pack_name_hint=pack_name_hint,
+        )
+
     manifest = parse_community_pack(payload)
     if manifest.pack_kind != "community":
         raise ValueError(
@@ -48,9 +91,7 @@ def install_community_pack(
         pack_name=manifest.metadata.name,
         version=manifest.metadata.version,
     )
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-
+    _write_pack_payload(target_path=target_path, payload=payload)
     return PulledCommunityPack(
         source_url=source_url,
         installed_path=target_path,
@@ -61,21 +102,162 @@ def install_community_pack(
 def default_pack_install_path(*, pack_name: str, version: str) -> Path:
     safe_pack_name = _require_safe_path_component(pack_name, field_name="pack_metadata.name")
     safe_version = _require_safe_path_component(version, field_name="pack_metadata.version")
-    return (
-        Path.home()
-        / ".local"
-        / "share"
-        / "driftshield"
-        / "signatures"
-        / safe_pack_name
-        / safe_version
-        / f"{safe_pack_name}.json"
+    return _default_cache_root() / safe_pack_name / safe_version / f"{safe_pack_name}.json"
+
+
+def default_manifest_install_path(*, pack_name: str, version: str) -> Path:
+    return default_pack_install_path(pack_name=pack_name, version=version).with_name(
+        DEFAULT_DISTRIBUTION_MANIFEST_NAME
     )
 
 
-def _download_manifest_payload(source_url: str) -> dict[str, object]:
+def describe_pack_source(source_url: str) -> str:
+    parsed = urlparse(source_url)
+    if parsed.scheme in {"http", "https", "file"}:
+        return source_url
+    return str(Path(source_url).expanduser().resolve())
+
+
+def _install_from_distribution_manifest(
+    *,
+    source_url: str,
+    payload: dict[str, object],
+    destination: Path | None,
+    pack_name_hint: str | None,
+) -> PulledCommunityPack:
+    distribution_manifest = _parse_distribution_manifest(payload)
+    pack_url = _resolve_pack_url(source_url=source_url, distribution_manifest=distribution_manifest)
+    try:
+        pack_payload = _download_json_payload(pack_url)
+    except OSError:
+        return _load_cached_pack(pack_name=distribution_manifest.pack_name or pack_name_hint or "", destination=destination)
+
+    pack_json = json.dumps(pack_payload, indent=2, sort_keys=True) + "\n"
+    artifact_checksum = sha256(pack_json.encode("utf-8")).hexdigest()
+    if artifact_checksum != distribution_manifest.artifact_checksum:
+        raise ValueError(
+            "downloaded signature pack checksum did not match the manifest artifact_checksum"
+        )
+
+    manifest = parse_community_pack(pack_payload)
+    if manifest.pack_kind != "community":
+        raise ValueError(
+            f"unsupported pack_kind {manifest.pack_kind!r}; expected 'community' for OSS distribution"
+        )
+    if manifest.metadata.name != distribution_manifest.pack_name:
+        raise ValueError("downloaded signature pack name did not match the manifest pack_name")
+    if manifest.metadata.version != distribution_manifest.pack_version:
+        raise ValueError("downloaded signature pack version did not match the manifest pack_version")
+    if len(manifest.signatures) != distribution_manifest.signature_count:
+        raise ValueError("downloaded signature pack signature count did not match the manifest")
+
+    target_path = destination or default_pack_install_path(
+        pack_name=manifest.metadata.name,
+        version=manifest.metadata.version,
+    )
+    _write_pack_payload(target_path=target_path, payload=pack_payload)
+    if destination is None:
+        default_manifest_install_path(
+            pack_name=manifest.metadata.name,
+            version=manifest.metadata.version,
+        ).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return PulledCommunityPack(
+        source_url=pack_url,
+        installed_path=target_path,
+        manifest=manifest,
+        manifest_url=source_url,
+    )
+
+
+def _download_json_payload(source_url: str) -> dict[str, object]:
     with urlopen(source_url) as response:
-        return json.loads(response.read().decode("utf-8"))
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("downloaded payload must be a JSON object")
+    return payload
+
+
+def _looks_like_distribution_manifest(payload: dict[str, object]) -> bool:
+    return "manifest_version" in payload and "artifact_checksum" in payload
+
+
+def _parse_distribution_manifest(payload: dict[str, object]) -> DistributionManifest:
+    return DistributionManifest(
+        manifest_version=_require_non_empty_string(payload.get("manifest_version"), field_name="manifest_version"),
+        schema_version=_require_non_empty_string(payload.get("schema_version"), field_name="schema_version"),
+        pack_name=_require_non_empty_string(payload.get("pack_name"), field_name="pack_name"),
+        pack_version=_require_non_empty_string(payload.get("pack_version"), field_name="pack_version"),
+        minimum_oss_version=_require_non_empty_string(
+            payload.get("minimum_oss_version"), field_name="minimum_oss_version"
+        ),
+        signature_count=_require_non_negative_int(payload.get("signature_count"), field_name="signature_count"),
+        artifact_checksum=_require_hex_checksum(payload.get("artifact_checksum")),
+        artifact_url=_optional_non_empty_string(payload.get("artifact_url")),
+    )
+
+
+def _resolve_pack_url(*, source_url: str, distribution_manifest: DistributionManifest) -> str:
+    if distribution_manifest.artifact_url is not None:
+        return distribution_manifest.artifact_url
+    parsed = urlparse(source_url)
+    if parsed.scheme in {"http", "https"}:
+        return urljoin(source_url, DEFAULT_DISTRIBUTION_PACK_NAME)
+    return str(Path(source_url).resolve().with_name(DEFAULT_DISTRIBUTION_PACK_NAME))
+
+
+def _load_cached_pack(*, pack_name: str, destination: Path | None) -> PulledCommunityPack:
+    cached_path = _find_latest_cached_pack(pack_name=pack_name)
+    if cached_path is None:
+        raise OSError("remote signature pack was unavailable and no cached pack was found")
+
+    payload = json.loads(cached_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("cached signature pack must be a JSON object")
+    manifest = parse_community_pack(payload)
+    target_path = destination or cached_path
+    if destination is not None:
+        _write_pack_payload(target_path=destination, payload=payload)
+    return PulledCommunityPack(
+        source_url=str(cached_path),
+        installed_path=target_path,
+        manifest=manifest,
+        manifest_url=(
+            str(cached_path.with_name(DEFAULT_DISTRIBUTION_MANIFEST_NAME))
+            if cached_path.with_name(DEFAULT_DISTRIBUTION_MANIFEST_NAME).exists()
+            else None
+        ),
+        used_cached_pack=True,
+    )
+
+
+def _find_latest_cached_pack(*, pack_name: str) -> Path | None:
+    if not pack_name.strip():
+        return None
+    root = _default_cache_root() / _require_safe_path_component(pack_name, field_name="pack_name")
+    if not root.exists():
+        return None
+
+    candidates: list[tuple[float, Path]] = []
+    for version_dir in root.iterdir():
+        if not version_dir.is_dir():
+            continue
+        candidate = version_dir / f"{root.name}.json"
+        if candidate.exists():
+            candidates.append((candidate.stat().st_mtime, candidate))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _write_pack_payload(*, target_path: Path, payload: dict[str, object]) -> None:
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _default_cache_root() -> Path:
+    return Path.home() / ".local" / "share" / "driftshield" / "signatures"
 
 
 def _require_safe_path_component(value: str, *, field_name: str) -> str:
@@ -94,8 +276,28 @@ def _require_safe_path_component(value: str, *, field_name: str) -> str:
     return candidate
 
 
-def describe_pack_source(source_url: str) -> str:
-    parsed = urlparse(source_url)
-    if parsed.scheme in {"http", "https", "file"}:
-        return source_url
-    return str(Path(source_url).expanduser().resolve())
+def _require_non_empty_string(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_non_empty_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("optional string fields must be non-empty when provided")
+    return value.strip()
+
+
+def _require_non_negative_int(value: object, *, field_name: str) -> int:
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+def _require_hex_checksum(value: object) -> str:
+    checksum = _require_non_empty_string(value, field_name="artifact_checksum")
+    if len(checksum) != 64 or any(char not in "0123456789abcdef" for char in checksum.lower()):
+        raise ValueError("artifact_checksum must be a 64-character hexadecimal sha256 digest")
+    return checksum.lower()

--- a/driftshield/tests/cli/test_signatures.py
+++ b/driftshield/tests/cli/test_signatures.py
@@ -7,8 +7,10 @@ from typer.testing import CliRunner
 
 from driftshield.cli.main import app
 from driftshield.signatures.distribution import (
+    DEFAULT_DISTRIBUTION_MANIFEST_NAME,
     build_github_raw_pack_url,
     default_pack_install_path,
+    default_manifest_install_path,
 )
 
 
@@ -56,6 +58,19 @@ def _community_pack_payload(*, version: str = "1.2.3", pack_kind: str = "communi
     }
 
 
+def _distribution_manifest_payload(*, pack_payload: dict[str, object]) -> dict[str, object]:
+    encoded_pack = json.dumps(pack_payload, indent=2, sort_keys=True) + "\n"
+    return {
+        "manifest_version": "phase-3f.signature-pack-manifest.v1",
+        "schema_version": "1.0.0",
+        "pack_name": str(pack_payload["pack_metadata"]["name"]),
+        "pack_version": str(pack_payload["pack_metadata"]["version"]),
+        "minimum_oss_version": "0.1.0",
+        "signature_count": len(pack_payload["signatures"]),
+        "artifact_checksum": __import__("hashlib").sha256(encoded_pack.encode("utf-8")).hexdigest(),
+    }
+
+
 def test_build_github_raw_pack_url_uses_repository_ref_and_pack_name() -> None:
     assert build_github_raw_pack_url(
         repository="tborys/driftshield",
@@ -69,35 +84,38 @@ def test_build_github_raw_pack_url_uses_repository_ref_and_pack_name() -> None:
 
 def test_pull_signature_pack_writes_versioned_manifest(monkeypatch, tmp_path: Path) -> None:
     payload = _community_pack_payload(version="1.2.3")
+    manifest_payload = _distribution_manifest_payload(pack_payload=payload)
 
     def fake_urlopen(source_url: str) -> DummyResponse:
-        assert source_url == "https://example.test/community-general.json"
+        if source_url == f"https://example.test/{DEFAULT_DISTRIBUTION_MANIFEST_NAME}":
+            return DummyResponse(manifest_payload)
+        assert source_url == "https://example.test/signature-pack.json"
         return DummyResponse(payload)
 
     monkeypatch.setattr("driftshield.signatures.distribution.urlopen", fake_urlopen)
+    monkeypatch.setattr("driftshield.signatures.distribution.Path.home", lambda: tmp_path)
 
-    output = tmp_path / "packs" / "community-general.json"
     result = runner.invoke(
         app,
         [
             "signatures",
             "pull",
             "community-general",
-            "--ref",
-            "v1.2.3",
             "--url",
-            "https://example.test/community-general.json",
-            "--output",
-            str(output),
+            f"https://example.test/{DEFAULT_DISTRIBUTION_MANIFEST_NAME}",
         ],
     )
 
+    output = default_pack_install_path(pack_name="community-general", version="1.2.3")
+    cached_manifest = default_manifest_install_path(pack_name="community-general", version="1.2.3")
     assert result.exit_code == 0
     assert output.exists()
+    assert cached_manifest.exists()
     installed_payload = json.loads(output.read_text(encoding="utf-8"))
     assert installed_payload["pack_metadata"]["version"] == "1.2.3"
     assert "community-general@" in result.output
     assert "schema" in result.output
+    assert "signature-pack-manifest.json" in result.output
 
 
 def test_pull_signature_pack_allows_url_without_ref(monkeypatch, tmp_path: Path) -> None:
@@ -186,3 +204,62 @@ def test_pull_signature_pack_rejects_non_community_pack(monkeypatch) -> None:
     assert result.exit_code == 1
     assert "unsupported pack_kind" in result.output
     assert "community" in result.output
+
+
+def test_pull_signature_pack_uses_cached_pack_when_remote_manifest_is_unavailable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    payload = _community_pack_payload(version="1.2.2")
+    monkeypatch.setattr("driftshield.signatures.distribution.Path.home", lambda: tmp_path)
+
+    cached_pack_path = default_pack_install_path(pack_name="community-general", version="1.2.2")
+    cached_pack_path.parent.mkdir(parents=True, exist_ok=True)
+    cached_pack_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def failing_urlopen(source_url: str) -> DummyResponse:
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr("driftshield.signatures.distribution.urlopen", failing_urlopen)
+
+    result = runner.invoke(
+        app,
+        [
+            "signatures",
+            "pull",
+            "community-general",
+            "--url",
+            f"https://example.test/{DEFAULT_DISTRIBUTION_MANIFEST_NAME}",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Using cached community pack" in result.output
+
+
+def test_pull_signature_pack_rejects_checksum_mismatch(monkeypatch, tmp_path: Path) -> None:
+    payload = _community_pack_payload(version="1.2.3")
+    manifest_payload = _distribution_manifest_payload(pack_payload=payload) | {
+        "artifact_checksum": "0" * 64,
+    }
+
+    def fake_urlopen(source_url: str) -> DummyResponse:
+        if source_url == f"https://example.test/{DEFAULT_DISTRIBUTION_MANIFEST_NAME}":
+            return DummyResponse(manifest_payload)
+        return DummyResponse(payload)
+
+    monkeypatch.setattr("driftshield.signatures.distribution.urlopen", fake_urlopen)
+    monkeypatch.setattr("driftshield.signatures.distribution.Path.home", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "signatures",
+            "pull",
+            "community-general",
+            "--url",
+            f"https://example.test/{DEFAULT_DISTRIBUTION_MANIFEST_NAME}",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "checksum" in result.output.lower()


### PR DESCRIPTION
## Summary
- pull a distribution manifest first, then validate and install the published OSS-safe signature pack
- verify the downloaded pack checksum before use and fall back to the latest cached pack if the remote artefact is unavailable
- cover manifest installs, checksum mismatches, and cached fallback behaviour with CLI tests

Closes #62

## Verification
```bash
uv run pytest tests/cli/test_signatures.py -q
```
