### PR TITLE
feat(telemetry): D7 OSS remote intake config (no network send)

### DIFF
--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -25,6 +25,9 @@ def telemetry_status(
         "registered_at": config.registered_at,
         "last_heartbeat_at": config.last_heartbeat_at,
         "event_stream_path": config.event_stream_path,
+        "remote_enabled": config.remote_intake_url is not None and config.remote_api_key is not None,
+        "remote_intake_url": config.remote_intake_url,
+        "remote_api_key_configured": config.remote_api_key is not None,
     }
     if json_output:
         typer.echo(json.dumps(payload))
@@ -49,6 +52,30 @@ def telemetry_disable() -> None:
     console.print(
         f"Telemetry disabled. Existing install id remains {config.install_id or 'unset'}."
     )
+
+
+@app.command("remote-enable")
+def telemetry_remote_enable(
+    intake_url: str = typer.Option(..., "--intake-url", help="Intake API URL the OSS submission envelope will POST to."),
+    api_key: str = typer.Option(..., "--api-key", help="API key for the configured intake URL."),
+) -> None:
+    """Persist remote intake configuration for OSS submission. Does not send anything."""
+    try:
+        config = TelemetryService().remote_enable(intake_url=intake_url, api_key=api_key)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    console.print(
+        f"Remote submission configured. Intake URL: {config.remote_intake_url}. "
+        "API key stored locally; not displayed."
+    )
+
+
+@app.command("remote-disable")
+def telemetry_remote_disable() -> None:
+    """Clear remote intake configuration. Local telemetry capture is unaffected."""
+    TelemetryService().remote_disable()
+    console.print("Remote submission configuration cleared.")
 
 
 @app.command("heartbeat")

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -21,6 +21,8 @@ class TelemetryConfig:
     registered_at: str | None = None
     last_heartbeat_at: str | None = None
     event_stream_path: str | None = None
+    remote_intake_url: str | None = None
+    remote_api_key: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +53,8 @@ class TelemetryService:
             last_heartbeat_at=_optional_string(data.get("last_heartbeat_at")),
             event_stream_path=_optional_string(data.get("event_stream_path"))
             or str(self._default_stream_path),
+            remote_intake_url=_optional_string(data.get("remote_intake_url")),
+            remote_api_key=_optional_string(data.get("remote_api_key")),
         )
 
     def enable(self) -> TelemetryConfig:
@@ -88,6 +92,30 @@ class TelemetryService:
     def disable(self) -> TelemetryConfig:
         config = self.load_config()
         config.enabled = False
