### PR TITLE
feat: add migration runner container for Postgres alembic upgrade

### DIFF
--- a/driftshield/migrations/Dockerfile
+++ b/driftshield/migrations/Dockerfile
@@ -1,0 +1,28 @@
+# Migration runner image for DriftShield.
+#
+# Builds a container that applies the DriftShield Alembic migration chain
+# against a PostgreSQL database. The same image runs locally with
+# DATABASE_URL or as an AWS Lambda function with DB_SECRET_ARN pointing at
+# a Secrets Manager secret in the {username, password, host, port, dbname}
+# shape produced by AWS managed credentials.
+
+FROM public.ecr.aws/lambda/python:3.12
+
+WORKDIR /var/task
+
+# Copy the package source and the Alembic configuration. The image installs
+# driftshield itself from the local source so the migration scripts can
+# import db.models for autogeneration consistency.
+COPY pyproject.toml ./
+COPY src/ ./src/
+COPY alembic.ini ./
+
+# Install the package and the runtime dependencies the handler needs.
+# boto3 is a hard dependency of the runner image so secret resolution does
+# not silently rely on the Lambda runtime copy.
+RUN pip install --no-cache-dir . boto3>=1.34.0
+
+# The handler module lives next to the Alembic config.
+COPY migrations/lambda_handler.py ./lambda_handler.py
+
+CMD ["lambda_handler.handler"]

--- a/driftshield/migrations/README.md
+++ b/driftshield/migrations/README.md
@@ -1,0 +1,102 @@
+# Migration runner
+
+A container image that applies the DriftShield Alembic migration chain
+against a PostgreSQL database. Runs locally for development and as an AWS
+Lambda function for managed deployments.
+
+The image is intentionally small and single-purpose. It does not start the
+DriftShield API server. It does one thing: `alembic upgrade head`.
+
+## Configuration
+
+Set exactly one of the following environment variables.
+
+`DATABASE_URL`
+  A SQLAlchemy-compatible PostgreSQL URL. Used as-is.
+
+`DB_SECRET_ARN`
+  An AWS Secrets Manager ARN. The secret value must be JSON containing
+  `username`, `password`, `host`, `port`, and `dbname` (`database` is
+  accepted as an alias for `dbname`). The runner builds the URL itself.
+
+If neither is set, the runner exits with an error. If both are set, the
+runner exits with an error. There are no defaults.
+
+The runner never logs the resolved URL or the password.
+
+## Build
+
+From the package root, with `Dockerfile` at `migrations/Dockerfile`:
+
+```bash
+docker build -f migrations/Dockerfile -t driftshield-migrations:dev .
+```
+
+## Run locally
+
+Bring up a throwaway PostgreSQL and run the migration image against it:
+
+```bash
+docker network create migrations-net
+
+docker run --rm -d --name pg --network migrations-net \
+  -e POSTGRES_PASSWORD=devpass \
+  -e POSTGRES_DB=driftshield \
+  postgres:16
+
+docker run --rm --network migrations-net \
+  -e DATABASE_URL=postgresql+psycopg2://postgres:devpass@pg:5432/driftshield \
+  --entrypoint python \
+  driftshield-migrations:dev \
+  -c "from lambda_handler import handler; import json; print(json.dumps(handler({}, None), indent=2))"
+```
+
+Expected output is a JSON object describing the starting and resulting
+head revisions.
+
+Tear down:
+
+```bash
+docker stop pg
+docker network rm migrations-net
+```
+
+## Deploy as a container Lambda
+
+The image is compatible with the AWS Lambda container runtime. The default
+`CMD` is `lambda_handler.handler`. The function role must allow
+`secretsmanager:GetSecretValue` on the target secret if `DB_SECRET_ARN`
+is used. The function must have network reachability to the database.
+
+The Lambda invocation event is ignored. Invoke with an empty payload:
+
+```bash
+aws lambda invoke \
+  --function-name <your-migration-function> \
+  --payload '{}' \
+  /tmp/migration-output.json
+
+cat /tmp/migration-output.json
+```
+
+A successful response looks like:
+
+```json
+{
+  "status": "ok",
+  "starting_revision": "8f1a2b3c4d5e",
+  "head_revision": "ce8b08023f17",
+  "target_head": "ce8b08023f17"
+}
+```
+
+A failed migration raises, so the Lambda invocation is marked as failed
+and CloudWatch contains a redacted error message.
+
+## What this image does not do
+
+- It does not seed sample data.
+- It does not start the API server.
+- It does not run integration tests.
+- It does not generate new revisions. Authoring revisions stays a developer
+  workflow with a local checkout.

