### PR TITLE
Seed OSS fallback installation and consent

### DIFF
--- a/driftshield/src/driftshield/db/hosted_schema_sql.py
+++ b/driftshield/src/driftshield/db/hosted_schema_sql.py
@@ -717,3 +717,56 @@ def build_phase3h_tenant_oss_seed_sql() -> tuple[str, str]:
         """,
         "select id from tenants where tenant_id = 'tenant-oss'",
     )
+
+
+def build_phase3h_oss_fallback_installation_seed_sql() -> tuple[str, str, str]:
+    return (
+        """
+        insert into installations (
+            id,
+            installation_id,
+            client_name,
+            platform,
+            metadata
+        )
+        values (
+            '00000000-0000-0000-0000-000000000551',
+            'oss-fallback-installation',
+            'OSS fallback installation',
+            'aws-lambda',
+            jsonb_build_object(
+                'seed_source', 'alembic',
+                'persona', 'oss-fallback'
+            )
+        )
+        on conflict (installation_id) do nothing
+        """,
+        """
+        insert into consent_records (
+            id,
+            installation_id,
+            consent_version,
+            consent_granted,
+            captured_at,
+            revoked_at
+        )
+        values (
+            '00000000-0000-0000-0000-000000000c51',
+            (select id from installations where installation_id = 'oss-fallback-installation'),
+            'phase3f-consent.v1',
+            true,
+            '2026-05-12T00:00:00+00:00'::timestamptz,
+            null
+        )
+        on conflict (id) do nothing
+        """,
+        """
+        select
+            installations.id as installation_row_id,
+            consent_records.id as consent_record_id
+        from installations
+        inner join consent_records on consent_records.installation_id = installations.id
+        where installations.installation_id = 'oss-fallback-installation'
+          and consent_records.id = '00000000-0000-0000-0000-000000000c51'
+        """,
+    )

--- a/driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py
@@ -1,0 +1,37 @@
+"""seed oss fallback installation
+
+Revision ID: 20260512_02
+Revises: 20260512_01
+Create Date: 2026-05-12 20:25:00.000000
+"""
+
+from collections.abc import Sequence
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+from driftshield.db.hosted_schema_sql import build_phase3h_oss_fallback_installation_seed_sql
+
+
+revision: str = "20260512_02"
+down_revision: str | None = "20260512_01"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+LOGGER = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    installation_insert_sql, consent_insert_sql, resolved_ids_sql = (
+        build_phase3h_oss_fallback_installation_seed_sql()
+    )
+    op.execute(installation_insert_sql)
+    op.execute(consent_insert_sql)
+    resolved_ids = op.get_bind().execute(sa.text(resolved_ids_sql)).mappings().one()
+    LOGGER.info("resolved oss fallback installation row uuid: %s", resolved_ids["installation_row_id"])
+    LOGGER.info("resolved oss fallback consent row uuid: %s", resolved_ids["consent_record_id"])
+
+
+def downgrade() -> None:
+    raise NotImplementedError("forward-only; restore from snapshot per #163 AC5")

--- a/driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py
@@ -21,6 +21,8 @@ depends_on: Sequence[str] | None = None
 
 LOGGER = logging.getLogger("alembic.runtime.migration")
 
+# Keep the hard-coded row UUIDs aligned with driftshield-infra fallback env wiring/test fixtures.
+
 
 def upgrade() -> None:
     installation_insert_sql, consent_insert_sql, resolved_ids_sql = (

--- a/driftshield/tests/db/test_migrations.py
+++ b/driftshield/tests/db/test_migrations.py
@@ -8,7 +8,10 @@ from alembic.operations import Operations
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
-from driftshield.db.hosted_schema_sql import build_phase3h_tenant_oss_seed_sql
+from driftshield.db.hosted_schema_sql import (
+    build_phase3h_oss_fallback_installation_seed_sql,
+    build_phase3h_tenant_oss_seed_sql,
+)
 
 
 def test_alembic_has_single_head():
@@ -80,3 +83,34 @@ def test_phase3h_tenant_oss_seed_sql_is_idempotent_and_resolves_uuid() -> None:
     assert "on conflict (tenant_id) do nothing" in statements[0].lower()
     assert "seed_revision" not in statements[0]
     assert statements[1].strip().lower() == "select id from tenants where tenant_id = 'tenant-oss'"
+
+
+def test_phase3h_oss_fallback_installation_seed_downgrade_is_forward_only() -> None:
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py"
+    )
+    spec = spec_from_file_location("migration_20260512_02", migration_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with pytest.raises(NotImplementedError, match="forward-only; restore from snapshot per #163 AC5"):
+        module.downgrade()
+
+
+def test_phase3h_oss_fallback_installation_seed_sql_is_idempotent_and_resolves_ids() -> None:
+    statements = build_phase3h_oss_fallback_installation_seed_sql()
+
+    assert len(statements) == 3
+    assert "insert into installations" in statements[0].lower()
+    assert "'oss-fallback-installation'" in statements[0]
+    assert "'00000000-0000-0000-0000-000000000551'" in statements[0]
+    assert "on conflict (installation_id) do nothing" in statements[0].lower()
+    assert "insert into consent_records" in statements[1].lower()
+    assert "'00000000-0000-0000-0000-000000000c51'" in statements[1]
+    assert "on conflict (id) do nothing" in statements[1].lower()
+    assert "select" in statements[2].lower()
+    assert "installation_row_id" in statements[2]
+    assert "consent_record_id" in statements[2]


### PR DESCRIPTION
## Summary
- add a forward-only Alembic data revision after `20260512_01`
- seed the OSS fallback installation and consent record idempotently
- log the resolved installation and consent UUIDs through `alembic.runtime.migration`

## Testing
- `./driftshield/.venv/bin/pytest driftshield/tests/db/test_migrations.py`
