### PR TITLE
feat: add verify_row_exists migration Lambda mode

### DIFF
--- a/driftshield/migrations/lambda_handler.py
+++ b/driftshield/migrations/lambda_handler.py
@@ -56,6 +56,10 @@ PHASE3H_REQUIRED_SUBMISSIONS_COLUMNS = (
     "workflow_reference",
     "workspace_id",
 )
+VERIFY_ROW_EXISTS_ALLOWED_TABLES = (
+    "installations",
+    "consent_records",
+)
 
 
 class MigrationRunnerError(RuntimeError):
@@ -221,6 +225,37 @@ def _verify_phase3h_objects(database_url: str) -> dict[str, Any]:
     }
 
 
+def _verify_row_exists(database_url: str, table: str, row_id: str) -> dict[str, Any]:
+    if table not in VERIFY_ROW_EXISTS_ALLOWED_TABLES:
+        return {
+            "status": "error",
+            "mode": "verify_row_exists",
+            "reason": f"unsupported table for row verification: {table}",
+            "table": table,
+            "row_id": row_id,
+        }
+
+    engine = create_engine(database_url, poolclass=None)
+    try:
+        with engine.connect() as connection:
+            exists = bool(
+                connection.execute(
+                    text(f"select exists(select 1 from {table} where id = cast(:row_id as uuid))"),
+                    {"row_id": row_id},
+                ).scalar()
+            )
+    finally:
+        engine.dispose()
+
+    return {
+        "status": "ok",
+        "mode": "verify_row_exists",
+        "exists": exists,
+        "table": table,
+        "row_id": row_id,
+    }
+
+
 def handler(event: Any, context: Any) -> dict[str, Any]:
     """Lambda entrypoint. Applies all pending migrations to the target DB."""
 
@@ -231,6 +266,24 @@ def handler(event: Any, context: Any) -> dict[str, Any]:
     except MigrationRunnerError as exc:
         logger.error("configuration error: %s", exc)
         raise
