### PR TITLE
feat: add verify_query mode on migration Lambda

### DIFF
--- a/driftshield/migrations/lambda_handler.py
+++ b/driftshield/migrations/lambda_handler.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+from datetime import date, datetime, time
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 from alembic import command
 from alembic.config import Config
@@ -65,6 +68,24 @@ VERIFY_ROW_EXISTS_ALLOWED_TABLES = (
 VERIFY_TABLE_COLUMNS_ALLOWED_TABLES = (
     "submissions",
 )
+VERIFY_QUERY_ALLOWED_TABLES = (
+    "signature_matches",
+    "trust_evaluations",
+    "recurrence_observations",
+    "submissions",
+)
+VERIFY_QUERY_FORBIDDEN_TOKENS = (
+    "insert",
+    "update",
+    "delete",
+    "alter",
+    "drop",
+    "truncate",
+    "create",
+    "grant",
+    "revoke",
+)
+VERIFY_QUERY_MAX_LIMIT = 50
 
 
 class MigrationRunnerError(RuntimeError):
@@ -309,6 +330,82 @@ def _verify_table_columns(
     }
 
 
+def _verify_query(database_url: str, table: str, where: str, limit: int) -> dict[str, Any]:
+    if table not in VERIFY_QUERY_ALLOWED_TABLES:
+        return {
+            "status": "error",
+            "mode": "verify_query",
+            "reason": f"unsupported table for query verification: {table}",
+            "table": table,
+        }
+
+    if limit < 1 or limit > VERIFY_QUERY_MAX_LIMIT:
+        return {
+            "status": "error",
+            "mode": "verify_query",
+            "reason": f"verify_query limit must be between 1 and {VERIFY_QUERY_MAX_LIMIT}",
+            "table": table,
+            "limit": limit,
+        }
+
+    if not where.strip():
+        return {
+            "status": "error",
+            "mode": "verify_query",
+            "reason": "verify_query requires a non-empty where clause",
+            "table": table,
+        }
+
+    lowered_where = where.casefold()
+    if any(token in lowered_where for token in VERIFY_QUERY_FORBIDDEN_TOKENS) or ";" in where:
+        return {
+            "status": "error",
+            "mode": "verify_query",
+            "reason": "verify_query accepts read-only SELECT filters only",
+            "table": table,
+        }
+
+    sql = f"select * from {table} where {where} limit :limit"
+    if not sql.lstrip().casefold().startswith("select "):
+        return {
+            "status": "error",
+            "mode": "verify_query",
+            "reason": "verify_query accepts read-only SELECT filters only",
+            "table": table,
+        }
+
+    engine = create_engine(database_url, poolclass=None)
+    try:
+        with engine.connect() as connection:
+            rows = connection.execute(
+                text(sql).bindparams(bindparam("limit")),
+                {"limit": limit},
+            ).mappings().all()
+    finally:
+        engine.dispose()
+
+    serialised_rows = [_json_safe(dict(row)) for row in rows]
+    return {
+        "status": "ok",
+        "mode": "verify_query",
+        "table": table,
+        "rows": serialised_rows,
+        "count": len(serialised_rows),
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, (UUID, Decimal)):
+        return str(value)
+    return value
+
+
 def handler(event: Any, context: Any) -> dict[str, Any]:
     """Lambda entrypoint. Applies all pending migrations to the target DB."""
 
@@ -368,6 +465,25 @@ def handler(event: Any, context: Any) -> dict[str, Any]:
             logger.error("table column verification failed: %s", _redact(str(exc), database_url))
             raise MigrationRunnerError("Could not verify Aurora table columns.") from exc
         logger.info("table column verification complete: %s", result)
+        return result
+
+    if isinstance(event, dict) and event.get("mode") == "verify_query":
+        table = event.get("table")
+        where = event.get("where")
+        limit = event.get("limit")
+        if not isinstance(table, str) or not isinstance(where, str) or not isinstance(limit, int):
+            return {
+                "status": "error",
+                "mode": "verify_query",
+                "reason": "verify_query requires string table, string where, and integer limit fields",
+            }
+
+        try:
+            result = _verify_query(database_url, table, where, limit)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("query verification failed: %s", _redact(str(exc), database_url))
+            raise MigrationRunnerError("Could not verify Aurora query output.") from exc
+        logger.info("query verification complete: %s", result)
         return result
 
     alembic_config = _build_alembic_config(database_url)

--- a/driftshield/tests/db/test_migration_runner.py
+++ b/driftshield/tests/db/test_migration_runner.py
@@ -1,6 +1,8 @@
+from datetime import UTC, datetime
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import SimpleNamespace
+from uuid import UUID
 
 import pytest
 from sqlalchemy.engine import make_url
@@ -320,4 +322,111 @@ def test_verify_table_columns_handler_mode_bypasses_upgrade(monkeypatch, migrati
         "table": "submissions",
         "columns": [{"name": "attempt_count", "type": "integer"}],
         "missing_columns": ["claimed_by"],
+    }
+
+
+def test_verify_query_returns_expected_payload(monkeypatch, migration_runner_module):
+    class FakeResult:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [
+                {
+                    "id": UUID("11111111-1111-1111-1111-111111111111"),
+                    "submission_id": "sub_demo",
+                    "received_at": datetime(2026, 5, 14, 10, 0, tzinfo=UTC),
+                    "envelope": {"summary": "safe"},
+                }
+            ]
+
+    class FakeConnection:
+        def execute(self, statement, params):
+            assert "select * from submissions where submission_id = 'sub_demo' limit :limit" in str(statement)
+            assert params == {"limit": 5}
+            return FakeResult()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeEngine:
+        def connect(self):
+            return FakeConnection()
+
+        def dispose(self):
+            return None
+
+    monkeypatch.setattr(migration_runner_module, "create_engine", lambda *args, **kwargs: FakeEngine())
+
+    result = migration_runner_module._verify_query(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "submissions",
+        "submission_id = 'sub_demo'",
+        5,
+    )
+
+    assert result == {
+        "status": "ok",
+        "mode": "verify_query",
+        "table": "submissions",
+        "rows": [
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "submission_id": "sub_demo",
+                "received_at": "2026-05-14T10:00:00+00:00",
+                "envelope": {"summary": "safe"},
+            }
+        ],
+        "count": 1,
+    }
+
+
+def test_verify_query_rejects_unsupported_table(migration_runner_module):
+    result = migration_runner_module._verify_query(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "bogus_table",
+        "1 = 1",
+        1,
+    )
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_query",
+        "reason": "unsupported table for query verification: bogus_table",
+        "table": "bogus_table",
+    }
+
+
+def test_verify_query_rejects_non_select_fragments(migration_runner_module):
+    result = migration_runner_module._verify_query(
+        "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+        "submissions",
+        "1 = 1; delete from submissions",
+        1,
+    )
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_query",
+        "reason": "verify_query accepts read-only SELECT filters only",
+        "table": "submissions",
+    }
+
+
+def test_verify_query_handler_rejects_missing_fields(monkeypatch, migration_runner_module):
+    monkeypatch.setattr(
+        migration_runner_module,
+        "_resolve_database_url",
+        lambda: "postgresql+psycopg2://runner:secret@db.example.internal:5432/driftshield",
+    )
+
+    result = migration_runner_module.handler({"mode": "verify_query", "table": "submissions"}, None)
+
+    assert result == {
+        "status": "error",
+        "mode": "verify_query",
+        "reason": "verify_query requires string table, string where, and integer limit fields",
     }


### PR DESCRIPTION
## Summary
- add read-only `verify_query` mode to the migration Lambda with a hard table allow-list and defensive write-keyword rejection
- return JSON-safe row payloads for operator smoke checks
- cover happy path plus rejection cases in migration runner tests

## Testing
- `uv run pytest tests/db -q`
- `scripts/check-public-scope.sh`

Refs tborys/driftshield-meta#171
