### PR TITLE
feat: seed tenant-oss for Phase 3h intake

### DIFF
--- a/driftshield/src/driftshield/db/hosted_schema_sql.py
+++ b/driftshield/src/driftshield/db/hosted_schema_sql.py
@@ -689,3 +689,38 @@ def build_phase3h_team_views_drop_sql() -> tuple[str, ...]:
         "drop index if exists ix_trust_evaluations_submission_created_at_write_order",
         "drop index if exists ix_signature_matches_recurrence_group_signature",
     )
+
+
+def build_phase3h_tenant_oss_seed_sql() -> tuple[str, ...]:
+    return (
+        """
+        insert into tenants (
+            tenant_id,
+            display_name,
+            tenancy_state,
+            home_region,
+            deployment_target,
+            metadata
+        )
+        values (
+            'tenant-oss',
+            'OSS fallback tenant',
+            'active',
+            'eu-west-2',
+            'aurora-postgresql-serverless-v2',
+            jsonb_build_object(
+                'seed_source', 'alembic',
+                'seed_revision', '20260512_01',
+                'persona', 'oss'
+            )
+        )
+        on conflict (tenant_id) do nothing
+        """,
+        "select id from tenants where tenant_id = 'tenant-oss'",
+    )
+
+
+def build_phase3h_tenant_oss_seed_delete_sql() -> tuple[str, ...]:
+    return (
+        "delete from tenants where tenant_id = 'tenant-oss'",
+    )

--- a/driftshield/src/driftshield/db/hosted_schema_sql.py
+++ b/driftshield/src/driftshield/db/hosted_schema_sql.py
@@ -691,7 +691,7 @@ def build_phase3h_team_views_drop_sql() -> tuple[str, ...]:
     )
 
 
-def build_phase3h_tenant_oss_seed_sql() -> tuple[str, ...]:
+def build_phase3h_tenant_oss_seed_sql() -> tuple[str, str]:
     return (
         """
         insert into tenants (
@@ -710,17 +710,10 @@ def build_phase3h_tenant_oss_seed_sql() -> tuple[str, ...]:
             'aurora-postgresql-serverless-v2',
             jsonb_build_object(
                 'seed_source', 'alembic',
-                'seed_revision', '20260512_01',
                 'persona', 'oss'
             )
         )
         on conflict (tenant_id) do nothing
         """,
         "select id from tenants where tenant_id = 'tenant-oss'",
-    )
-
-
-def build_phase3h_tenant_oss_seed_delete_sql() -> tuple[str, ...]:
-    return (
-        "delete from tenants where tenant_id = 'tenant-oss'",
     )

--- a/driftshield/src/driftshield/db/migrations/versions/20260512_01_seed_tenant_oss.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260512_01_seed_tenant_oss.py
@@ -1,0 +1,31 @@
+"""seed tenant oss
+
+Revision ID: 20260512_01
+Revises: 20260511_03
+Create Date: 2026-05-12 09:45:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+from driftshield.db.hosted_schema_sql import (
+    build_phase3h_tenant_oss_seed_delete_sql,
+    build_phase3h_tenant_oss_seed_sql,
+)
+
+
+revision: str = "20260512_01"
+down_revision: str | None = "20260511_03"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    for statement in build_phase3h_tenant_oss_seed_sql():
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    for statement in build_phase3h_tenant_oss_seed_delete_sql():
+        op.execute(statement)

--- a/driftshield/src/driftshield/db/migrations/versions/20260512_01_seed_tenant_oss.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260512_01_seed_tenant_oss.py
@@ -6,13 +6,12 @@ Create Date: 2026-05-12 09:45:00.000000
 """
 
 from collections.abc import Sequence
+import logging
 
 from alembic import op
+import sqlalchemy as sa
 
-from driftshield.db.hosted_schema_sql import (
-    build_phase3h_tenant_oss_seed_delete_sql,
-    build_phase3h_tenant_oss_seed_sql,
-)
+from driftshield.db.hosted_schema_sql import build_phase3h_tenant_oss_seed_sql
 
 
 revision: str = "20260512_01"
@@ -20,12 +19,17 @@ down_revision: str | None = "20260511_03"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
+LOGGER = logging.getLogger("alembic.runtime.migration")
+
 
 def upgrade() -> None:
