### PR TITLE
fix: add submissions worker column migration

### DIFF
--- a/driftshield/migrations/lambda_handler.py
+++ b/driftshield/migrations/lambda_handler.py
@@ -49,6 +49,8 @@ PHASE3H_REQUIRED_OBJECTS = (
     "workspaces",
 )
 PHASE3H_REQUIRED_SUBMISSIONS_COLUMNS = (
+    "attempt_count",
+    "claimed_by",
     "evidence_artifact_prefix",
     "project_reference",
     "service_identity_id",
@@ -59,6 +61,9 @@ PHASE3H_REQUIRED_SUBMISSIONS_COLUMNS = (
 VERIFY_ROW_EXISTS_ALLOWED_TABLES = (
     "installations",
     "consent_records",
+)
+VERIFY_TABLE_COLUMNS_ALLOWED_TABLES = (
+    "submissions",
 )
 
 
@@ -88,7 +93,7 @@ def _resolve_database_url() -> str:
 
 def _build_url_from_secret(secret_arn: str) -> str:
     try:
-        import boto3
+        import boto3  # type: ignore[import-not-found]
     except ImportError as exc:
         raise MigrationRunnerError(
             "DB_SECRET_ARN is set but boto3 is not installed. "
@@ -256,6 +261,54 @@ def _verify_row_exists(database_url: str, table: str, row_id: str) -> dict[str, 
     }
 
 
+def _verify_table_columns(
+    database_url: str,
+    table: str,
+    columns: tuple[str, ...],
+) -> dict[str, Any]:
+    if table not in VERIFY_TABLE_COLUMNS_ALLOWED_TABLES:
+        return {
+            "status": "error",
+            "mode": "verify_table_columns",
+            "reason": f"unsupported table for column verification: {table}",
+            "table": table,
+            "columns": list(columns),
+        }
+
+    engine = create_engine(database_url, poolclass=None)
+    try:
+        with engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    """
+                    select column_name, data_type
+                    from information_schema.columns
+                    where table_schema = 'public'
+                      and table_name = :table
+                      and column_name in :columns
+                    order by column_name
+                    """
+                ).bindparams(bindparam("columns", expanding=True)),
+                {"table": table, "columns": columns},
+            ).all()
+    finally:
+        engine.dispose()
+
+    found_columns = {row.column_name for row in rows}
+    return {
+        "status": "ok",
+        "mode": "verify_table_columns",
+        "table": table,
+        "columns": [
+            {"name": row.column_name, "type": row.data_type}
+            for row in rows
+        ],
+        "missing_columns": [
+            column_name for column_name in columns if column_name not in found_columns
+        ],
+    }
+
+
 def handler(event: Any, context: Any) -> dict[str, Any]:
     """Lambda entrypoint. Applies all pending migrations to the target DB."""
 
@@ -292,6 +345,29 @@ def handler(event: Any, context: Any) -> dict[str, Any]:
             logger.error("phase 3h object verification failed: %s", _redact(str(exc), database_url))
             raise MigrationRunnerError("Could not verify Phase 3h Aurora objects.") from exc
         logger.info("phase 3h object verification complete: %s", result)
+        return result
+
+    if isinstance(event, dict) and event.get("mode") == "verify_table_columns":
+        table = event.get("table")
+        columns = event.get("columns")
+        if (
+            not isinstance(table, str)
+            or not isinstance(columns, list)
+            or not columns
+            or any(not isinstance(column_name, str) for column_name in columns)
+        ):
+            return {
+                "status": "error",
+                "mode": "verify_table_columns",
+                "reason": "verify_table_columns requires string table and non-empty string columns fields",
+            }
+
+        try:
+            result = _verify_table_columns(database_url, table, tuple(columns))
+        except Exception as exc:  # noqa: BLE001
+            logger.error("table column verification failed: %s", _redact(str(exc), database_url))
+            raise MigrationRunnerError("Could not verify Aurora table columns.") from exc
+        logger.info("table column verification complete: %s", result)
         return result
 
     alembic_config = _build_alembic_config(database_url)

--- a/driftshield/src/driftshield/db/hosted_schema_sql.py
+++ b/driftshield/src/driftshield/db/hosted_schema_sql.py
@@ -60,11 +60,13 @@ def build_hosted_base_sql() -> tuple[str, ...]:
             envelope_checksum text not null,
             state submission_state not null default 'received',
             duplicate_of_submission_id uuid references submissions(id) on delete set null,
+            attempt_count integer not null default 0,
             received_at timestamptz not null default timezone('utc', now()),
             processing_started_at timestamptz,
             processed_at timestamptz,
             quarantined_at timestamptz,
             failed_at timestamptz,
+            claimed_by text,
             last_error_code text,
             last_error_detail text,
             created_at timestamptz not null default timezone('utc', now()),
@@ -235,6 +237,8 @@ def build_phase3h_teams_sql() -> tuple[str, ...]:
         "alter table submissions add column if not exists workflow_reference text",
         "alter table submissions add column if not exists project_reference text",
         "alter table submissions add column if not exists evidence_artifact_prefix text",
+        "alter table submissions add column if not exists attempt_count integer not null default 0",
+        "alter table submissions add column if not exists claimed_by text",
         "create index if not exists ix_submissions_tenant_workspace_received_at on submissions (tenant_id, workspace_id, received_at)",
         """
         create table if not exists team_api_access_audit (

--- a/driftshield/src/driftshield/db/migrations/versions/20260514_01_add_submissions_worker_columns.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260514_01_add_submissions_worker_columns.py
@@ -1,0 +1,35 @@
+"""add submissions worker columns
+
+Revision ID: 20260514_01
+Revises: 20260513_01
+Create Date: 2026-05-14 06:50:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260514_01"
+down_revision: str | None = "20260513_01"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "submissions",
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "submissions",
+        sa.Column("claimed_by", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("submissions", "claimed_by")
+    op.drop_column("submissions", "attempt_count")

--- a/driftshield/tests/db/test_hosted_schema_sql.py
+++ b/driftshield/tests/db/test_hosted_schema_sql.py
@@ -55,6 +55,8 @@ def test_phase3h_teams_sql_covers_identity_tables_and_submission_scope_columns()
     assert "workflow_reference text" in sql
     assert "project_reference text" in sql
     assert "evidence_artifact_prefix text" in sql
+    assert "attempt_count integer not null default 0" in sql
+    assert "claimed_by text" in sql
     assert "ix_submissions_tenant_workspace_received_at" in sql
     assert "tenant_public_id text" in sql
     assert "service_identity_public_id text" in sql

--- a/driftshield/tests/db/test_migration_runner.py
+++ b/driftshield/tests/db/test_migration_runner.py
@@ -203,3 +203,121 @@ def test_verify_phase3h_handler_mode_bypasses_upgrade(monkeypatch, migration_run
     assert result["head_revision"] == "20260511_03"
     assert result["missing_objects"] == []
     assert result["missing_submission_columns"] == []
+
+
+def test_verify_table_columns_returns_expected_payload(monkeypatch, migration_runner_module):
+    class FakeResult:
+        def all(self):
+            return [
+                SimpleNamespace(column_name="attempt_count", data_type="integer"),
+                SimpleNamespace(column_name="claimed_by", data_type="text"),
+            ]
+
+    class FakeConnection:
+        def execute(self, statement, params):
+            assert "information_schema.columns" in str(statement)
+            assert params == {
+                "table": "submissions",
+                "columns": ("attempt_count", "claimed_by"),
+            }
+            return FakeResult()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeEngine:
+        def connect(self):
+            return FakeConnection()
+
+        def dispose(self):
+            return None
+
+    monkeypatch.setattr(migration_runner_module, "create_engine", lambda *args, **kwargs: FakeEngine())
+
+    result = migration_runner_module._verify_table_columns(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "submissions",
+        ("attempt_count", "claimed_by"),
+    )
+
+    assert result == {
+        "status": "ok",
+        "mode": "verify_table_columns",
+        "table": "submissions",
+        "columns": [
+            {"name": "attempt_count", "type": "integer"},
+            {"name": "claimed_by", "type": "text"},
+        ],
+        "missing_columns": [],
+    }
+
+
+def test_verify_table_columns_rejects_unsupported_table(migration_runner_module):
+    result = migration_runner_module._verify_table_columns(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "bogus_table",
+        ("attempt_count",),
+    )
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_table_columns",
+        "reason": "unsupported table for column verification: bogus_table",
+        "table": "bogus_table",
+        "columns": ["attempt_count"],
+    }
+
+
+def test_verify_table_columns_handler_rejects_missing_fields(monkeypatch, migration_runner_module):
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_resolve_database_url",
+        lambda: "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+    )
+
+    result = migration_runner_module.handler({"mode": "verify_table_columns", "table": "submissions"}, None)
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_table_columns",
+        "reason": "verify_table_columns requires string table and non-empty string columns fields",
+    }
+
+
+def test_verify_table_columns_handler_mode_bypasses_upgrade(monkeypatch, migration_runner_module):
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_resolve_database_url",
+        lambda: "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+    )
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_verify_table_columns",
+        lambda database_url, table, columns: {
+            "status": "ok",
+            "mode": "verify_table_columns",
+            "table": table,
+            "columns": [{"name": "attempt_count", "type": "integer"}],
+            "missing_columns": [column_name for column_name in columns if column_name != "attempt_count"],
+        },
+    )
+
+    result = migration_runner_module.handler(
+        {
+            "mode": "verify_table_columns",
+            "table": "submissions",
+            "columns": ["attempt_count", "claimed_by"],
+        },
+        None,
+    )
+
+    assert result == {
+        "status": "ok",
+        "mode": "verify_table_columns",
+        "table": "submissions",
+        "columns": [{"name": "attempt_count", "type": "integer"}],
+        "missing_columns": ["claimed_by"],
+    }

