### PR TITLE
fix: harden migration runner secret handling

### DIFF
--- a/driftshield/migrations/Dockerfile
+++ b/driftshield/migrations/Dockerfile
@@ -20,7 +20,7 @@ COPY alembic.ini ./
 # Install the package and the runtime dependencies the handler needs.
 # boto3 is a hard dependency of the runner image so secret resolution does
 # not silently rely on the Lambda runtime copy.
-RUN pip install --no-cache-dir . boto3>=1.34.0
+RUN pip install --no-cache-dir . 'boto3>=1.34.0'
 
 # The handler module lives next to the Alembic config.
 COPY migrations/lambda_handler.py ./lambda_handler.py

--- a/driftshield/migrations/lambda_handler.py
+++ b/driftshield/migrations/lambda_handler.py
@@ -25,12 +25,14 @@ import logging
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine
+from sqlalchemy.engine import URL, make_url
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -104,7 +106,19 @@ def _build_url_from_secret(secret_arn: str) -> str:
     host = payload["host"]
     port = payload["port"]
 
-    return f"postgresql+psycopg2://{username}:{password}@{host}:{port}/{dbname}"
+    try:
+        parsed_port = int(port)
+    except (TypeError, ValueError) as exc:
+        raise MigrationRunnerError("Secret JSON field 'port' must be an integer.") from exc
+
+    return URL.create(
+        "postgresql+psycopg2",
+        username=str(username),
+        password=str(password),
+        host=str(host),
+        port=parsed_port,
+        database=str(dbname),
+    ).render_as_string(hide_password=False)
 
 
 def _build_alembic_config(database_url: str) -> Config:
@@ -186,14 +200,21 @@ def _redact(message: str, database_url: str) -> str:
 
     if not database_url:
         return message
+
     redacted = message.replace(database_url, "<redacted-database-url>")
-    if "://" in database_url:
-        scheme, rest = database_url.split("://", 1)
-        if "@" in rest:
-            credentials, host_part = rest.rsplit("@", 1)
-            redacted = redacted.replace(f"{scheme}://{credentials}@", f"{scheme}://<redacted>@")
-            if ":" in credentials:
-                password = credentials.split(":", 1)[1]
-                if password:
-                    redacted = redacted.replace(password, "<redacted>")
+
+    try:
+        parsed = make_url(database_url)
+    except Exception:  # noqa: BLE001 - best-effort redaction only
+        return redacted
+
+    password = parsed.password
+    if password:
+        redacted = redacted.replace(password, "<redacted>")
+        redacted = redacted.replace(quote(password, safe=""), "<redacted>")
+
+    rendered = parsed.render_as_string(hide_password=False)
+    rendered_redacted = parsed.render_as_string(hide_password=True)
+    redacted = redacted.replace(rendered, "<redacted-database-url>")
+    redacted = redacted.replace(rendered_redacted, "<redacted-database-url>")
     return redacted

--- a/driftshield/tests/db/test_migration_runner.py
+++ b/driftshield/tests/db/test_migration_runner.py
@@ -1,0 +1,66 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.engine import make_url
+
+
+@pytest.fixture()
+def migration_runner_module():
+    module_path = Path(__file__).resolve().parents[2] / "migrations/lambda_handler.py"
+    spec = spec_from_file_location("migration_runner", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_url_from_secret_percent_encodes_credentials(monkeypatch, migration_runner_module):
+    class FakeSecretsClient:
+        def get_secret_value(self, *, SecretId: str):
+            assert SecretId == "arn:aws:secretsmanager:eu-west-1:123456789012:secret:test"
+            return {
+                "SecretString": (
+                    '{"username":"runner","password":"p@ss:/?#[]!$&\'()*+,;=word",'
+                    '"host":"db.example.internal","port":5432,"dbname":"driftshield"}'
+                )
+            }
+
+    fake_boto3 = SimpleNamespace(client=lambda *args, **kwargs: FakeSecretsClient())
+    monkeypatch.setitem(__import__("sys").modules, "boto3", fake_boto3)
+
+    url = migration_runner_module._build_url_from_secret(
+        "arn:aws:secretsmanager:eu-west-1:123456789012:secret:test"
+    )
+
+    assert "p@ss:/?#[]!$&'()*+,;=word" not in url
+    parsed = make_url(url)
+    assert parsed.username == "runner"
+    assert parsed.password == "p@ss:/?#[]!$&'()*+,;=word"
+    assert parsed.host == "db.example.internal"
+    assert parsed.port == 5432
+    assert parsed.database == "driftshield"
+
+
+def test_redact_strips_raw_and_percent_encoded_passwords(migration_runner_module):
+    database_url = "postgresql+psycopg2://runner:p%40ss%3Aword@db.example.internal:5432/driftshield"
+    message = (
+        "connect failed for postgresql+psycopg2://runner:p%40ss%3Aword@db.example.internal:5432/driftshield "
+        "and raw password p@ss:word should not leak"
+    )
+
+    redacted = migration_runner_module._redact(message, database_url)
+
+    assert "p%40ss%3Aword" not in redacted
+    assert "p@ss:word" not in redacted
+    assert "<redacted>" in redacted
+
+
+def test_resolve_database_url_rejects_both_envs(monkeypatch, migration_runner_module):
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg2://example")
+    monkeypatch.setenv("DB_SECRET_ARN", "arn:aws:secretsmanager:eu-west-1:123:secret:test")
+
+    with pytest.raises(migration_runner_module.MigrationRunnerError):
+        migration_runner_module._resolve_database_url()


### PR DESCRIPTION
## Summary
- quote the boto3 requirement in the migration runner Dockerfile so Docker does not treat the version floor as shell redirection
- build secret-derived Postgres URLs via SQLAlchemy `URL.create(...)` so reserved password characters are encoded correctly
- add regression tests for secret URL construction, redaction, and the xor env contract

## Verification
- `./scripts/check-public-scope.sh`
- `cd driftshield && uv run --extra dev pytest tests/db/test_migrations.py tests/db/test_migration_runner.py -q`
- `cd driftshield && uv run --extra dev ruff check migrations/lambda_handler.py tests/db/test_migration_runner.py`

## Links

Closes #82

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [ ] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- None