--- a/driftshield/migrations/lambda_handler.py
+++ b/driftshield/migrations/lambda_handler.py
@@ -1,0 +1,199 @@
+"""Migration runner entrypoint.
+
+Runs `alembic upgrade head` against a PostgreSQL database. Designed to run
+inside the migrations container image, either locally or as an AWS Lambda
+function. Configuration is via environment variables only.
+
+Required: exactly one of DATABASE_URL or DB_SECRET_ARN.
+
+DATABASE_URL
+    A SQLAlchemy-compatible PostgreSQL URL. Used as-is.
+
+DB_SECRET_ARN
+    An AWS Secrets Manager ARN. The secret value must be JSON containing
+    `username`, `password`, `host`, `port`, and `dbname` (or `database` as
+    an alias for `dbname`).
+
+The handler returns a payload describing the starting and resulting head
+revisions. On error it raises so the Lambda invocation fails visibly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from alembic import command
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+ALEMBIC_INI_PATH = Path(__file__).resolve().parent / "alembic.ini"
+
+REQUIRED_SECRET_KEYS = ("username", "password", "host", "port")
+
+
+class MigrationRunnerError(RuntimeError):
+    """Raised when configuration or migration execution fails."""
+
+
+def _resolve_database_url() -> str:
+    direct_url = os.environ.get("DATABASE_URL")
+    secret_arn = os.environ.get("DB_SECRET_ARN")
+
+    if direct_url and secret_arn:
+        raise MigrationRunnerError(
+            "Set exactly one of DATABASE_URL or DB_SECRET_ARN, not both."
+        )
+
+    if direct_url:
+        return direct_url
+
+    if not secret_arn:
+        raise MigrationRunnerError(
+            "Set DATABASE_URL or DB_SECRET_ARN. Neither was provided."
+        )
+
+    return _build_url_from_secret(secret_arn)
+
+
+def _build_url_from_secret(secret_arn: str) -> str:
+    try:
+        import boto3
+    except ImportError as exc:
+        raise MigrationRunnerError(
+            "DB_SECRET_ARN is set but boto3 is not installed. "
+            "Install boto3 in the runner environment."
+        ) from exc
+
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    client = boto3.client("secretsmanager", region_name=region) if region else boto3.client("secretsmanager")
+
+    response = client.get_secret_value(SecretId=secret_arn)
+    raw = response.get("SecretString")
+    if not raw:
+        raise MigrationRunnerError("Secret value is empty or binary; expected JSON string.")
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise MigrationRunnerError("Secret value is not valid JSON.") from exc
+
+    if not isinstance(payload, dict):
+        raise MigrationRunnerError("Secret JSON must be an object.")
+
+    missing = [key for key in REQUIRED_SECRET_KEYS if key not in payload]
+    dbname = payload.get("dbname") or payload.get("database")
+    if not dbname:
+        missing.append("dbname")
+
+    if missing:
+        raise MigrationRunnerError(
+            f"Secret JSON is missing required keys: {sorted(set(missing))}."
+        )
+
+    username = payload["username"]
+    password = payload["password"]
+    host = payload["host"]
+    port = payload["port"]
+
+    return f"postgresql+psycopg2://{username}:{password}@{host}:{port}/{dbname}"
+
+
+def _build_alembic_config(database_url: str) -> Config:
+    if not ALEMBIC_INI_PATH.exists():
+        raise MigrationRunnerError(f"alembic.ini not found at {ALEMBIC_INI_PATH}.")
+
+    config = Config(str(ALEMBIC_INI_PATH))
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+def _current_revision(database_url: str) -> str | None:
+    engine = create_engine(database_url, poolclass=None)
+    try:
+        with engine.connect() as connection:
+            context = MigrationContext.configure(connection)
+            return context.get_current_revision()
+    finally:
+        engine.dispose()
+
+
+def _script_head(config: Config) -> str | None:
+    script = ScriptDirectory.from_config(config)
+    head = script.get_current_head()
+    return head
+
+
+def handler(event: Any, context: Any) -> dict[str, Any]:
+    """Lambda entrypoint. Applies all pending migrations to the target DB."""
+
+    del event, context  # The runner ignores the invocation payload.
+
+    try:
+        database_url = _resolve_database_url()
+    except MigrationRunnerError as exc:
+        logger.error("configuration error: %s", exc)
+        raise
+
+    alembic_config = _build_alembic_config(database_url)
+
+    try:
+        starting_revision = _current_revision(database_url)
+    except Exception as exc:  # noqa: BLE001 - re-raised below as a runner error
+        logger.error("failed to read current revision: %s", _redact(str(exc), database_url))
+        raise MigrationRunnerError("Could not read current Alembic revision before upgrade.") from exc
+
+    target_head = _script_head(alembic_config)
+    logger.info(
+        "migration plan: starting_revision=%s target_head=%s",
+        starting_revision,
+        target_head,
+    )
+
+    try:
+        command.upgrade(alembic_config, "head")
+    except Exception as exc:  # noqa: BLE001 - all alembic errors are runner errors here
+        message = _redact(str(exc), database_url)
+        logger.error("alembic upgrade failed: %s", message)
+        raise MigrationRunnerError(f"Alembic upgrade failed: {message}") from exc
+
+    try:
+        ending_revision = _current_revision(database_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("failed to read post-upgrade revision: %s", _redact(str(exc), database_url))
+        raise MigrationRunnerError("Could not read Alembic revision after upgrade.") from exc
+
+    result = {
+        "status": "ok",
+        "starting_revision": starting_revision,
+        "head_revision": ending_revision,
+        "target_head": target_head,
+    }
+    logger.info("migration complete: %s", result)
+    return result
+
+
+def _redact(message: str, database_url: str) -> str:
+    """Strip the database URL from any string before it reaches logs or responses."""
+
+    if not database_url:
+        return message
+    redacted = message.replace(database_url, "<redacted-database-url>")
+    if "://" in database_url:
+        scheme, rest = database_url.split("://", 1)
+        if "@" in rest:
+            credentials, host_part = rest.rsplit("@", 1)
+            redacted = redacted.replace(f"{scheme}://{credentials}@", f"{scheme}://<redacted>@")
+            if ":" in credentials:
+                password = credentials.split(":", 1)[1]
+                if password:
+                    redacted = redacted.replace(password, "<redacted>")
+    return redacted


### PR DESCRIPTION
## Summary
- add a Lambda-compatible container runner under `driftshield/migrations/` for `alembic upgrade head`
- support `DATABASE_URL` xor `DB_SECRET_ARN` with Aurora-style secret parsing and redacted errors
- document local build/run flow and container Lambda deployment in `migrations/README.md`

## Verification
- built `migrations/Dockerfile` image successfully
- ran the handler against a throwaway `postgres:16` container and confirmed `starting_revision=null` and `head_revision == target_head == b7c1e3d5f6a2`
- spot-checked no-env, both-envs, and bad-URL failure paths; bad-URL output did not leak the password
- ran `./scripts/check-public-scope.sh`
- ran `cd driftshield && uv run --extra dev pytest tests/db/test_migrations.py tests/db/test_migration_runner.py -q`
- ran `cd driftshield && uv run --extra dev ruff check migrations/lambda_handler.py tests/db/test_migration_runner.py`

## Links

Closes #82

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [ ] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- None

See `driftshield/migrations/README.md` for the runner contract and usage.