--- a/driftshield/tests/db/test_migrations.py
+++ b/driftshield/tests/db/test_migrations.py
@@ -158,3 +158,48 @@ def test_phase3h_teams_ab_fixture_seed_sql_is_idempotent_and_resolves_summary_ro
     assert "select" in statements[9].lower()
     assert "tenant_alpha_recurrence_summary_rows" in statements[9]
     assert "tenant_beta_pattern_summary_rows" in statements[9]
+
+
+def test_submission_worker_columns_revision_applies_and_rolls_back_cleanly() -> None:
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "src/driftshield/db/migrations/versions/20260514_01_add_submissions_worker_columns.py"
+    )
+    spec = spec_from_file_location("migration_20260514_01", migration_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    sa.Table(
+        "submissions",
+        metadata,
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("submission_id", sa.String(length=64), nullable=False),
+    )
+
+    with engine.begin() as connection:
+        metadata.create_all(connection)
+
+        context = MigrationContext.configure(connection)
+        with Operations.context(context):
+            module.upgrade()
+
+        inspector = sa.inspect(connection)
+        columns_after_upgrade = {
+            column["name"]: column for column in inspector.get_columns("submissions")
+        }
+        assert "attempt_count" in columns_after_upgrade
+        assert "claimed_by" in columns_after_upgrade
+
+        context = MigrationContext.configure(connection)
+        with Operations.context(context):
+            module.downgrade()
+
+        columns_after_downgrade = {
+            column["name"]: column for column in sa.inspect(connection).get_columns("submissions")
+        }
+        assert "attempt_count" not in columns_after_downgrade
+        assert "claimed_by" not in columns_after_downgrade


### PR DESCRIPTION
## Summary
- add the live Alembic revision for `submissions.attempt_count` and `submissions.claimed_by`
- teach the migration Lambda verifier to check those worker columns and add a direct table-column probe mode for the later Aurora cross-check
- keep the hosted schema helper and db tests aligned with the new worker-column surface

## Verification
```
uv run pytest tests/db -q
./scripts/check-public-scope.sh
```

Refs tborys/driftshield-infra#29
