### PR TITLE
feat: seed phase3h Teams A/B fixtures

### DIFF
--- a/driftshield/src/driftshield/db/hosted_schema_sql.py
+++ b/driftshield/src/driftshield/db/hosted_schema_sql.py
@@ -770,3 +770,287 @@ def build_phase3h_oss_fallback_installation_seed_sql() -> tuple[str, str, str]:
           and consent_records.id = '00000000-0000-0000-0000-000000000c51'
         """,
     )
+
+
+def build_phase3h_teams_ab_fixture_seed_sql() -> tuple[str, ...]:
+    return (
+        # Keep these row UUIDs aligned with the public Teams API fixture contract.
+        """
+        insert into tenants (
+            id,
+            tenant_id,
+            display_name,
+            tenancy_state,
+            home_region,
+            deployment_target,
+            metadata
+        )
+        values
+            (
+                '00000000-0000-0000-0000-000000000101',
+                'tenant-alpha',
+                'Teams Alpha tenant',
+                'active',
+                'eu-west-2',
+                'aurora-postgresql-serverless-v2',
+                jsonb_build_object('seed_source', 'alembic', 'persona', 'teams', 'fixture_key', 'tenant-alpha')
+            ),
+            (
+                '00000000-0000-0000-0000-000000000201',
+                'tenant-beta',
+                'Teams Beta tenant',
+                'active',
+                'eu-west-2',
+                'aurora-postgresql-serverless-v2',
+                jsonb_build_object('seed_source', 'alembic', 'persona', 'teams', 'fixture_key', 'tenant-beta')
+            )
+        on conflict (tenant_id) do nothing
+        """,
+        """
+        insert into workspaces (
+            id,
+            tenant_id,
+            workspace_id,
+            display_name,
+            project_reference,
+            metadata
+        )
+        values
+            (
+                '00000000-0000-0000-0000-000000000102',
+                '00000000-0000-0000-0000-000000000101',
+                'workspace-alpha',
+                'Teams Alpha workspace',
+                'project-gateway',
+                jsonb_build_object('seed_source', 'alembic', 'fixture_key', 'workspace-alpha')
+            ),
+            (
+                '00000000-0000-0000-0000-000000000202',
+                '00000000-0000-0000-0000-000000000201',
+                'workspace-beta',
+                'Teams Beta workspace',
+                'project-fulfilment',
+                jsonb_build_object('seed_source', 'alembic', 'fixture_key', 'workspace-beta')
+            )
+        on conflict (tenant_id, workspace_id) do nothing
+        """,
+        """
+        insert into service_identities (
+            id,
+            tenant_id,
+            workspace_id,
+            service_identity_id,
+            display_name,
+            auth_method,
+            secret_reference,
+            status,
+            metadata
+        )
+        values
+            (
+                '00000000-0000-0000-0000-000000000103',
+                '00000000-0000-0000-0000-000000000101',
+                '00000000-0000-0000-0000-000000000102',
+                'svc-alpha',
+                'Teams Alpha service identity',
+                'api_key',
+                'phase3h/teams/api-keys/tenant-alpha',
+                'active',
+                jsonb_build_object('seed_source', 'alembic', 'fixture_key', 'svc-alpha')
+            ),
+            (
+                '00000000-0000-0000-0000-000000000203',
+                '00000000-0000-0000-0000-000000000201',
+                '00000000-0000-0000-0000-000000000202',
+                'svc-beta',
+                'Teams Beta service identity',
+                'api_key',
+                'phase3h/teams/api-keys/tenant-beta',
+                'active',
+                jsonb_build_object('seed_source', 'alembic', 'fixture_key', 'svc-beta')
+            )
+        on conflict (tenant_id, service_identity_id) do nothing
+        """,
+        """
+        insert into entitlements (
+            id,
+            tenant_id,
+            workspace_id,
+            service_identity_id,
+            access_tier,
+            subject_scope,
+            capabilities,
+            metadata,
+            effective_from
+        )
+        values
+            (
+                '00000000-0000-0000-0000-000000000104',
+                '00000000-0000-0000-0000-000000000101',
+                '00000000-0000-0000-0000-000000000102',
+                '00000000-0000-0000-0000-000000000103',
+                'teams',
+                'workspace',
+                '["teams:read"]'::jsonb,
+                jsonb_build_object('seed_source', 'alembic'),
+                '2026-05-07T00:00:00+00:00'::timestamptz
+            ),
+            (
+                '00000000-0000-0000-0000-000000000204',
+                '00000000-0000-0000-0000-000000000201',
+                '00000000-0000-0000-0000-000000000202',
+                '00000000-0000-0000-0000-000000000203',
+                'teams',
+                'workspace',
+                '["teams:read"]'::jsonb,
+                jsonb_build_object('seed_source', 'alembic'),
+                '2026-05-07T00:00:00+00:00'::timestamptz
+            )
+        on conflict (id) do nothing
+        """,
+        """
+        insert into installations (
+            id,
+            installation_id,
+            client_name,
+            platform,
+            metadata
+        )
+        values
+            (
+                '00000000-0000-0000-0000-000000000151',
+                'teams-fixture-installation-alpha',
+                'Teams Alpha installation',
+                'aws-lambda',
+                jsonb_build_object('seed_source', 'alembic', 'tenant_id', 'tenant-alpha')
+            ),
+            (
+                '00000000-0000-0000-0000-000000000251',
+                'teams-fixture-installation-beta',
+                'Teams Beta installation',
+                'aws-lambda',
+                jsonb_build_object('seed_source', 'alembic', 'tenant_id', 'tenant-beta')
+            )
+        on conflict (installation_id) do nothing
+        """,
+        """
+        insert into consent_records (
+            id,
+            installation_id,
+            consent_version,
+            consent_granted,
+            consent_scope,
+            captured_at,
+            revoked_at
+        )
+        values
+            (
+                '00000000-0000-0000-0000-000000000161',
+                '00000000-0000-0000-0000-000000000151',
+                'phase3f-consent.v1',
+                true,
+                jsonb_build_object('persona', 'teams', 'tenant_id', 'tenant-alpha'),
+                '2026-05-07T19:55:00+00:00'::timestamptz,
+                null
+            ),
+            (
+                '00000000-0000-0000-0000-000000000261',
+                '00000000-0000-0000-0000-000000000251',
+                'phase3f-consent.v1',
+                true,
+                jsonb_build_object('persona', 'teams', 'tenant_id', 'tenant-beta'),
+                '2026-05-07T19:55:00+00:00'::timestamptz,
+                null
+            )
+        on conflict (id) do nothing
+        """,
+        """
+        insert into submissions (
+            id,
+            installation_id,
+            consent_record_id,
+            submission_id,
+            source_system,
+            source_session_id,
+            source_report_id,
+            envelope_contract_version,
+            envelope,
+            envelope_checksum,
+            state,
+            received_at,
+            processed_at,
+            tenant_id,
+            workspace_id,
+            service_identity_id,
+            workflow_reference,
+            project_reference,
+            evidence_artifact_prefix
+        )
+        values
+            ('00000000-0000-0000-0000-000000000111', '00000000-0000-0000-0000-000000000151', '00000000-0000-0000-0000-000000000161', 'sub-alpha-1', 'teams-e2e', 'teams-alpha-session', 'teams-alpha-report-1', 'phase3h-envelope.v1', jsonb_build_object('environment', 'prod'), 'sha256:sub-alpha-1', 'processed', '2026-05-07T20:00:00+00:00'::timestamptz, '2026-05-07T20:00:00+00:00'::timestamptz, '00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000103', 'workflow-build', 'project-gateway', 's3://driftshield-phase3h/teams/sub-alpha-1/'),
+            ('00000000-0000-0000-0000-000000000112', '00000000-0000-0000-0000-000000000151', '00000000-0000-0000-0000-000000000161', 'sub-alpha-2', 'teams-e2e', 'teams-alpha-session', 'teams-alpha-report-2', 'phase3h-envelope.v1', jsonb_build_object('environment', 'prod'), 'sha256:sub-alpha-2', 'processed', '2026-05-07T20:05:00+00:00'::timestamptz, '2026-05-07T20:05:00+00:00'::timestamptz, '00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000103', 'workflow-build', 'project-gateway', 's3://driftshield-phase3h/teams/sub-alpha-2/'),
+            ('00000000-0000-0000-0000-000000000113', '00000000-0000-0000-0000-000000000151', '00000000-0000-0000-0000-000000000161', 'sub-alpha-3', 'teams-e2e', 'teams-alpha-session', 'teams-alpha-report-3', 'phase3h-envelope.v1', jsonb_build_object('environment', 'staging'), 'sha256:sub-alpha-3', 'processed', '2026-05-07T20:10:00+00:00'::timestamptz, '2026-05-07T20:10:00+00:00'::timestamptz, '00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000103', 'workflow-review', 'project-gateway', 's3://driftshield-phase3h/teams/sub-alpha-3/'),
+            ('00000000-0000-0000-0000-000000000114', '00000000-0000-0000-0000-000000000151', '00000000-0000-0000-0000-000000000161', 'sub-alpha-4', 'teams-e2e', 'teams-alpha-session', 'teams-alpha-report-4', 'phase3h-envelope.v1', jsonb_build_object('environment', 'prod'), 'sha256:sub-alpha-4', 'processed', '2026-05-07T20:15:00+00:00'::timestamptz, '2026-05-07T20:15:00+00:00'::timestamptz, '00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000103', 'workflow-corrected', 'project-gateway', 's3://driftshield-phase3h/teams/sub-alpha-4/'),
+            ('00000000-0000-0000-0000-000000000211', '00000000-0000-0000-0000-000000000251', '00000000-0000-0000-0000-000000000261', 'sub-beta-1', 'teams-e2e', 'teams-beta-session', 'teams-beta-report-1', 'phase3h-envelope.v1', jsonb_build_object('environment', 'prod'), 'sha256:sub-beta-1', 'processed', '2026-05-07T20:03:00+00:00'::timestamptz, '2026-05-07T20:03:00+00:00'::timestamptz, '00000000-0000-0000-0000-000000000201', '00000000-0000-0000-0000-000000000202', '00000000-0000-0000-0000-000000000203', 'workflow-build', 'project-fulfilment', 's3://driftshield-phase3h/teams/sub-beta-1/')
+        on conflict (submission_id) do nothing
+        """,
+        """
+        insert into trust_evaluations (
+            id,
+            submission_id,
+            trust_band,
+            confidence_band,
+            final_learning_weight,
+            learning_eligible,
+            requires_review,
+            provenance,
+            evaluation_metadata,
+            created_at
+        )
+        values
+            ('00000000-0000-0000-0000-000000000121', '00000000-0000-0000-0000-000000000111', 'trusted', 'high', 1.0, true, false, jsonb_build_object('seed_source', 'alembic'), jsonb_build_object('fixture_key', 'sub-alpha-1'), '2026-05-07T20:00:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000122', '00000000-0000-0000-0000-000000000112', 'provisional', 'high', 0.5, true, false, jsonb_build_object('seed_source', 'alembic'), jsonb_build_object('fixture_key', 'sub-alpha-2'), '2026-05-07T20:05:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000123', '00000000-0000-0000-0000-000000000113', 'trusted', 'high', 1.0, true, false, jsonb_build_object('seed_source', 'alembic'), jsonb_build_object('fixture_key', 'sub-alpha-3'), '2026-05-07T20:10:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000124', '00000000-0000-0000-0000-000000000114', 'trusted', 'high', 1.0, true, false, jsonb_build_object('seed_source', 'alembic'), jsonb_build_object('fixture_key', 'sub-alpha-4'), '2026-05-07T20:15:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000125', '00000000-0000-0000-0000-000000000114', 'quarantined', 'high', 0.0, false, true, jsonb_build_object('seed_source', 'alembic'), jsonb_build_object('fixture_key', 'sub-alpha-4-corrected'), '2026-05-07T20:20:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000221', '00000000-0000-0000-0000-000000000211', 'trusted', 'high', 1.0, true, false, jsonb_build_object('seed_source', 'alembic'), jsonb_build_object('fixture_key', 'sub-beta-1'), '2026-05-07T20:03:00+00:00'::timestamptz)
+        on conflict (id) do nothing
+        """,
+        """
+        insert into signature_matches (
+            id,
+            submission_id,
+            signature_id,
+            signature_version,
+            match_status,
+            confidence,
+            mechanism_id,
+            evidence,
+            confidence_breakdown,
+            review_needed,
+            visibility_class,
+            recurrence_group_key,
+            created_at
+        )
+        values
+            ('00000000-0000-0000-0000-000000000131', '00000000-0000-0000-0000-000000000111', 'sig.retry-loop', 'v1', 'matched', 0.98, 'phase3h-seed', '{}'::jsonb, '{}'::jsonb, false, 'internal_only', 'grp:retry-loop', '2026-05-07T20:00:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000132', '00000000-0000-0000-0000-000000000112', 'sig.retry-loop', 'v1', 'matched', 0.91, 'phase3h-seed', '{}'::jsonb, '{}'::jsonb, false, 'internal_only', 'grp:retry-loop', '2026-05-07T20:05:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000133', '00000000-0000-0000-0000-000000000113', 'sig.timeout', 'v1', 'matched', 0.96, 'phase3h-seed', '{}'::jsonb, '{}'::jsonb, false, 'internal_only', 'grp:timeout', '2026-05-07T20:10:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000134', '00000000-0000-0000-0000-000000000114', 'sig.corrected', 'v1', 'matched', 0.95, 'phase3h-seed', '{}'::jsonb, '{}'::jsonb, false, 'internal_only', 'grp:corrected', '2026-05-07T20:15:00+00:00'::timestamptz),
+            ('00000000-0000-0000-0000-000000000231', '00000000-0000-0000-0000-000000000211', 'sig.retry-loop', 'v1', 'matched', 0.97, 'phase3h-seed', '{}'::jsonb, '{}'::jsonb, false, 'internal_only', 'grp:retry-loop', '2026-05-07T20:03:00+00:00'::timestamptz)
+        on conflict (id) do nothing
+        """,
+        """
+        select
+            (select id from tenants where tenant_id = 'tenant-alpha') as tenant_alpha_row_id,
+            (select id from workspaces where workspace_id = 'workspace-alpha' and tenant_id = '00000000-0000-0000-0000-000000000101'::uuid) as workspace_alpha_row_id,
+            (select id from service_identities where service_identity_id = 'svc-alpha' and tenant_id = '00000000-0000-0000-0000-000000000101'::uuid) as service_identity_alpha_row_id,
+            (select id from tenants where tenant_id = 'tenant-beta') as tenant_beta_row_id,
+            (select id from workspaces where workspace_id = 'workspace-beta' and tenant_id = '00000000-0000-0000-0000-000000000201'::uuid) as workspace_beta_row_id,
+            (select id from service_identities where service_identity_id = 'svc-beta' and tenant_id = '00000000-0000-0000-0000-000000000201'::uuid) as service_identity_beta_row_id,
+            (select count(*) from team_recurrence_summary where tenant_id = 'tenant-alpha') as tenant_alpha_recurrence_summary_rows,
+            (select count(*) from team_recurrence_summary where tenant_id = 'tenant-beta') as tenant_beta_recurrence_summary_rows,
+            (select count(*) from team_pattern_summary where tenant_id = 'tenant-alpha') as tenant_alpha_pattern_summary_rows,
+            (select count(*) from team_pattern_summary where tenant_id = 'tenant-beta') as tenant_beta_pattern_summary_rows
+        """,
+    )

--- a/driftshield/src/driftshield/db/migrations/versions/20260513_01_seed_teams_ab_fixtures.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260513_01_seed_teams_ab_fixtures.py
@@ -1,0 +1,37 @@
+"""seed teams alpha beta fixtures
+
+Revision ID: 20260513_01
+Revises: 20260512_02
+Create Date: 2026-05-13 12:20:00.000000
+"""
+
+from collections.abc import Sequence
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+from driftshield.db.hosted_schema_sql import build_phase3h_teams_ab_fixture_seed_sql
+
+
+revision: str = "20260513_01"
+down_revision: str | None = "20260512_02"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+LOGGER = logging.getLogger("alembic.runtime.migration")
+
+# Keep the hard-coded row UUIDs aligned with the public Teams API fixture contract.
+
+
+def upgrade() -> None:
+    *seed_sql, resolved_ids_sql = build_phase3h_teams_ab_fixture_seed_sql()
+    for statement in seed_sql:
+        op.execute(statement)
+    resolved_ids = op.get_bind().execute(sa.text(resolved_ids_sql)).mappings().one()
+    for key, value in resolved_ids.items():
+        LOGGER.info("resolved teams fixture %s: %s", key, value)
+
+
+def downgrade() -> None:
+    raise NotImplementedError("forward-only; restore from snapshot per #26 AC5")

--- a/driftshield/tests/db/test_migrations.py
+++ b/driftshield/tests/db/test_migrations.py
@@ -10,6 +10,7 @@ from alembic.script import ScriptDirectory
 
 from driftshield.db.hosted_schema_sql import (
     build_phase3h_oss_fallback_installation_seed_sql,
+    build_phase3h_teams_ab_fixture_seed_sql,
     build_phase3h_tenant_oss_seed_sql,
 )
 
@@ -114,3 +115,46 @@ def test_phase3h_oss_fallback_installation_seed_sql_is_idempotent_and_resolves_i
     assert "select" in statements[2].lower()
     assert "installation_row_id" in statements[2]
     assert "consent_record_id" in statements[2]
+
+
+def test_phase3h_teams_ab_fixture_seed_downgrade_is_forward_only() -> None:
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "src/driftshield/db/migrations/versions/20260513_01_seed_teams_ab_fixtures.py"
+    )
+    spec = spec_from_file_location("migration_20260513_01", migration_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with pytest.raises(NotImplementedError, match="forward-only; restore from snapshot per #26 AC5"):
+        module.downgrade()
+
+
+def test_phase3h_teams_ab_fixture_seed_sql_is_idempotent_and_resolves_summary_rows() -> None:
+    statements = build_phase3h_teams_ab_fixture_seed_sql()
+
+    assert len(statements) == 10
+    assert "insert into tenants" in statements[0].lower()
+    assert "'tenant-alpha'" in statements[0]
+    assert "'00000000-0000-0000-0000-000000000101'" in statements[0]
+    assert "'tenant-beta'" in statements[0]
+    assert "insert into workspaces" in statements[1].lower()
+    assert "'workspace-alpha'" in statements[1]
+    assert "'workspace-beta'" in statements[1]
+    assert "insert into service_identities" in statements[2].lower()
+    assert "'svc-alpha'" in statements[2]
+    assert "'svc-beta'" in statements[2]
+    assert "insert into entitlements" in statements[3].lower()
+    assert "[\"teams:read\"]'::jsonb" in statements[3]
+    assert "insert into submissions" in statements[6].lower()
+    assert "'sub-alpha-4'" in statements[6]
+    assert "'sub-beta-1'" in statements[6]
+    assert "insert into trust_evaluations" in statements[7].lower()
+    assert "'quarantined'" in statements[7]
+    assert "insert into signature_matches" in statements[8].lower()
+    assert "'grp:retry-loop'" in statements[8]
+    assert "select" in statements[9].lower()
+    assert "tenant_alpha_recurrence_summary_rows" in statements[9]
+    assert "tenant_beta_pattern_summary_rows" in statements[9]


### PR DESCRIPTION
## Summary
- add a forward-only Alembic seed migration for deterministic Teams Alpha/Beta tenant, workspace, service identity, entitlement, installation, consent, submission, trust, and signature rows
- keep the hard-coded UUIDs aligned with the deployed Teams authoriser context and driftshield-intel Phase 3h e2e fixtures
- extend migration tests to cover the new seed SQL contract and forward-only downgrade behaviour

## Pre-PR live read-back
- invoked the deployed Phase 3h migration Lambda in verify_phase3h_objects mode
- confirmed head revision 20260512_02
- confirmed tenants, workspaces, service_identities, entitlements, team_recurrence_summary, and team_pattern_summary exist
- confirmed submissions already exposes the Phase 3h tenant/workspace/service/workflow/project/evidence columns required by the seed FK path

## Testing
- uv run pytest tests -q
- uv run ruff check src tests
- uv run mypy src/
- uv run pytest tests/db/test_migrations.py -q