+
+    if isinstance(event, dict) and event.get("mode") == "verify_row_exists":
+        table = event.get("table")
+        row_id = event.get("row_id")
+        if not isinstance(table, str) or not isinstance(row_id, str):
+            return {
+                "status": "error",
+                "mode": "verify_row_exists",
+                "reason": "verify_row_exists requires string table and row_id fields",
+            }
+
+        try:
+            result = _verify_row_exists(database_url, table, row_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("row existence verification failed: %s", _redact(str(exc), database_url))
+            raise MigrationRunnerError("Could not verify Aurora row existence.") from exc
+        logger.info("row existence verification complete: %s", result)
+        return result
 
     if isinstance(event, dict) and event.get("mode") == "verify_phase3h_objects":
         try:

--- a/driftshield/tests/db/test_migration_runner.py
+++ b/driftshield/tests/db/test_migration_runner.py
@@ -66,10 +66,11 @@ def test_resolve_database_url_rejects_both_envs(monkeypatch, migration_runner_mo
         migration_runner_module._resolve_database_url()
 
 
-def test_verify_row_exists_returns_expected_payload(monkeypatch, migration_runner_module):
+@pytest.mark.parametrize("exists", [True, False])
+def test_verify_row_exists_returns_expected_payload(monkeypatch, migration_runner_module, exists):
     class FakeResult:
         def scalar(self):
-            return True
+            return exists
 
     class FakeConnection:
         def execute(self, statement, params):
@@ -101,7 +102,7 @@ def test_verify_row_exists_returns_expected_payload(monkeypatch, migration_runne
     assert result == {
         "status": "ok",
         "mode": "verify_row_exists",
-        "exists": True,
+        "exists": exists,
         "table": "installations",
         "row_id": "00000000-0000-0000-0000-000000000551",
     }
@@ -120,6 +121,22 @@ def test_verify_row_exists_rejects_unsupported_table(migration_runner_module):
         "reason": "unsupported table for row verification: bogus_table",
         "table": "bogus_table",
         "row_id": "00000000-0000-0000-0000-000000000000",
+    }
+
+
+def test_verify_row_exists_handler_rejects_missing_fields(monkeypatch, migration_runner_module):
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_resolve_database_url",
+        lambda: "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+    )
+
+    result = migration_runner_module.handler({"mode": "verify_row_exists"}, None)
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_row_exists",
+        "reason": "verify_row_exists requires string table and row_id fields",
     }
 
 

--- a/driftshield/tests/db/test_migration_runner.py
+++ b/driftshield/tests/db/test_migration_runner.py
@@ -66,6 +66,99 @@ def test_resolve_database_url_rejects_both_envs(monkeypatch, migration_runner_mo
         migration_runner_module._resolve_database_url()
 
 
+def test_verify_row_exists_returns_expected_payload(monkeypatch, migration_runner_module):
+    class FakeResult:
+        def scalar(self):
+            return True
+
+    class FakeConnection:
+        def execute(self, statement, params):
+            assert "from installations" in str(statement)
+            assert params == {"row_id": "00000000-0000-0000-0000-000000000551"}
+            return FakeResult()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeEngine:
+        def connect(self):
+            return FakeConnection()
+
+        def dispose(self):
+            return None
+
+    monkeypatch.setattr(migration_runner_module, "create_engine", lambda *args, **kwargs: FakeEngine())
+
+    result = migration_runner_module._verify_row_exists(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "installations",
+        "00000000-0000-0000-0000-000000000551",
+    )
+
+    assert result == {
+        "status": "ok",
+        "mode": "verify_row_exists",
+        "exists": True,
+        "table": "installations",
+        "row_id": "00000000-0000-0000-0000-000000000551",
+    }
+
+
+def test_verify_row_exists_rejects_unsupported_table(migration_runner_module):
+    result = migration_runner_module._verify_row_exists(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "bogus_table",
+        "00000000-0000-0000-0000-000000000000",
+    )
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_row_exists",
+        "reason": "unsupported table for row verification: bogus_table",
+        "table": "bogus_table",
+        "row_id": "00000000-0000-0000-0000-000000000000",
+    }
+
+
+def test_verify_row_exists_handler_mode_bypasses_upgrade(monkeypatch, migration_runner_module):
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_resolve_database_url",
+        lambda: "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+    )
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_verify_row_exists",
+        lambda database_url, table, row_id: {
+            "status": "ok",
+            "mode": "verify_row_exists",
+            "exists": False,
+            "table": table,
+            "row_id": row_id,
+        },
+    )
+
+    result = migration_runner_module.handler(
+        {
+            "mode": "verify_row_exists",
+            "table": "installations",
+            "row_id": "00000000-0000-0000-0000-000000000551",
+        },
+        None,
+    )
+
+    assert result == {
+        "status": "ok",
+        "mode": "verify_row_exists",
+        "exists": False,
+        "table": "installations",
+        "row_id": "00000000-0000-0000-0000-000000000551",
+    }
+
+
 def test_verify_phase3h_handler_mode_bypasses_upgrade(monkeypatch, migration_runner_module):
     monkeypatch.setattr(
         migration_runner_module,


### PR DESCRIPTION
## Summary
- add a VPC-resident `verify_row_exists` mode to the Phase 3h migration Lambda
- keep the row-check surface hard-limited to `installations` and `consent_records`, with explicit error payloads for unsupported tables
- cover the new mode and handler dispatch path in `test_migration_runner.py`

## Testing
- `uv run pytest tests/db/test_migration_runner.py -q`
- `uv run python -m compileall migrations/lambda_handler.py`

## Rollout plan
1. Merge this PR.
2. Rebuild and push a new `driftshield-phase3h-migrations` image.
3. Update the live Lambda image:
   ```bash
   aws lambda update-function-code \
     --function-name DriftShieldPhase3hMigrati-Phase3hMigrationLambda4F-YUkjsl92hKJe \
     --image-uri 036230294331.dkr.ecr.eu-west-2.amazonaws.com/driftshield-phase3h-migrations:<new-tag-or-digest> \
     --profile driftshield-tede --region eu-west-2
   ```
4. Verify the live Lambda responses before switching the helper PR:
   ```bash
   aws lambda invoke --function-name DriftShieldPhase3hMigrati-Phase3hMigrationLambda4F-YUkjsl92hKJe \
     --payload '{"mode":"verify_row_exists","table":"installations","row_id":"00000000-0000-0000-0000-000000000551"}' \
     --cli-binary-format raw-in-base64-out /tmp/verify-known-good.json
   cat /tmp/verify-known-good.json

   aws lambda invoke --function-name DriftShieldPhase3hMigrati-Phase3hMigrationLambda4F-YUkjsl92hKJe \
     --payload '{"mode":"verify_row_exists","table":"bogus_table","row_id":"00000000-0000-0000-0000-000000000000"}' \
     --cli-binary-format raw-in-base64-out /tmp/verify-bogus.json
   cat /tmp/verify-bogus.json
   ```
5. Only after both responses match the contracted shape should the `driftshield-infra` helper-switch PR proceed.

## Manual gate
- I confirmed `driftshield-tede` can read the live function with `aws lambda get-function`.
- I have **not** confirmed `lambda:UpdateFunctionCode` permission non-destructively from this runner, so the image update remains a manual live gate at rollout time.

## Links
- Refs tborys/driftshield-infra#42
