### PR TITLE
feat: persist canonical analysed-run summaries

### DIFF
--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -208,6 +208,15 @@ def _extract_signature_match(session: SessionModel) -> SignatureMatchSummaryResp
     )
 
 
+
+def _extract_canonical_analysis(session: SessionModel) -> dict[str, Any] | None:
+    metadata = session.metadata_json or {}
+    payload = metadata.get("canonical_analysis")
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
 def _feedback_response(
     row: ValidationRecord | AnalystValidationModel,
 ) -> ForensicFeedbackResponse:
@@ -415,6 +424,7 @@ def get_session(
         risk_summary=_risk_summary(nodes),
         explanations=_session_explanations(nodes),
         signature_match=_extract_signature_match(session),
+        canonical_analysis=_extract_canonical_analysis(session),
     )
 
 

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -78,6 +78,7 @@ class SessionDetail(SessionSummary):
     risk_summary: dict[str, int] = Field(default_factory=dict)
     explanations: SessionExplanationsResponse | None = None
     signature_match: SignatureMatchSummaryResponse | None = None
+    canonical_analysis: dict[str, Any] | None = None
 
 
 class GraphNodeResponse(BaseModel):

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -24,7 +24,7 @@ def build_canonical_analysis(
     result: AnalysisResult,
     provenance: IngestProvenance | None,
 ) -> dict[str, Any]:
-    normalized_events = [_canonical_event_payload(event) for event in result.events]
+    normalized_events = _canonical_event_payloads(result.events)
     missing_fields = sum(len(event["missing_fields"]) for event in normalized_events)
     ambiguity_count = sum(len(event.get("missing_fields", [])) for event in normalized_events)
     direct_events = sum(1 for event in normalized_events if event["recovery_mode"] == _DIRECT_RECOVERY_MODE)