+        if not config.event_stream_path:
+            config.event_stream_path = str(self._default_stream_path)
+        self._save_config(config)
+        return config
+
+    def remote_enable(self, *, intake_url: str, api_key: str) -> TelemetryConfig:
+        intake_url_clean = intake_url.strip()
+        api_key_clean = api_key.strip()
+        if not intake_url_clean:
+            raise ValueError("intake_url must not be empty")
+        if not api_key_clean:
+            raise ValueError("api_key must not be empty")
+        config = self.load_config()
+        config.remote_intake_url = intake_url_clean
+        config.remote_api_key = api_key_clean
+        if not config.event_stream_path:
+            config.event_stream_path = str(self._default_stream_path)
+        self._save_config(config)
+        return config
+
+    def remote_disable(self) -> TelemetryConfig:
+        config = self.load_config()
+        config.remote_intake_url = None
+        config.remote_api_key = None
         if not config.event_stream_path:
             config.event_stream_path = str(self._default_stream_path)
         self._save_config(config)

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -134,3 +134,165 @@ def test_emit_analysis_normalizes_outcome_status_before_classifiable_check(tmp_p
     analysis_event = TelemetryService().read_events()[-1]
     assert analysis_event["payload"]["outcome_status"] == "matched"
     assert analysis_event["payload"]["classifiable"] is True
+
+
+_OSS_TEST_INTAKE_URL = "https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/intake"
+_OSS_TEST_API_KEY = "test-d7-api-key-not-real"
+
+
+def test_status_default_shows_remote_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    status = runner.invoke(app, ["telemetry", "status", "--json"])
+
+    assert status.exit_code == 0
+    payload = json.loads(status.stdout)
+    assert payload["remote_enabled"] is False
+    assert payload["remote_intake_url"] is None
+    assert payload["remote_api_key_configured"] is False
+
+
+def test_remote_enable_persists_config_and_redacts_key_in_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    enabled = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            _OSS_TEST_API_KEY,
+        ],
+    )
+    assert enabled.exit_code == 0
+    assert _OSS_TEST_API_KEY not in enabled.stdout
+
+    config = TelemetryService().load_config()
+    assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
+    assert config.remote_api_key == _OSS_TEST_API_KEY
+
+    status = runner.invoke(app, ["telemetry", "status", "--json"])
+    assert status.exit_code == 0
+    payload = json.loads(status.stdout)
+    assert payload["remote_enabled"] is True
+    assert payload["remote_intake_url"] == _OSS_TEST_INTAKE_URL
+    assert payload["remote_api_key_configured"] is True
+    assert "remote_api_key" not in payload
+    assert _OSS_TEST_API_KEY not in status.stdout
+
+
+def test_remote_disable_clears_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            _OSS_TEST_API_KEY,
+        ],
+    )
+
+    disabled = runner.invoke(app, ["telemetry", "remote-disable"])
+    assert disabled.exit_code == 0
+
+    config = TelemetryService().load_config()
+    assert config.remote_intake_url is None
+    assert config.remote_api_key is None
+
+
+def test_remote_enable_rejects_empty_inputs(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    blank_url = runner.invoke(
+        app,
+        ["telemetry", "remote-enable", "--intake-url", "   ", "--api-key", _OSS_TEST_API_KEY],
+    )
+    assert blank_url.exit_code == 1
+    assert "intake_url" in blank_url.stdout
+
+    blank_key = runner.invoke(
+        app,
+        ["telemetry", "remote-enable", "--intake-url", _OSS_TEST_INTAKE_URL, "--api-key", "   "],
+    )
+    assert blank_key.exit_code == 1
+    assert "api_key" in blank_key.stdout
+
+    config = TelemetryService().load_config()
+    assert config.remote_intake_url is None
+    assert config.remote_api_key is None
+
+
+def test_local_capture_unchanged_when_remote_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    runner.invoke(app, ["telemetry", "enable"])
+    runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            _OSS_TEST_API_KEY,
+        ],
+    )
+    heartbeat = runner.invoke(app, ["telemetry", "heartbeat"])
+    assert heartbeat.exit_code == 0
+
+    events = TelemetryService().read_events()
+    assert [event["event_type"] for event in events] == ["registration", "heartbeat"]
+
+    config = TelemetryService().load_config()
+    assert config.enabled is True
+    assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
+
+
+def test_remote_enable_does_not_toggle_local_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            _OSS_TEST_API_KEY,
+        ],
+    )
+    config = TelemetryService().load_config()
+    assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
+    assert config.enabled is False
+    assert config.install_id is None
+
+
+def test_remote_disable_does_not_clear_local_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    runner.invoke(app, ["telemetry", "enable"])
+    runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            _OSS_TEST_API_KEY,
+        ],
+    )
+
+    install_id_before = TelemetryService().load_config().install_id
+    runner.invoke(app, ["telemetry", "remote-disable"])
+
+    config = TelemetryService().load_config()
+    assert config.enabled is True
+    assert config.install_id == install_id_before
+    assert config.remote_intake_url is None


### PR DESCRIPTION
## Summary

- Add `driftshield telemetry remote-enable --intake-url <url> --api-key <key>` and `driftshield telemetry remote-disable` to persist the OSS submission intake target. No network send happens in D7 — D8 reads this config to build and POST the `phase3f.v1` envelope.
- Extend `driftshield telemetry status` to show `remote_enabled`, `remote_intake_url`, and `remote_api_key_configured`. The API key value is never returned via the CLI surface.
- Extend `TelemetryConfig` with `remote_intake_url` and `remote_api_key` fields. Existing local capture (`enable` / `disable` / `heartbeat` / `emit-analysis`) is on a separate axis and unchanged.

D7 boundary is config + persistence only. Per TeDe's 2026-05-15T20:56Z decision on `tborys/driftshield-meta#160`: no raw-event POST to `/v1/intake`, no new `/v1/telemetry/events` endpoint. Auth header shape for D8 default: `X-API-Key` (matches the live intake contract).

## Verification

- [x] Automated tests run — `uv run pytest -q` → 432 passed, 3 skipped. New cases in `tests/cli/test_telemetry.py` (7 added):
  - Default status shows remote disabled
  - `remote-enable` persists URL + key and redacts key in status
  - `remote-disable` clears config
  - Empty URL / empty key rejected (exit 1)
  - Local NDJSON capture unchanged when remote-enabled
  - `remote-enable` does not flip local `enabled` (separate axis)
  - `remote-disable` does not clear local install state
- [x] CLI flow exercised — `telemetry remote-enable` / `remote-disable` / `status --json` round-trip covered by tests.
- [ ] Browser flow exercised if UI changed — n/a (CLI-only).
- [x] `ruff check` on touched files — passes.

## Links

Closes #84

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- D8 (`#85`) will read `TelemetryConfig.remote_intake_url` + `TelemetryConfig.remote_api_key`, build the `phase3f.v1` envelope, and perform the single `POST /v1/intake` call. D7 explicitly leaves the network send and envelope build to D8.