-    for statement in build_phase3h_tenant_oss_seed_sql():
-        op.execute(statement)
+    seed_insert_sql, select_sql = build_phase3h_tenant_oss_seed_sql()
+    op.execute(seed_insert_sql)
+    tenant_row_id = op.get_bind().execute(sa.text(select_sql)).scalar_one()
+    LOGGER.info("resolved tenant-oss row uuid: %s", tenant_row_id)
 
 
 def downgrade() -> None:
-    for statement in build_phase3h_tenant_oss_seed_delete_sql():
-        op.execute(statement)
+    raise NotImplementedError(
+        "tenant-oss seed is forward-only; restore from the pre-execute Aurora snapshot recorded on #163 AC5"
+    )

--- a/driftshield/tests/db/test_migrations.py
+++ b/driftshield/tests/db/test_migrations.py
@@ -7,6 +7,8 @@ from alembic.operations import Operations
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
+from driftshield.db.hosted_schema_sql import build_phase3h_tenant_oss_seed_sql
+
 
 def test_alembic_has_single_head():
     config = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
@@ -51,3 +53,13 @@ def test_recurrence_cleanup_downgrade_uses_sqlite_safe_types():
         assert isinstance(recurrence_columns["id"]["type"], sa.String)
         assert isinstance(session_columns["session_id"]["type"], sa.String)
         assert isinstance(session_columns["signature_id"]["type"], sa.String)
+
+
+def test_phase3h_tenant_oss_seed_sql_is_idempotent_and_resolves_uuid() -> None:
+    statements = build_phase3h_tenant_oss_seed_sql()
+
+    assert len(statements) == 2
+    assert "insert into tenants" in statements[0]
+    assert "'tenant-oss'" in statements[0]
+    assert "on conflict (tenant_id) do nothing" in statements[0].lower()
+    assert statements[1].strip().lower() == "select id from tenants where tenant_id = 'tenant-oss'"

--- a/driftshield/tests/db/test_migrations.py
+++ b/driftshield/tests/db/test_migrations.py
@@ -1,6 +1,7 @@
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
 import sqlalchemy as sa
 from alembic.config import Config
 from alembic.operations import Operations
@@ -55,6 +56,21 @@ def test_recurrence_cleanup_downgrade_uses_sqlite_safe_types():
         assert isinstance(session_columns["signature_id"]["type"], sa.String)
 
 
+def test_phase3h_tenant_oss_seed_downgrade_is_forward_only() -> None:
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "src/driftshield/db/migrations/versions/20260512_01_seed_tenant_oss.py"
+    )
+    spec = spec_from_file_location("migration_20260512_01", migration_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with pytest.raises(NotImplementedError, match="forward-only"):
+        module.downgrade()
+
+
 def test_phase3h_tenant_oss_seed_sql_is_idempotent_and_resolves_uuid() -> None:
     statements = build_phase3h_tenant_oss_seed_sql()
 
@@ -62,4 +78,5 @@ def test_phase3h_tenant_oss_seed_sql_is_idempotent_and_resolves_uuid() -> None:
     assert "insert into tenants" in statements[0]
     assert "'tenant-oss'" in statements[0]
     assert "on conflict (tenant_id) do nothing" in statements[0].lower()
+    assert "seed_revision" not in statements[0]
     assert statements[1].strip().lower() == "select id from tenants where tenant_id = 'tenant-oss'"


### PR DESCRIPTION
## Summary
- add a Phase 3h Alembic data revision that seeds the reviewed OSS fallback tenant row
- keep the seed idempotent with `ON CONFLICT (tenant_id) DO NOTHING`
- resolve the row UUID via a follow-up `SELECT id FROM tenants WHERE tenant_id = 'tenant-oss'`

## Why
D2 intake needs a server-side-only fallback tenant before the Intake Lambda can persist real OSS submissions.

## Verification
```bash
uv run --directory /home/node/.openclaw/workspace-engineering/driftshield/driftshield --extra dev pytest tests/db/test_migrations.py -q
```

## Notes
- this is the smaller seed-first PR ahead of the intake infra PR
- reviewed execute for this migration run still requires a manual `aws rds create-db-cluster-snapshot` recorded before approval
- pre-PR live schema evidence for D2 is recorded on `tborys/driftshield-infra#25`