@@ -65,7 +65,7 @@ def build_canonical_analysis(
         },
         "policy_and_instruction_context": {
             "system_constraints": _constraints_for_role(result.events, "system"),
-            "developer_constraints": [],
+            "developer_constraints": _developer_constraints(result.events),
             "user_constraints": _constraints_for_role(result.events, "user"),
             "derived_operational_constraints": _derived_operational_constraints(result.events),
             "conflict_or_shadowing_notes": _constraint_conflicts(result.events),
@@ -96,7 +96,28 @@ def build_canonical_analysis(
     }
 
 
-def _canonical_event_payload(event: CanonicalEvent) -> dict[str, Any]:
+def _canonical_event_payloads(events: list[CanonicalEvent]) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    sequence_index = 0
+    for event in events:
+        payloads.append(_canonical_event_payload(event, sequence_index=sequence_index))
+        sequence_index += 1
+        if _has_result_payload(event):
+            payloads.append(_canonical_result_payload(event, sequence_index=sequence_index))
+            sequence_index += 1
+    return payloads
+
+
+def _canonical_event_payload(
+    event: CanonicalEvent,
+    *,
+    sequence_index: int,
+    event_id: str | None = None,
+    event_family: str | None = None,
+    content_summary: str | None = None,
+    causal_parents: list[str] | None = None,
+    structured_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     raw_reference = next((ref for ref in event.source_refs if ref.get("kind") != "parser"), None)
     source_span = None
     if raw_reference is not None:
@@ -105,6 +126,33 @@ def _canonical_event_payload(event: CanonicalEvent) -> dict[str, Any]:
             "value": raw_reference.get("value"),
         }
 
+    payload = structured_payload or _structured_payload(event, raw_reference=raw_reference)
+    missing_fields = _event_missing_fields(event)
+    recovery_mode = _recovery_mode(event, missing_fields=missing_fields)
+
+    return {
+        "event_id": event_id or str(event.id),
+        "sequence_index": sequence_index,
+        "event_family": event_family or _event_family(event),
+        "event_type": event.event_kind,
+        "actor_type": (event.actor or {}).get("role") or "assistant",
+        "timestamp": event.timestamp.isoformat() if isinstance(event.timestamp, datetime) else None,
+        "source_span": source_span,
+        "raw_reference": raw_reference,
+        "content_summary": content_summary or event.summary,
+        "structured_payload": payload,
+        "causal_parents": causal_parents if causal_parents is not None else [str(ref) for ref in event.parent_event_refs],
+        "confidence": _event_confidence(event, missing_fields=missing_fields),
+        "recovery_mode": recovery_mode,
+        "missing_fields": missing_fields,
+    }
+
+
+def _structured_payload(
+    event: CanonicalEvent,
+    *,
+    raw_reference: dict[str, str] | None,
+) -> dict[str, Any]:
     structured_payload: dict[str, Any] = {
         "action": event.action,
         "inputs": event.inputs,
@@ -122,26 +170,30 @@ def _canonical_event_payload(event: CanonicalEvent) -> dict[str, Any]:
         structured_payload["failure_context"] = dict(event.failure_context)
     if event.artifact_refs:
         structured_payload["artifact_refs"] = [dict(item) for item in event.artifact_refs]
+    return structured_payload
 
-    missing_fields = _event_missing_fields(event)
-    recovery_mode = _recovery_mode(event, missing_fields=missing_fields)
 
-    return {
-        "event_id": str(event.id),
-        "sequence_index": event.ordinal if event.ordinal is not None else 0,
-        "event_family": _event_family(event),
-        "event_type": event.event_kind,
-        "actor_type": (event.actor or {}).get("role") or "assistant",
-        "timestamp": event.timestamp.isoformat() if isinstance(event.timestamp, datetime) else None,
-        "source_span": source_span,
-        "raw_reference": raw_reference,
-        "content_summary": event.summary,
-        "structured_payload": structured_payload,
-        "causal_parents": [str(ref) for ref in event.parent_event_refs],
-        "confidence": _event_confidence(event, missing_fields=missing_fields),
-        "recovery_mode": recovery_mode,
-        "missing_fields": missing_fields,
+def _canonical_result_payload(event: CanonicalEvent, *, sequence_index: int) -> dict[str, Any]:
+    result_payload = {
+        "action": event.action,
+        "outputs": event.outputs,
+        "tool_activity": dict(event.tool_activity or {}),
+        **_tool_payload(event, raw_reference=_tool_raw_reference(event)),
     }
+    if event.failure_context:
+        result_payload["failure_context"] = dict(event.failure_context)
+    if event.artifact_refs:
+        result_payload["artifact_refs"] = [dict(item) for item in event.artifact_refs]
+
+    return _canonical_event_payload(
+        event,
+        sequence_index=sequence_index,
+        event_id=f"{event.id}:result",
+        event_family=_result_event_family(event),
+        content_summary=_tool_result_summary(event),
+        causal_parents=[str(event.id)],
+        structured_payload=result_payload,
+    )
 
 
 def _event_family(event: CanonicalEvent) -> str:
@@ -198,6 +250,14 @@ def _event_confidence(event: CanonicalEvent, *, missing_fields: list[str]) -> fl
     return round(max(confidence, 0.2), 2)
 
 
+def _has_result_payload(event: CanonicalEvent) -> bool:
+    return bool(event.tool_activity and (event.outputs or event.failure_context))
+
+
+def _tool_raw_reference(event: CanonicalEvent) -> dict[str, str] | None:
+    return next((ref for ref in event.source_refs if ref.get("kind") != "parser"), None)
+
+
 def _tool_event_family(event: CanonicalEvent) -> str:
     tool_name = str((event.tool_activity or {}).get("name") or event.action or "").lower()
     category = str((event.tool_activity or {}).get("category") or "").lower()
@@ -212,6 +272,20 @@ def _tool_event_family(event: CanonicalEvent) -> str:
         return "error_or_exception"
     return "tool_call"
 
+
+
+def _result_event_family(event: CanonicalEvent) -> str:
+    return "retrieval_result" if _tool_event_family(event) == "retrieval_query" else "tool_result"
+
+
+def _tool_result_summary(event: CanonicalEvent) -> str:
+    tool_name = str((event.tool_activity or {}).get("name") or event.action or "tool")
+    if event.failure_context and event.failure_context.get("error"):
+        return f"{tool_name} returned an error"
+    result_summary = _mapping_summary(event.outputs)
+    if result_summary:
+        return f"{tool_name} returned {result_summary}"
+    return f"{tool_name} returned a result"
 
 
 def _tool_payload(event: CanonicalEvent, *, raw_reference: dict[str, str] | None) -> dict[str, Any]:
@@ -368,6 +442,41 @@ def _constraints_for_role(events: list[CanonicalEvent], role: str) -> list[dict[
                 }
             )
     return payload
+
+
+def _developer_constraints(events: list[CanonicalEvent]) -> list[dict[str, Any]]:
+    payload = _constraints_for_role(events, "developer")
+    for event in events:
+        if not event.constraints or not _looks_like_developer_instruction_source(event):
+            continue
+        for constraint in event.constraints:
+            payload.append(
+                {
+                    "constraint": constraint.get("value"),
+                    "source": constraint.get("source"),
+                    "observed_via": "inferred_from_instruction_artifact",
+                    "event_id": str(event.id),
+                }
+            )
+    return payload
+
+
+def _looks_like_developer_instruction_source(event: CanonicalEvent) -> bool:
+    instruction_markers = (
+        "soul.md",
+        "style.md",
+        "identity.md",
+        "voice.md",
+        "agents.md",
+        "prompt",
+        "persona",
+        ".claude",
+        ".openclaw",
+    )
+    values: list[str] = []
+    values.extend(str(ref.get("value", "")).lower() for ref in event.artifact_refs)
+    values.extend(str(ref.get("value", "")).lower() for ref in event.source_refs)
+    return any(marker in value for value in values for marker in instruction_markers)
 
 
 def _derived_operational_constraints(events: list[CanonicalEvent]) -> list[dict[str, Any]]:

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -1,0 +1,515 @@
+"""Phase 3g canonical analysed-run builder."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from driftshield.core.analysis.session import AnalysisResult
+from driftshield.core.models import CanonicalEvent, EventType, Session as DomainSession
+
+if TYPE_CHECKING:
+    from driftshield.db.persistence import IngestProvenance
+
+ANALYSIS_SCHEMA_VERSION = "phase-3g-canonical-v1"
+
+_DIRECT_RECOVERY_MODE = "direct"
+_NORMALISED_RECOVERY_MODE = "normalised"
+_INFERRED_RECOVERY_MODE = "inferred"
+
+
+def build_canonical_analysis(
+    *,
+    session: DomainSession,
+    result: AnalysisResult,
+    provenance: IngestProvenance | None,
+) -> dict[str, Any]:
+    normalized_events = [_canonical_event_payload(event) for event in result.events]
+    missing_fields = sum(len(event["missing_fields"]) for event in normalized_events)
+    ambiguity_count = sum(len(event.get("missing_fields", [])) for event in normalized_events)
+    direct_events = sum(1 for event in normalized_events if event["recovery_mode"] == _DIRECT_RECOVERY_MODE)
+    inferred_events = len(normalized_events) - direct_events
+
+    integrity_reasons = _integrity_reasons(result.events)
+    overall_quality_band = _overall_quality_band(result.events, ambiguity_count=ambiguity_count)
+    delta_types = _delta_types(result)
+    parser_name = _parser_name(provenance)
+
+    return {
+        "analysis_session": {
+            "session_id": str(session.id),
+            "analysis_schema_version": ANALYSIS_SCHEMA_VERSION,
+            "source_kind": parser_name,
+            "source_provenance": {
+                "source_type": parser_name,
+                "source_session_id": provenance.source_session_id if provenance else session.external_id,
+                "source_path": provenance.source_path if provenance else None,
+            },
+            "parser_name": parser_name,
+            "parser_version": provenance.parser_version if provenance else None,
+            "ingested_at": provenance.ingested_at.isoformat() if provenance else None,
+            "source_fingerprint": provenance.transcript_hash if provenance else None,
+            "time_bounds": _time_bounds(result.events),
+            "event_count": len(normalized_events),
+            "integrity_status": _integrity_status(result.events),
+            "integrity_reasons": integrity_reasons,
+        },
+        "normalized_events": normalized_events,
+        "run_context": {
+            "workflow_label": session.metadata.get("workflow_label") if isinstance(session.metadata, dict) else None,
+            "environment": session.metadata.get("environment") if isinstance(session.metadata, dict) else None,
+            "repository_or_workspace": provenance.source_path if provenance else None,
+            "tool_availability_summary": _tool_availability_summary(result.events),
+            "major_constraints": _major_constraints(result.events),
+            "user_goal_summary": _user_goal_summary(result.events),
+        },
+        "policy_and_instruction_context": {
+            "system_constraints": _constraints_for_role(result.events, "system"),
+            "developer_constraints": [],
+            "user_constraints": _constraints_for_role(result.events, "user"),
+            "derived_operational_constraints": _derived_operational_constraints(result.events),
+            "conflict_or_shadowing_notes": _constraint_conflicts(result.events),
+        },
+        "expected_vs_actual_delta": {
+            "delta_present": bool(delta_types),
+            "expected_outcome_summary": _expected_outcome_summary(result.events),
+            "actual_outcome_summary": _actual_outcome_summary(result.events),
+            "delta_types": delta_types or ["no_material_delta_detected"],
+            "severity_hint": _severity_hint(result),
+            "supporting_event_ids": _supporting_event_ids(result),
+            "blocked_goal_summary": _blocked_goal_summary(result),
+        },
+        "extraction_quality_summary": {
+            "overall_quality_band": overall_quality_band,
+            "coverage_ratio": round(_coverage_ratio(normalized_events), 4),
+            "missing_event_families": _missing_event_families(normalized_events),
+            "ordering_confidence": _ordering_confidence(result.events),
+            "field_recovery_summary": {
+                "direct_event_count": direct_events,
+                "inferred_event_count": inferred_events,
+                "missing_field_count": missing_fields,
+            },
+            "inference_ratio": round(inferred_events / len(normalized_events), 4) if normalized_events else 0.0,
+            "critical_gaps": _critical_gaps(result.events),
+            "quality_warnings": _quality_warnings(result.events),
+        },
+    }
+
+
+def _canonical_event_payload(event: CanonicalEvent) -> dict[str, Any]:
+    raw_reference = next((ref for ref in event.source_refs if ref.get("kind") != "parser"), None)
+    source_span = None
+    if raw_reference is not None:
+        source_span = {
+            "kind": raw_reference.get("kind"),
+            "value": raw_reference.get("value"),
+        }
+
+    structured_payload: dict[str, Any] = {
+        "action": event.action,
+        "inputs": event.inputs,
+        "outputs": event.outputs,
+    }
+    if event.constraints:
+        structured_payload["constraints"] = [dict(item) for item in event.constraints]
+    if event.tool_activity:
+        structured_payload["tool_activity"] = dict(event.tool_activity)
+        structured_payload.update(_tool_payload(event, raw_reference=raw_reference))
+    state_transition = _state_transition_payload(event)
+    if state_transition is not None:
+        structured_payload["state_transition"] = state_transition
+    if event.failure_context:
+        structured_payload["failure_context"] = dict(event.failure_context)
+    if event.artifact_refs:
+        structured_payload["artifact_refs"] = [dict(item) for item in event.artifact_refs]
+
+    missing_fields = _event_missing_fields(event)
+    recovery_mode = _recovery_mode(event, missing_fields=missing_fields)
+
+    return {
+        "event_id": str(event.id),
+        "sequence_index": event.ordinal if event.ordinal is not None else 0,
+        "event_family": _event_family(event),
+        "event_type": event.event_kind,
+        "actor_type": (event.actor or {}).get("role") or "assistant",
+        "timestamp": event.timestamp.isoformat() if isinstance(event.timestamp, datetime) else None,
+        "source_span": source_span,
+        "raw_reference": raw_reference,
+        "content_summary": event.summary,
+        "structured_payload": structured_payload,
+        "causal_parents": [str(ref) for ref in event.parent_event_refs],
+        "confidence": _event_confidence(event, missing_fields=missing_fields),
+        "recovery_mode": recovery_mode,
+        "missing_fields": missing_fields,
+    }
+
+
+def _event_family(event: CanonicalEvent) -> str:
+    actor_role = (event.actor or {}).get("role")
+    if actor_role == "user":
+        return "user_instruction"
+    if actor_role == "system":
+        if event.constraints:
+            return "policy_instruction"
+        return "system_instruction"
+    if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF}:
+        return _tool_event_family(event)
+    if event.failure_context:
+        return "error_or_exception"
+    if event.event_type == EventType.OUTPUT:
+        if event.constraints:
+            return "actual_outcome_marker"
+        return "output_emission"
+    if event.event_type == EventType.CONSTRAINT_CHECK:
+        return "confirmation_checkpoint"
+    if event.constraints:
+        return "expectation_marker"
+    return "model_reasoning_or_decision"
+
+
+def _event_missing_fields(event: CanonicalEvent) -> list[str]:
+    missing: list[str] = []
+    if not event.source_refs:
+        missing.append("source_reference_missing")
+    if not event.summary:
+        missing.append("content_summary_missing")
+    if not event.parent_event_refs and (event.ordinal or 0) > 0:
+        missing.append("causal_parents_missing")
+    if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF} and not event.inputs:
+        missing.append("tool_inputs_missing")
+    if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF} and not event.outputs:
+        missing.append("tool_outputs_missing")
+    return sorted(set(missing + list(event.ambiguities)))
+
+
+def _recovery_mode(event: CanonicalEvent, *, missing_fields: list[str]) -> str:
+    if event.ambiguities or any(item.endswith("_inferred_from_text") for item in missing_fields):
+        return _INFERRED_RECOVERY_MODE
+    if missing_fields:
+        return _NORMALISED_RECOVERY_MODE
+    return _DIRECT_RECOVERY_MODE
+
+
+def _event_confidence(event: CanonicalEvent, *, missing_fields: list[str]) -> float:
+    confidence = 1.0
+    confidence -= min(0.15 * len(missing_fields), 0.45)
+    if event.failure_context and event.failure_context.get("status") == "warning":
+        confidence -= 0.1
+    return round(max(confidence, 0.2), 2)
+
+
+def _tool_event_family(event: CanonicalEvent) -> str:
+    tool_name = str((event.tool_activity or {}).get("name") or event.action or "").lower()
+    category = str((event.tool_activity or {}).get("category") or "").lower()
+
+    if tool_name in {"read", "read_file", "cat"} or "file_io" in category and "read" in tool_name:
+        return "state_read"
+    if tool_name in {"write", "edit", "apply_patch"} or "file_io" in category and tool_name in {"write", "edit"}:
+        return "state_write"
+    if tool_name in {"grep", "glob", "search", "web_search", "web_fetch"} or "search" in tool_name:
+        return "retrieval_query"
+    if event.failure_context:
+        return "error_or_exception"
+    return "tool_call"
+
+
+
+def _tool_payload(event: CanonicalEvent, *, raw_reference: dict[str, str] | None) -> dict[str, Any]:
+    tool_activity = event.tool_activity or {}
+    artifact_target = next((ref.get("value") for ref in event.artifact_refs if ref.get("value")), None)
+    invocation_id = None
+    if raw_reference is not None and raw_reference.get("kind") in {"tool_use_id", "tool_call_id"}:
+        invocation_id = raw_reference.get("value")
+
+    payload: dict[str, Any] = {
+        "tool_name": tool_activity.get("name") or event.action,
+        "tool_category": tool_activity.get("category"),
+        "arguments_summary": _mapping_summary(event.inputs),
+        "target_summary": artifact_target,
+        "invocation_id": invocation_id,
+        "safety_relevant_flags": _tool_safety_flags(event),
+        "result_status": tool_activity.get("status"),
+        "result_summary": _mapping_summary(event.outputs),
+        "result_artifact_refs": [dict(item) for item in event.artifact_refs],
+        "error_code": (event.outputs or {}).get("error") or (event.failure_context or {}).get("error"),
+    }
+    return payload
+
+
+
+def _state_transition_payload(event: CanonicalEvent) -> dict[str, Any] | None:
+    family = _tool_event_family(event) if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF} else None
+    if family not in {"state_read", "state_write"}:
+        return None
+
+    subject = next((ref.get("value") for ref in event.artifact_refs if ref.get("value")), None)
+    operation = "read" if family == "state_read" else "write"
+    if str(event.action).lower() == "edit":
+        operation = "update"
+    elif str(event.action).lower() == "apply_patch":
+        operation = "patch"
+
+    return {
+        "state_subject": subject,
+        "prior_state_summary": None,
+        "proposed_state_summary": _mapping_summary(event.inputs) if family == "state_write" else None,
+        "applied_state_summary": _mapping_summary(event.outputs),
+        "state_operation": operation,
+        "state_conflict_flag": bool(event.failure_context),
+        "state_conflict_reason": (event.failure_context or {}).get("error"),
+    }
+
+
+
+def _parser_name(provenance: IngestProvenance | None) -> str | None:
+    if provenance is None:
+        return None
+    return provenance.parser_version.split("@", 1)[0]
+
+
+def _time_bounds(events: list[CanonicalEvent]) -> dict[str, str | None]:
+    if not events:
+        return {"started_at": None, "ended_at": None}
+    return {
+        "started_at": events[0].timestamp.isoformat(),
+        "ended_at": events[-1].timestamp.isoformat(),
+    }
+
+
+def _integrity_status(events: list[CanonicalEvent]) -> str:
+    if not events:
+        return "corrupted_but_usable"
+    if any(event.failure_context for event in events):
+        return "recovered"
+    if any(event.ambiguities for event in events):
+        return "partial"
+    return "complete"
+
+
+def _integrity_reasons(events: list[CanonicalEvent]) -> list[str]:
+    reasons: set[str] = set()
+    for event in events:
+        reasons.update(event.ambiguities)
+        if event.failure_context:
+            reasons.add("failure_context_present")
+        if not event.source_refs:
+            reasons.add("missing_source_reference")
+    return sorted(reasons)
+
+
+def _mapping_summary(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        keys = sorted(str(key) for key in payload.keys())
+        return ", ".join(keys[:6]) if keys else None
+    if isinstance(payload, list):
+        return f"list[{len(payload)}]"
+    if payload is None:
+        return None
+    return str(payload)[:160]
+
+
+
+def _tool_safety_flags(event: CanonicalEvent) -> list[str]:
+    flags: list[str] = []
+    tool_name = str((event.tool_activity or {}).get("name") or event.action or "").lower()
+    if tool_name in {"bash", "shell"}:
+        flags.append("executes_shell")
+    if tool_name in {"write", "edit", "apply_patch"}:
+        flags.append("mutates_state")
+    if event.failure_context:
+        flags.append("reported_failure")
+    return flags
+
+
+
+def _tool_availability_summary(events: list[CanonicalEvent]) -> dict[str, Any]:
+    tool_names = sorted(
+        {
+            str((event.tool_activity or {}).get("name"))
+            for event in events
+            if event.tool_activity and (event.tool_activity or {}).get("name")
+        }
+    )
+    return {
+        "tool_count": len(tool_names),
+        "tool_names": tool_names,
+    }
+
+
+def _major_constraints(events: list[CanonicalEvent]) -> list[str]:
+    values: list[str] = []
+    for event in events:
+        for constraint in event.constraints:
+            value = constraint.get("value")
+            if isinstance(value, str) and value not in values:
+                values.append(value)
+    return values[:10]
+
+
+def _user_goal_summary(events: list[CanonicalEvent]) -> str | None:
+    for event in events:
+        if (event.actor or {}).get("role") == "user" and event.summary:
+            return event.summary
+    return None
+
+
+def _constraints_for_role(events: list[CanonicalEvent], role: str) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for event in events:
+        if (event.actor or {}).get("role") != role:
+            continue
+        for constraint in event.constraints:
+            payload.append(
+                {
+                    "constraint": constraint.get("value"),
+                    "source": constraint.get("source"),
+                    "observed_via": "direct",
+                    "event_id": str(event.id),
+                }
+            )
+    return payload
+
+
+def _derived_operational_constraints(events: list[CanonicalEvent]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for event in events:
+        for constraint in event.constraints:
+            payload.append(
+                {
+                    "constraint": constraint.get("value"),
+                    "kind": constraint.get("kind"),
+                    "event_id": str(event.id),
+                    "observed_via": "normalised",
+                }
+            )
+    return payload
+
+
+def _constraint_conflicts(events: list[CanonicalEvent]) -> list[str]:
+    role_counts: dict[str, int] = {}
+    for event in events:
+        role = (event.actor or {}).get("role") or "assistant"
+        if event.constraints:
+            role_counts[role] = role_counts.get(role, 0) + len(event.constraints)
+    if sum(role_counts.values()) > 1 and len(role_counts) > 1:
+        return ["multi_source_constraints_present"]
+    return []
+
+
+def _expected_outcome_summary(events: list[CanonicalEvent]) -> str | None:
+    for event in events:
+        for constraint in event.constraints:
+            if constraint.get("kind") == "expected_output":
+                return str(constraint.get("value"))
+    return _user_goal_summary(events)
+
+
+def _actual_outcome_summary(events: list[CanonicalEvent]) -> str | None:
+    for event in reversed(events):
+        if event.summary:
+            return event.summary
+    return None
+
+
+def _delta_types(result: AnalysisResult) -> list[str]:
+    delta_types: list[str] = []
+    summary = result.risk_summary
+    if summary.get("coverage_gap"):
+        delta_types.append("missing_required_action")
+    if summary.get("constraint_violation"):
+        delta_types.append("policy_violation")
+    if summary.get("context_contamination"):
+        delta_types.append("retrieval_failure_or_omission")
+    if summary.get("policy_divergence"):
+        delta_types.append("wrong_action")
+    if result.candidate_break_point and not result.candidate_break_point.is_identified and result.flagged_events:
+        delta_types.append("unresolved_ambiguity")
+    return sorted(set(delta_types))
+
+
+def _severity_hint(result: AnalysisResult) -> str:
+    if result.flagged_events >= 3:
+        return "high"
+    if result.flagged_events >= 1:
+        return "medium"
+    return "low"
+
+
+def _supporting_event_ids(result: AnalysisResult) -> list[str]:
+    return [str(event.id) for event in result.events if event.has_risk_flags()]
+
+
+def _blocked_goal_summary(result: AnalysisResult) -> str | None:
+    if not result.flagged_events:
+        return None
+    if result.candidate_break_point is not None:
+        return result.candidate_break_point.summary
+    return "Run deviated from the expected outcome."
+
+
+def _coverage_ratio(normalized_events: list[dict[str, Any]]) -> float:
+    if not normalized_events:
+        return 0.0
+    total_fields = len(normalized_events) * 10
+    missing = sum(len(event["missing_fields"]) for event in normalized_events)
+    return max(0.0, min(1.0, (total_fields - missing) / total_fields))
+
+
+def _missing_event_families(normalized_events: list[dict[str, Any]]) -> list[str]:
+    required = {
+        "user_instruction",
+        "system_instruction",
+        "policy_instruction",
+        "model_reasoning_or_decision",
+        "tool_call",
+        "tool_result",
+        "retrieval_query",
+        "retrieval_result",
+        "state_read",
+        "state_write",
+        "confirmation_checkpoint",
+        "output_emission",
+        "error_or_exception",
+        "expectation_marker",
+        "actual_outcome_marker",
+    }
+    present = {str(event["event_family"]) for event in normalized_events}
+    return sorted(required - present)
+
+
+def _ordering_confidence(events: list[CanonicalEvent]) -> float:
+    if not events:
+        return 0.0
+    ambiguity_penalty = sum(1 for event in events if "missing_parent_ref" in event.ambiguities)
+    confidence = 1.0 - min(ambiguity_penalty * 0.1, 0.5)
+    return round(max(confidence, 0.4), 2)
+
+
+def _critical_gaps(events: list[CanonicalEvent]) -> list[str]:
+    gaps: set[str] = set()
+    for event in events:
+        if not event.source_refs:
+            gaps.add("missing_source_reference")
+        if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF} and not event.outputs:
+            gaps.add("missing_tool_result")
+    return sorted(gaps)
+
+
+def _quality_warnings(events: list[CanonicalEvent]) -> list[str]:
+    warnings: set[str] = set()
+    for event in events:
+        if event.failure_context and event.failure_context.get("status") == "warning":
+            warnings.add("failure_only_inferred_from_text")
+        if event.ambiguities:
+            warnings.add("event_ambiguities_present")
+    return sorted(warnings)
+
+
+def _overall_quality_band(events: list[CanonicalEvent], *, ambiguity_count: int) -> str:
+    if not events:
+        return "insufficient_for_matching"
+    if ambiguity_count >= max(3, len(events)):
+        return "degraded"
+    if any(not event.source_refs for event in events):
+        return "usable"
+    return "high"

--- a/driftshield/src/driftshield/db/persistence.py
+++ b/driftshield/src/driftshield/db/persistence.py
@@ -6,6 +6,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session as DBSession
 
 from driftshield.core.analysis.session import AnalysisResult
+from driftshield.core.canonical_analysis import build_canonical_analysis
 from driftshield.core.graph.builder import build_graph
 from driftshield.core.graph.models import DecisionNode, LineageGraph
 from driftshield.core.integrity import build_integrity_provenance, build_integrity_summary
@@ -159,6 +160,11 @@ class PersistenceService:
         integrity_summary = build_integrity_summary(session, result, provenance)
         metadata["integrity_summary"] = integrity_summary
         metadata["integrity_provenance"] = build_integrity_provenance(integrity_summary, provenance)
+        metadata["canonical_analysis"] = build_canonical_analysis(
+            session=session,
+            result=result,
+            provenance=provenance,
+        )
 
         session_model.external_id = getattr(session, "external_id", None)
         session_model.agent_id = session.agent_id

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -122,6 +122,18 @@ def test_ingest_persists_provenance_fields(client, auth_headers, sample_transcri
     assert session.parser_version == "claude_code@1"
     assert session.ingested_at is not None
 
+    canonical_analysis = session.metadata_json["canonical_analysis"]
+    assert canonical_analysis["analysis_session"]["analysis_schema_version"] == "phase-3g-canonical-v1"
+    assert canonical_analysis["analysis_session"]["source_fingerprint"] == session.transcript_hash
+    assert canonical_analysis["analysis_session"]["parser_version"] == "claude_code@1"
+    assert canonical_analysis["normalized_events"]
+    first_event = canonical_analysis["normalized_events"][0]
+    assert first_event["event_family"] == "state_read"
+    assert first_event["structured_payload"]["tool_name"] == "Read"
+    assert first_event["structured_payload"]["state_transition"]["state_operation"] == "read"
+    assert canonical_analysis["expected_vs_actual_delta"]["delta_types"] == ["no_material_delta_detected"]
+    assert "state_write" in canonical_analysis["extraction_quality_summary"]["missing_event_families"]
+
 
 def test_ingest_stabilizes_normalized_parent_refs(db_session):
     transcript = "\n".join(

--- a/driftshield/tests/api/test_sessions.py
+++ b/driftshield/tests/api/test_sessions.py
@@ -89,6 +89,27 @@ def seeded_session(db_session):
                 "match_count": 2,
                 "summary": "Matched two known failure families.",
             },
+            "canonical_analysis": {
+                "analysis_session": {
+                    "session_id": str(session_id),
+                    "analysis_schema_version": "phase-3g-canonical-v1",
+                    "source_kind": "claude_code",
+                    "parser_version": "claude_code@1",
+                    "source_fingerprint": "abc123",
+                },
+                "normalized_events": [
+                    {
+                        "event_id": "node-1",
+                        "sequence_index": 0,
+                        "event_family": "tool_call",
+                        "missing_fields": [],
+                    }
+                ],
+                "run_context": {},
+                "policy_and_instruction_context": {},
+                "expected_vs_actual_delta": {"delta_types": ["missing_required_action"]},
+                "extraction_quality_summary": {"overall_quality_band": "usable"},
+            },
             "recurrence_status": {
                 "status": "recurring",
                 "cluster_id": "cluster-42",
@@ -222,6 +243,9 @@ def test_get_session_detail(client, auth_headers, seeded_session):
             "summary": "Matched two known failure families.",
         },
     }
+    assert data["canonical_analysis"]["analysis_session"]["analysis_schema_version"] == "phase-3g-canonical-v1"
+    assert data["canonical_analysis"]["normalized_events"][0]["event_family"] == "tool_call"
+    assert data["canonical_analysis"]["expected_vs_actual_delta"]["delta_types"] == ["missing_required_action"]
     assert "recurrence_status" not in data
 
 

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from driftshield.core.analysis.session import analyze_session
+from driftshield.core.canonical_analysis import build_canonical_analysis
+from driftshield.core.models import CanonicalEvent, EventType, Session, SessionStatus
+from driftshield.core.normalization import normalize_events
+from driftshield.parsers.claude_code import ClaudeCodeParser
+
+
+def test_build_canonical_analysis_emits_result_families_for_completed_tool_calls():
+    transcript = "\n".join(
+        [
+            '{"sessionId":"canonical-1","type":"assistant","timestamp":"2026-05-04T12:00:00Z","message":{"content":[{"type":"tool_use","id":"tool_1","name":"Read","input":{"file_path":"README.md"}}]}}',
+            '{"sessionId":"canonical-1","type":"user","timestamp":"2026-05-04T12:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_1","content":"file contents here","is_error":false}]}}',
+        ]
+    )
+    events = ClaudeCodeParser().parse(transcript)
+    result = analyze_session(events)
+
+    payload = build_canonical_analysis(
+        session=Session(
+            id=uuid4(),
+            agent_id="claude",
+            started_at=datetime.now(timezone.utc),
+            status=SessionStatus.COMPLETED,
+        ),
+        result=result,
+        provenance=None,
+    )
+
+    families = [event["event_family"] for event in payload["normalized_events"]]
+    assert "state_read" in families
+    assert "tool_result" in families
+    assert "tool_result" not in payload["extraction_quality_summary"]["missing_event_families"]
+
+    result_event = next(
+        event for event in payload["normalized_events"] if event["event_family"] == "tool_result"
+    )
+    assert result_event["causal_parents"] == [payload["normalized_events"][0]["event_id"]]
+    assert result_event["structured_payload"]["invocation_id"] == "tool_1"
+    assert result_event["structured_payload"]["result_status"] == "completed"
+
+
+def test_build_canonical_analysis_preserves_developer_constraints_from_instruction_artifacts():
+    event = CanonicalEvent(
+        id=uuid4(),
+        session_id="canonical-2",
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="claude",
+        action="Read",
+        inputs={"file_path": "/tmp/.openclaw/SOUL.md"},
+        outputs={"result": "You must verify changes before replying."},
+        metadata={"tool_use_id": "tool_2", "semantic_action_category": "file_io"},
+    )
+    events = normalize_events([event], source_type="claude_code")
+    result = analyze_session(events)
+
+    payload = build_canonical_analysis(
+        session=Session(
+            id=uuid4(),
+            agent_id="claude",
+            started_at=datetime.now(timezone.utc),
+            status=SessionStatus.COMPLETED,
+        ),
+        result=result,
+        provenance=None,
+    )
+
+    developer_constraints = payload["policy_and_instruction_context"]["developer_constraints"]
+    assert developer_constraints
+    assert developer_constraints[0]["constraint"] == "You must verify changes before replying."
+    assert developer_constraints[0]["observed_via"] == "inferred_from_instruction_artifact"


### PR DESCRIPTION
## Summary

- persist a Phase 3g-style `canonical_analysis` object alongside the existing session integrity metadata
- expose the canonical analysed-run payload on the session detail API so downstream deterministic matching can consume a stable surface
- add targeted coverage for ingest persistence and session-detail exposure of canonical event families, state transitions, delta summaries, and quality metadata

Part of #65.

## Verification

```bash
PYTHONPATH=src python3 -m pytest tests/api/test_ingest.py tests/api/test_sessions.py tests/parsers/test_normalized_pipeline.py tests/db/test_persistence.py tests/core/test_models.py -q
PYTHONPATH=src python3 -m ruff check src/driftshield/core/canonical_analysis.py src/driftshield/db/persistence.py src/driftshield/api/routes/sessions.py src/driftshield/api/schemas.py tests/api/test_ingest.py tests/api/test_sessions.py
```

## Notes

- This is the canonical analysed-run persistence/API slice for `#65`, not the full deterministic matching work from `#66`.
- The issue stays in progress until the remaining canonical normalisation acceptance criteria are fully covered.
