### PR TITLE
feat: extend canonical extraction quality metadata

### DIFF
--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -26,7 +26,7 @@ def build_canonical_analysis(
 ) -> dict[str, Any]:
     normalized_events = _canonical_event_payloads(result.events)
     missing_fields = sum(len(event["missing_fields"]) for event in normalized_events)
-    ambiguity_count = sum(len(event.get("missing_fields", [])) for event in normalized_events)
+    ambiguity_count = sum(len(event.ambiguities) for event in result.events)
     direct_events = sum(1 for event in normalized_events if event["recovery_mode"] == _DIRECT_RECOVERY_MODE)
     inferred_events = len(normalized_events) - direct_events
 

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -34,6 +34,10 @@ def build_canonical_analysis(
     overall_quality_band = _overall_quality_band(result.events, ambiguity_count=ambiguity_count)
     delta_types = _delta_types(result)
     parser_name = _parser_name(provenance)
+    coverage_ratio = round(_coverage_ratio(normalized_events), 4)
+    ordering_confidence = _ordering_confidence(result.events)
+    critical_gaps = _critical_gaps(result.events)
+    quality_warnings = _quality_warnings(result.events)
 
     return {
         "analysis_session": {
@@ -81,17 +85,32 @@ def build_canonical_analysis(
         },
         "extraction_quality_summary": {
             "overall_quality_band": overall_quality_band,
-            "coverage_ratio": round(_coverage_ratio(normalized_events), 4),
+            "coverage_ratio": coverage_ratio,
+            "parse_completeness": coverage_ratio,
             "missing_event_families": _missing_event_families(normalized_events),
-            "ordering_confidence": _ordering_confidence(result.events),
+            "ordering_confidence": ordering_confidence,
+            "structural_confidence": _structural_confidence(
+                coverage_ratio=coverage_ratio,
+                ordering_confidence=ordering_confidence,
+                ambiguity_count=ambiguity_count,
+            ),
+            "ambiguity_count": ambiguity_count,
             "field_recovery_summary": {
                 "direct_event_count": direct_events,
                 "inferred_event_count": inferred_events,
                 "missing_field_count": missing_fields,
             },
             "inference_ratio": round(inferred_events / len(normalized_events), 4) if normalized_events else 0.0,
-            "critical_gaps": _critical_gaps(result.events),
-            "quality_warnings": _quality_warnings(result.events),
+            "critical_gaps": critical_gaps,
+            "missing_critical_fields_status": _missing_critical_fields_status(critical_gaps),
+            "parser_warnings": _parser_warnings(result.events),
+            "quality_warnings": quality_warnings,
+            "review_requirements": _review_requirements(
+                critical_gaps=critical_gaps,
+                quality_warnings=quality_warnings,
+                ambiguity_count=ambiguity_count,
+                overall_quality_band=overall_quality_band,
+            ),
         },
     }
 
@@ -564,6 +583,17 @@ def _coverage_ratio(normalized_events: list[dict[str, Any]]) -> float:
     return max(0.0, min(1.0, (total_fields - missing) / total_fields))
 
 
+def _structural_confidence(
+    *,
+    coverage_ratio: float,
+    ordering_confidence: float,
+    ambiguity_count: int,
+) -> float:
+    confidence = min(coverage_ratio, ordering_confidence)
+    confidence -= min(ambiguity_count * 0.03, 0.3)
+    return round(max(confidence, 0.0), 4)
+
+
 def _missing_event_families(normalized_events: list[dict[str, Any]]) -> list[str]:
     required = {
         "user_instruction",
@@ -612,6 +642,45 @@ def _quality_warnings(events: list[CanonicalEvent]) -> list[str]:
         if event.ambiguities:
             warnings.add("event_ambiguities_present")
     return sorted(warnings)
+
+
+def _parser_warnings(events: list[CanonicalEvent]) -> list[str]:
+    warnings: set[str] = set()
+    for event in events:
+        if not event.source_refs:
+            warnings.add("missing_source_reference")
+        if event.failure_context and event.failure_context.get("status") == "warning":
+            warnings.add("parser_recovered_from_text_only_failure")
+        if event.ambiguities:
+            warnings.add("parser_observed_ambiguous_event_fields")
+    return sorted(warnings)
+
+
+def _missing_critical_fields_status(critical_gaps: list[str]) -> str:
+    if not critical_gaps:
+        return "complete"
+    if len(critical_gaps) >= 2:
+        return "missing"
+    return "partial"
+
+
+def _review_requirements(
+    *,
+    critical_gaps: list[str],
+    quality_warnings: list[str],
+    ambiguity_count: int,
+    overall_quality_band: str,
+) -> list[str]:
+    requirements: list[str] = []
+    if critical_gaps:
+        requirements.append("manual_review_required_for_missing_critical_fields")
+    if ambiguity_count:
+        requirements.append("manual_review_required_for_ambiguous_lineage")
+    if quality_warnings:
+        requirements.append("manual_review_required_for_parser_warnings")
+    if overall_quality_band in {"degraded", "insufficient_for_matching"}:
+        requirements.append("manual_review_required_before_matching")
+    return requirements
 
 
 def _overall_quality_band(events: list[CanonicalEvent], *, ambiguity_count: int) -> str:

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -132,7 +132,13 @@ def test_ingest_persists_provenance_fields(client, auth_headers, sample_transcri
     assert first_event["structured_payload"]["tool_name"] == "Read"
     assert first_event["structured_payload"]["state_transition"]["state_operation"] == "read"
     assert canonical_analysis["expected_vs_actual_delta"]["delta_types"] == ["no_material_delta_detected"]
-    assert "state_write" in canonical_analysis["extraction_quality_summary"]["missing_event_families"]
+    quality = canonical_analysis["extraction_quality_summary"]
+    assert "state_write" in quality["missing_event_families"]
+    assert quality["parse_completeness"] == quality["coverage_ratio"]
+    assert quality["missing_critical_fields_status"] == "complete"
+    assert isinstance(quality["ambiguity_count"], int)
+    assert isinstance(quality["parser_warnings"], list)
+    assert quality["review_requirements"] == []
 
 
 def test_ingest_stabilizes_normalized_parent_refs(db_session):

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -72,3 +72,38 @@ def test_build_canonical_analysis_preserves_developer_constraints_from_instructi
     assert developer_constraints
     assert developer_constraints[0]["constraint"] == "You must verify changes before replying."
     assert developer_constraints[0]["observed_via"] == "inferred_from_instruction_artifact"
+
+
+def test_build_canonical_analysis_exposes_extraction_quality_contract_for_ambiguous_runs():
+    event = CanonicalEvent(
+        id=uuid4(),
+        session_id="canonical-3",
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="claude",
+        action="Read",
+        inputs={"file_path": "README.md"},
+        outputs={},
+        ambiguities=["missing_parent_ref"],
+    )
+    result = analyze_session([event])
+
+    payload = build_canonical_analysis(
+        session=Session(
+            id=uuid4(),
+            agent_id="claude",
+            started_at=datetime.now(timezone.utc),
+            status=SessionStatus.COMPLETED,
+        ),
+        result=result,
+        provenance=None,
+    )
+
+    quality = payload["extraction_quality_summary"]
+    assert quality["parse_completeness"] == quality["coverage_ratio"]
+    assert quality["ambiguity_count"] >= 1
+    assert quality["structural_confidence"] < 1.0
+    assert quality["missing_critical_fields_status"] == "missing"
+    assert "parser_observed_ambiguous_event_fields" in quality["parser_warnings"]
+    assert "manual_review_required_for_missing_critical_fields" in quality["review_requirements"]
+    assert "manual_review_required_for_ambiguous_lineage" in quality["review_requirements"]

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from driftshield.core.analysis.session import analyze_session
+from driftshield.core.analysis.session import AnalysisResult, analyze_session
 from driftshield.core.canonical_analysis import build_canonical_analysis
+from driftshield.core.graph.models import LineageGraph
 from driftshield.core.models import CanonicalEvent, EventType, Session, SessionStatus
 from driftshield.core.normalization import normalize_events
 from driftshield.parsers.claude_code import ClaudeCodeParser
@@ -107,3 +108,41 @@ def test_build_canonical_analysis_exposes_extraction_quality_contract_for_ambigu
     assert "parser_observed_ambiguous_event_fields" in quality["parser_warnings"]
     assert "manual_review_required_for_missing_critical_fields" in quality["review_requirements"]
     assert "manual_review_required_for_ambiguous_lineage" in quality["review_requirements"]
+
+
+def test_build_canonical_analysis_does_not_treat_missing_fields_as_ambiguity():
+    event = CanonicalEvent(
+        id=uuid4(),
+        session_id="canonical-4",
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="claude",
+        action="Read",
+        inputs={"file_path": "README.md"},
+        outputs={},
+        summary="Read invoked on README.md",
+        source_refs=[{"kind": "message_id", "value": "tool-call-1"}],
+    )
+    result = AnalysisResult(
+        events=[event],
+        graph=LineageGraph(session_id=event.session_id),
+        inflection_node=None,
+        total_events=1,
+        flagged_events=0,
+    )
+
+    payload = build_canonical_analysis(
+        session=Session(
+            id=uuid4(),
+            agent_id="claude",
+            started_at=datetime.now(timezone.utc),
+            status=SessionStatus.COMPLETED,
+        ),
+        result=result,
+        provenance=None,
+    )
+
+    quality = payload["extraction_quality_summary"]
+    assert quality["field_recovery_summary"]["missing_field_count"] >= 1
+    assert quality["ambiguity_count"] == 0
+    assert "manual_review_required_for_ambiguous_lineage" not in quality["review_requirements"]


### PR DESCRIPTION
$## Summary

- add the remaining extraction-quality contract fields for canonical analysed runs
- expose explicit parse completeness, structural confidence, ambiguity count, missing-critical-fields status, parser warnings, and review requirements
- add regression coverage for clean and ambiguous canonical runs

Part of #65.

## Verification

```bash
PYTHONPATH=src python3 -m pytest tests/core/test_canonical_analysis.py tests/api/test_ingest.py tests/api/test_sessions.py tests/parsers/test_normalized_pipeline.py tests/db/test_persistence.py tests/core/test_models.py -q
PYTHONPATH=src python3 -m ruff check src/driftshield/core/canonical_analysis.py tests/core/test_canonical_analysis.py tests/api/test_ingest.py tests/api/test_sessions.py tests/parsers/test_normalized_pipeline.py tests/db/test_persistence.py tests/core/test_models.py
```

## Notes

- This keeps issue #65 open; it closes another contract gap after PR #69 without starting deterministic matching work from #66.
- No UI changes in this slice.
