### PR TITLE
feat: expose canonical field recovery provenance

### DIFF
--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -318,8 +318,6 @@ def _field_recovery(
         direct_fields.add("timestamp")
     if raw_reference is not None:
         direct_fields.update({"raw_reference", "source_span"})
-    if payload:
-        direct_fields.add("structured_payload")
     if content_summary is not None or event.summary:
         direct_fields.add("content_summary")
     if event.parent_event_refs or causal_parents:
@@ -336,6 +334,12 @@ def _field_recovery(
     if recovery_mode == _INFERRED_RECOVERY_MODE:
         normalised_fields.update(_normalised_fields_from_missing_fields(missing_fields))
 
+    if payload and not _has_non_direct_structured_payload_fields(
+        normalised_fields=normalised_fields,
+        inferred_fields=inferred_fields,
+    ):
+        direct_fields.add("structured_payload")
+
     direct_fields -= inferred_fields
 
     return {
@@ -348,6 +352,14 @@ def _field_recovery(
 
 def _recovered_field_count(field_recovery: dict[str, list[str]]) -> int:
     return len(set(field_recovery["normalised_fields"]) - _BASE_NORMALISED_FIELDS)
+
+
+def _has_non_direct_structured_payload_fields(
+    *,
+    normalised_fields: set[str],
+    inferred_fields: set[str],
+) -> bool:
+    return any(field.startswith("structured_payload.") for field in normalised_fields | inferred_fields)
 
 
 def _normalised_fields_from_missing_fields(missing_fields: list[str]) -> set[str]:

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -17,6 +17,15 @@ _DIRECT_RECOVERY_MODE = "direct"
 _NORMALISED_RECOVERY_MODE = "normalised"
 _INFERRED_RECOVERY_MODE = "inferred"
 
+_BASE_NORMALISED_FIELDS = {
+    "actor_type",
+    "confidence",
+    "event_family",
+    "event_type",
+    "recovery_mode",
+    "sequence_index",
+}
+
 
 def build_canonical_analysis(
     *,
@@ -34,9 +43,7 @@ def build_canonical_analysis(
     inferred_events = sum(
         1 for event in normalized_events if event["recovery_mode"] == _INFERRED_RECOVERY_MODE
     )
-    recovered_fields = sum(
-        len(event["field_recovery"]["normalised_fields"]) for event in normalized_events
-    )
+    recovered_fields = sum(_recovered_field_count(event["field_recovery"]) for event in normalized_events)
     inferred_fields = sum(
         len(event["field_recovery"]["inferred_fields"]) for event in normalized_events
     )
@@ -304,14 +311,7 @@ def _field_recovery(
     causal_parents: list[str] | None,
 ) -> dict[str, list[str]]:
     direct_fields: set[str] = set()
-    normalised_fields = {
-        "actor_type",
-        "confidence",
-        "event_family",
-        "event_type",
-        "recovery_mode",
-        "sequence_index",
-    }
+    normalised_fields = set(_BASE_NORMALISED_FIELDS)
     inferred_fields: set[str] = set()
 
     if event.timestamp is not None:
@@ -344,6 +344,10 @@ def _field_recovery(
         "inferred_fields": sorted(inferred_fields),
         "missing_fields": list(missing_fields),
     }
+
+
+def _recovered_field_count(field_recovery: dict[str, list[str]]) -> int:
+    return len(set(field_recovery["normalised_fields"]) - _BASE_NORMALISED_FIELDS)
 
 
 def _normalised_fields_from_missing_fields(missing_fields: list[str]) -> set[str]:

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -28,7 +28,18 @@ def build_canonical_analysis(
     missing_fields = sum(len(event["missing_fields"]) for event in normalized_events)
     ambiguity_count = sum(len(event.ambiguities) for event in result.events)
     direct_events = sum(1 for event in normalized_events if event["recovery_mode"] == _DIRECT_RECOVERY_MODE)
-    inferred_events = len(normalized_events) - direct_events
+    normalised_events = sum(
+        1 for event in normalized_events if event["recovery_mode"] == _NORMALISED_RECOVERY_MODE
+    )
+    inferred_events = sum(
+        1 for event in normalized_events if event["recovery_mode"] == _INFERRED_RECOVERY_MODE
+    )
+    recovered_fields = sum(
+        len(event["field_recovery"]["normalised_fields"]) for event in normalized_events
+    )
+    inferred_fields = sum(
+        len(event["field_recovery"]["inferred_fields"]) for event in normalized_events
+    )
 
     integrity_reasons = _integrity_reasons(result.events)
     overall_quality_band = _overall_quality_band(result.events, ambiguity_count=ambiguity_count)
@@ -97,8 +108,11 @@ def build_canonical_analysis(
             "ambiguity_count": ambiguity_count,
             "field_recovery_summary": {
                 "direct_event_count": direct_events,
+                "normalised_event_count": normalised_events,
                 "inferred_event_count": inferred_events,
                 "missing_field_count": missing_fields,
+                "recovered_field_count": recovered_fields,
+                "inferred_field_count": inferred_fields,
             },
             "inference_ratio": round(inferred_events / len(normalized_events), 4) if normalized_events else 0.0,
             "critical_gaps": critical_gaps,
@@ -148,6 +162,15 @@ def _canonical_event_payload(
     payload = structured_payload or _structured_payload(event, raw_reference=raw_reference)
     missing_fields = _event_missing_fields(event)
     recovery_mode = _recovery_mode(event, missing_fields=missing_fields)
+    field_recovery = _field_recovery(
+        event,
+        raw_reference=raw_reference,
+        payload=payload,
+        missing_fields=missing_fields,
+        recovery_mode=recovery_mode,
+        content_summary=content_summary,
+        causal_parents=causal_parents,
+    )
 
     return {
         "event_id": event_id or str(event.id),
@@ -163,6 +186,7 @@ def _canonical_event_payload(
         "causal_parents": causal_parents if causal_parents is not None else [str(ref) for ref in event.parent_event_refs],
         "confidence": _event_confidence(event, missing_fields=missing_fields),
         "recovery_mode": recovery_mode,
+        "field_recovery": field_recovery,
         "missing_fields": missing_fields,
     }
 
@@ -267,6 +291,85 @@ def _event_confidence(event: CanonicalEvent, *, missing_fields: list[str]) -> fl
     if event.failure_context and event.failure_context.get("status") == "warning":
         confidence -= 0.1
     return round(max(confidence, 0.2), 2)
+
+
+def _field_recovery(
+    event: CanonicalEvent,
+    *,
+    raw_reference: dict[str, str] | None,
+    payload: dict[str, Any],
+    missing_fields: list[str],
+    recovery_mode: str,
+    content_summary: str | None,
+    causal_parents: list[str] | None,
+) -> dict[str, list[str]]:
+    direct_fields: set[str] = set()
+    normalised_fields = {
+        "actor_type",
+        "confidence",
+        "event_family",
+        "event_type",
+        "recovery_mode",
+        "sequence_index",
+    }
+    inferred_fields: set[str] = set()
+
+    if event.timestamp is not None:
+        direct_fields.add("timestamp")
+    if raw_reference is not None:
+        direct_fields.update({"raw_reference", "source_span"})
+    if payload:
+        direct_fields.add("structured_payload")
+    if content_summary is not None or event.summary:
+        direct_fields.add("content_summary")
+    if event.parent_event_refs or causal_parents:
+        direct_fields.add("causal_parents")
+
+    if event.ambiguities:
+        inferred_fields.update(_inferred_fields_from_ambiguities(event.ambiguities))
+
+    if event.failure_context and event.failure_context.get("status") == "warning":
+        inferred_fields.update({"structured_payload.failure_context", "structured_payload.tool_activity"})
+
+    if recovery_mode == _NORMALISED_RECOVERY_MODE:
+        normalised_fields.update(_normalised_fields_from_missing_fields(missing_fields))
+    if recovery_mode == _INFERRED_RECOVERY_MODE:
+        normalised_fields.update(_normalised_fields_from_missing_fields(missing_fields))
+
+    direct_fields -= inferred_fields
+
+    return {
+        "direct_fields": sorted(direct_fields),
+        "normalised_fields": sorted(normalised_fields),
+        "inferred_fields": sorted(inferred_fields),
+        "missing_fields": list(missing_fields),
+    }
+
+
+def _normalised_fields_from_missing_fields(missing_fields: list[str]) -> set[str]:
+    field_map = {
+        "causal_parents_missing": "causal_parents",
+        "content_summary_missing": "content_summary",
+        "source_reference_missing": "raw_reference",
+        "tool_inputs_missing": "structured_payload.inputs",
+        "tool_outputs_missing": "structured_payload.outputs",
+    }
+    return {field_map[item] for item in missing_fields if item in field_map}
+
+
+def _inferred_fields_from_ambiguities(ambiguities: list[str]) -> set[str]:
+    field_map = {
+        "failure_inferred_from_text": "structured_payload.failure_context",
+        "missing_actor": "actor_type",
+        "missing_parent_ref": "causal_parents",
+        "missing_source_ref": "raw_reference",
+        "missing_tool_inputs": "structured_payload.inputs",
+        "missing_tool_outputs": "structured_payload.outputs",
+    }
+    inferred_fields = {field_map[item] for item in ambiguities if item in field_map}
+    if "failure_inferred_from_text" in ambiguities:
+        inferred_fields.add("recovery_mode")
+    return inferred_fields
 
 
 def _has_result_payload(event: CanonicalEvent) -> bool:

--- a/driftshield/tests/api/test_ingest.py
+++ b/driftshield/tests/api/test_ingest.py
@@ -129,6 +129,7 @@ def test_ingest_persists_provenance_fields(client, auth_headers, sample_transcri
     assert canonical_analysis["normalized_events"]
     first_event = canonical_analysis["normalized_events"][0]
     assert first_event["event_family"] == "state_read"
+    assert first_event["field_recovery"]["direct_fields"]
     assert first_event["structured_payload"]["tool_name"] == "Read"
     assert first_event["structured_payload"]["state_transition"]["state_operation"] == "read"
     assert canonical_analysis["expected_vs_actual_delta"]["delta_types"] == ["no_material_delta_detected"]
@@ -136,6 +137,7 @@ def test_ingest_persists_provenance_fields(client, auth_headers, sample_transcri
     assert "state_write" in quality["missing_event_families"]
     assert quality["parse_completeness"] == quality["coverage_ratio"]
     assert quality["missing_critical_fields_status"] == "complete"
+    assert quality["field_recovery_summary"]["normalised_event_count"] == 0
     assert isinstance(quality["ambiguity_count"], int)
     assert isinstance(quality["parser_warnings"], list)
     assert quality["review_requirements"] == []

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -149,6 +149,7 @@ def test_build_canonical_analysis_does_not_treat_missing_fields_as_ambiguity():
     assert event_payload["recovery_mode"] == "normalised"
     assert event_payload["field_recovery"]["normalised_fields"]
     assert "structured_payload.outputs" in event_payload["field_recovery"]["normalised_fields"]
+    assert "structured_payload" not in event_payload["field_recovery"]["direct_fields"]
     assert event_payload["field_recovery"]["inferred_fields"] == []
     assert quality["field_recovery_summary"]["missing_field_count"] >= 1
     assert quality["field_recovery_summary"]["normalised_event_count"] == 1
@@ -201,6 +202,7 @@ def test_build_canonical_analysis_exposes_field_recovery_provenance_for_inferred
     quality = payload["extraction_quality_summary"]
 
     assert event_payload["recovery_mode"] == "inferred"
+    assert "structured_payload" not in event_payload["field_recovery"]["direct_fields"]
     assert "structured_payload.failure_context" in event_payload["field_recovery"]["inferred_fields"]
     assert "recovery_mode" in event_payload["field_recovery"]["inferred_fields"]
     assert quality["field_recovery_summary"]["inferred_event_count"] == 1

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -41,6 +41,7 @@ def test_build_canonical_analysis_emits_result_families_for_completed_tool_calls
     assert result_event["causal_parents"] == [payload["normalized_events"][0]["event_id"]]
     assert result_event["structured_payload"]["invocation_id"] == "tool_1"
     assert result_event["structured_payload"]["result_status"] == "completed"
+    assert payload["extraction_quality_summary"]["field_recovery_summary"]["recovered_field_count"] == 0
 
 
 def test_build_canonical_analysis_preserves_developer_constraints_from_instruction_artifacts():

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -143,6 +143,64 @@ def test_build_canonical_analysis_does_not_treat_missing_fields_as_ambiguity():
     )
 
     quality = payload["extraction_quality_summary"]
+    event_payload = payload["normalized_events"][0]
+
+    assert event_payload["recovery_mode"] == "normalised"
+    assert event_payload["field_recovery"]["normalised_fields"]
+    assert "structured_payload.outputs" in event_payload["field_recovery"]["normalised_fields"]
+    assert event_payload["field_recovery"]["inferred_fields"] == []
     assert quality["field_recovery_summary"]["missing_field_count"] >= 1
+    assert quality["field_recovery_summary"]["normalised_event_count"] == 1
+    assert quality["field_recovery_summary"]["inferred_event_count"] == 0
     assert quality["ambiguity_count"] == 0
     assert "manual_review_required_for_ambiguous_lineage" not in quality["review_requirements"]
+
+
+def test_build_canonical_analysis_exposes_field_recovery_provenance_for_inferred_failures():
+    event = CanonicalEvent(
+        id=uuid4(),
+        session_id="canonical-5",
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="claude",
+        action="Read",
+        inputs={"file_path": "README.md"},
+        outputs={"result": "permission denied while reading README.md"},
+        source_refs=[{"kind": "message_id", "value": "tool-call-2"}],
+        artifact_refs=[{"kind": "file_path", "value": "README.md"}],
+        failure_context={
+            "status": "warning",
+            "error": None,
+            "signals": ["failure_language"],
+            "declared_failure": True,
+        },
+        ambiguities=["failure_inferred_from_text"],
+        summary="Read reported a warning on README.md",
+    )
+    result = AnalysisResult(
+        events=[event],
+        graph=LineageGraph(session_id=event.session_id),
+        inflection_node=None,
+        total_events=1,
+        flagged_events=0,
+    )
+
+    payload = build_canonical_analysis(
+        session=Session(
+            id=uuid4(),
+            agent_id="claude",
+            started_at=datetime.now(timezone.utc),
+            status=SessionStatus.COMPLETED,
+        ),
+        result=result,
+        provenance=None,
+    )
+
+    event_payload = payload["normalized_events"][0]
+    quality = payload["extraction_quality_summary"]
+
+    assert event_payload["recovery_mode"] == "inferred"
+    assert "structured_payload.failure_context" in event_payload["field_recovery"]["inferred_fields"]
+    assert "recovery_mode" in event_payload["field_recovery"]["inferred_fields"]
+    assert quality["field_recovery_summary"]["inferred_event_count"] == 1
+    assert quality["field_recovery_summary"]["inferred_field_count"] >= 1


### PR DESCRIPTION
## Summary

- add explicit per-event field recovery provenance to the canonical analysed-run payload
- separate direct, normalised, and inferred recovery counts in the extraction quality summary
- cover the new provenance contract for both normalised missing-data cases and inferred failure recovery

Closes #65.

## Verification

```bash
PYTHONPATH=src python3 -m pytest tests/core/test_canonical_analysis.py tests/api/test_ingest.py tests/api/test_sessions.py tests/parsers/test_normalized_pipeline.py tests/db/test_persistence.py tests/core/test_models.py -q
PYTHONPATH=src python3 -m ruff check src/driftshield/core/canonical_analysis.py tests/core/test_canonical_analysis.py tests/api/test_ingest.py tests/api/test_sessions.py tests/parsers/test_normalized_pipeline.py tests/db/test_persistence.py tests/core/test_models.py
```

## Notes

- This is the final planned `#65` closure slice after PRs #69 and #70.
- No UI changes in this slice.
