### PR TITLE
feat(telemetry): D8 OSS envelope builder + submit-session (checkpoint; flag surface superseded-pending-option-c)

### DIFF
--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import typer
 from rich.console import Console
 
+from driftshield.remote_submission import (
+    RemoteSubmissionConfig,
+    RemoteSubmissionError,
+    build_intake_request,
+    post_submission,
+)
 from driftshield.telemetry import TelemetryService, validate_outcome_status
 
 console = Console(force_terminal=True)
@@ -25,8 +32,13 @@ def telemetry_status(
         "registered_at": config.registered_at,
         "last_heartbeat_at": config.last_heartbeat_at,
         "event_stream_path": config.event_stream_path,
-        "remote_enabled": config.remote_intake_url is not None and config.remote_api_key is not None,
+        "remote_enabled": (
+            config.remote_intake_url is not None
+            and config.remote_api_key is not None
+            and config.remote_installation_id is not None
+        ),
         "remote_intake_url": config.remote_intake_url,
+        "remote_installation_id": config.remote_installation_id,
         "remote_api_key_configured": config.remote_api_key is not None,
     }
     if json_output:
@@ -58,15 +70,21 @@ def telemetry_disable() -> None:
 def telemetry_remote_enable(
     intake_url: str = typer.Option(..., "--intake-url", help="Intake API URL the OSS submission envelope will POST to."),
     api_key: str = typer.Option(..., "--api-key", help="API key for the configured intake URL."),
+    installation_id: str = typer.Option(..., "--installation-id", help="Installation identifier registered with the intake server."),
 ) -> None:
     """Persist remote intake configuration for OSS submission. Does not send anything."""
     try:
-        config = TelemetryService().remote_enable(intake_url=intake_url, api_key=api_key)
+        config = TelemetryService().remote_enable(
+            intake_url=intake_url,
+            api_key=api_key,
+            installation_id=installation_id,
+        )
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
     console.print(
         f"Remote submission configured. Intake URL: {config.remote_intake_url}. "
+        f"Installation: {config.remote_installation_id}. "
         "API key stored locally; not displayed."
     )
 
@@ -76,6 +94,72 @@ def telemetry_remote_disable() -> None:
     """Clear remote intake configuration. Local telemetry capture is unaffected."""
     TelemetryService().remote_disable()
     console.print("Remote submission configuration cleared.")
+
+
+@app.command("submit-session")
+def telemetry_submit_session(
+    path: Path = typer.Option(..., "--path", help="JSON file with the finished session payload."),
+    source_session_id: str | None = typer.Option(
+        None,
+        "--source-session-id",
+        help="Override the source_session_id field. Defaults to the JSON file stem.",
+    ),
+    workflow_reference: str | None = typer.Option(
+        None, "--workflow-reference", help="Optional workflow identifier."
+    ),
+    project_reference: str | None = typer.Option(
+        None, "--project-reference", help="Optional project identifier."
+    ),
+    source_report_id: str | None = typer.Option(
+        None, "--source-report-id", help="Optional source report identifier."
+    ),
+) -> None:
+    """Build a phase3f.v1 envelope from a finished session JSON and POST once to the configured intake URL."""
+    config = TelemetryService().load_config()
+    if not config.remote_intake_url or not config.remote_api_key or not config.remote_installation_id:
+        console.print(
+            "[red]Error:[/red] Remote submission is not configured. "
+            "Run `driftshield telemetry remote-enable` first."
+        )
+        raise typer.Exit(1)
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        console.print(f"[red]Error:[/red] Could not read session file: {exc}")
+        raise typer.Exit(1) from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        console.print(f"[red]Error:[/red] Session file is not valid JSON: {exc}")
+        raise typer.Exit(1) from exc
+    if not isinstance(payload, dict):
+        console.print("[red]Error:[/red] Session file must contain a JSON object at top level.")
+        raise typer.Exit(1)
+
+    submission = build_intake_request(
+        installation_id=config.remote_installation_id,
+        source_session_id=source_session_id or path.stem,
+        payload=payload,
+        workflow_reference=workflow_reference,
+        project_reference=project_reference,
+        source_report_id=source_report_id,
+    )
+
+    submission_config = RemoteSubmissionConfig(
+        intake_url=config.remote_intake_url,
+        api_key=config.remote_api_key,
+        installation_id=config.remote_installation_id,
+    )
+    try:
+        response = post_submission(config=submission_config, submission=submission)
+    except RemoteSubmissionError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    console.print(
+        f"Submitted. submission_id={response.submission_id} status={response.processing_status}"
+    )
 
 
 @app.command("heartbeat")

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -1,0 +1,68 @@
+"""Phase 3h intake submission contract (OSS side).
+
+Duplicate-with-version-pin of the canonical models at
+driftshield-intel/src/driftshield_intel/intake_api.py:35-80.
+Promote to a shared package in Phase 3i. Until then, any change here must be
+mirrored on the intel side and vice versa, and both ends must continue to
+advertise the same SUPPORTED_CONTRACT_VERSION.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+SUPPORTED_CONTRACT_VERSION = "phase3f.v1"
+MAX_ENVELOPE_BYTES = 256_000
+REDACTION_MANIFEST_VERSION = "redaction-manifest.v1"
+REQUIRED_REDACTION_FIELDS: frozenset[str] = frozenset(
+    {"prompts", "responses", "user_identifiers"}
+)
+
+
+class RedactionManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    manifest_version: str = Field(default=REDACTION_MANIFEST_VERSION)
+    redaction_applied: bool
+    redacted_fields: list[str] = Field(min_length=1)
+
+
+class ConsentState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    consent_version: str = Field(min_length=1)
+    consent_granted: bool
+    captured_at: datetime
+    revoked_at: datetime | None = None
+
+
+class SubmissionEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_system: str = Field(min_length=1)
+    source_session_id: str = Field(min_length=1)
+    source_report_id: str | None = None
+    workflow_reference: str | None = Field(default=None, min_length=1)
+    project_reference: str | None = Field(default=None, min_length=1)
+    schema_version: str = Field(min_length=1)
+    payload: dict[str, Any]
+    payload_size_bytes: int = Field(ge=1, le=MAX_ENVELOPE_BYTES)
+    redaction_manifest: RedactionManifest
+
+
+class IntakeSubmissionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    installation_id: str = Field(min_length=1)
+    envelope_contract_version: str = Field(min_length=1)
+    consent_state: ConsentState
+    envelope: SubmissionEnvelope
+
+
+class IntakeSubmissionResponse(BaseModel):
+    submission_id: str
+    processing_status: str

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -1,0 +1,135 @@
+"""OSS-side submission envelope builder, redaction, and intake POST."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+from typing import Any
+from urllib import error, request
+
+from driftshield.intake_contract import (
+    REDACTION_MANIFEST_VERSION,
+    REQUIRED_REDACTION_FIELDS,
+    SUPPORTED_CONTRACT_VERSION,
+    ConsentState,
+    IntakeSubmissionRequest,
+    IntakeSubmissionResponse,
+    RedactionManifest,
+    SubmissionEnvelope,
+)
+
+
+_DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteSubmissionConfig:
+    intake_url: str
+    api_key: str
+    installation_id: str
+
+
+class RemoteSubmissionError(RuntimeError):
+    """Raised when the remote submission cannot be assembled or accepted."""
+
+
+def redact_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Strip required-redaction fields from the top level of the payload.
+
+    Returns (redacted_payload, redacted_fields). The manifest must always
+    advertise the full REQUIRED_REDACTION_FIELDS superset, even if the input
+    payload did not carry one of them, so the intake validator
+    (incomplete_redaction_manifest) is satisfied without lying about it.
+    """
+    redacted = {k: v for k, v in payload.items() if k not in REQUIRED_REDACTION_FIELDS}
+    return redacted, sorted(REQUIRED_REDACTION_FIELDS)
+
+
+def _encode_payload(payload: dict[str, Any]) -> tuple[bytes, int]:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return encoded, len(encoded)
+
+
+def build_intake_request(
+    *,
+    installation_id: str,
+    source_session_id: str,
+    payload: dict[str, Any],
+    consent_version: str = SUPPORTED_CONTRACT_VERSION,
+    source_system: str = _DEFAULT_SOURCE_SYSTEM,
+    workflow_reference: str | None = None,
+    project_reference: str | None = None,
+    source_report_id: str | None = None,
+    captured_at: datetime | None = None,
+) -> IntakeSubmissionRequest:
+    redacted_payload, redacted_fields = redact_payload(payload)
+    _, payload_size = _encode_payload(redacted_payload)
+
+    envelope = SubmissionEnvelope(
+        source_system=source_system,
+        source_session_id=source_session_id,
+        source_report_id=source_report_id,
+        workflow_reference=workflow_reference,
+        project_reference=project_reference,
+        schema_version=SUPPORTED_CONTRACT_VERSION,
+        payload=redacted_payload,
+        payload_size_bytes=payload_size,
+        redaction_manifest=RedactionManifest(
+            manifest_version=REDACTION_MANIFEST_VERSION,
+            redaction_applied=True,
+            redacted_fields=redacted_fields,
+        ),
+    )
+    consent = ConsentState(
+        consent_version=consent_version,
+        consent_granted=True,
+        captured_at=captured_at or datetime.now(UTC),
+        revoked_at=None,
+    )
+    return IntakeSubmissionRequest(
+        installation_id=installation_id,
+        envelope_contract_version=SUPPORTED_CONTRACT_VERSION,
+        consent_state=consent,
+        envelope=envelope,
+    )
+
+
+def post_submission(
+    *,
+    config: RemoteSubmissionConfig,
+    submission: IntakeSubmissionRequest,
+    opener: Any = None,
+) -> IntakeSubmissionResponse:
+    """Single POST to the configured intake URL. No retry on failure."""
+    body = submission.model_dump_json().encode("utf-8")
+    req = request.Request(
+        config.intake_url,
+        data=body,
+        method="POST",
+        headers={
+            "X-API-Key": config.api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    urlopen = opener or request.urlopen
+    try:
+        with urlopen(req) as resp:
+            raw = resp.read().decode("utf-8")
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else str(exc)
+        raise RemoteSubmissionError(f"intake HTTP {exc.code}: {detail}") from exc
+    except error.URLError as exc:
+        raise RemoteSubmissionError(f"intake unreachable: {exc.reason}") from exc
+
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RemoteSubmissionError(f"intake returned non-JSON body: {raw!r}") from exc
+    return IntakeSubmissionResponse.model_validate(decoded)

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -23,6 +23,7 @@ class TelemetryConfig:
     event_stream_path: str | None = None
     remote_intake_url: str | None = None
     remote_api_key: str | None = None
+    remote_installation_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +56,7 @@ class TelemetryService:
             or str(self._default_stream_path),
             remote_intake_url=_optional_string(data.get("remote_intake_url")),
             remote_api_key=_optional_string(data.get("remote_api_key")),
+            remote_installation_id=_optional_string(data.get("remote_installation_id")),
         )
 
     def enable(self) -> TelemetryConfig:
@@ -97,16 +99,26 @@ class TelemetryService:
         self._save_config(config)
         return config
 
-    def remote_enable(self, *, intake_url: str, api_key: str) -> TelemetryConfig:
+    def remote_enable(
+        self,
+        *,
+        intake_url: str,
+        api_key: str,
+        installation_id: str,
+    ) -> TelemetryConfig:
         intake_url_clean = intake_url.strip()
         api_key_clean = api_key.strip()
+        installation_id_clean = installation_id.strip()
         if not intake_url_clean:
             raise ValueError("intake_url must not be empty")
         if not api_key_clean:
             raise ValueError("api_key must not be empty")
+        if not installation_id_clean:
+            raise ValueError("installation_id must not be empty")
         config = self.load_config()
         config.remote_intake_url = intake_url_clean
         config.remote_api_key = api_key_clean
+        config.remote_installation_id = installation_id_clean
         if not config.event_stream_path:
             config.event_stream_path = str(self._default_stream_path)
         self._save_config(config)
@@ -116,6 +128,7 @@ class TelemetryService:
         config = self.load_config()
         config.remote_intake_url = None
         config.remote_api_key = None
+        config.remote_installation_id = None
         if not config.event_stream_path:
             config.event_stream_path = str(self._default_stream_path)
         self._save_config(config)

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -138,6 +138,25 @@ def test_emit_analysis_normalizes_outcome_status_before_classifiable_check(tmp_p
 
 _OSS_TEST_INTAKE_URL = "https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/intake"
 _OSS_TEST_API_KEY = "test-d7-api-key-not-real"
+_OSS_TEST_INSTALLATION_ID = "oss-fallback-installation"
+
+
+def _remote_enable_argv(
+    *,
+    intake_url: str = _OSS_TEST_INTAKE_URL,
+    api_key: str = _OSS_TEST_API_KEY,
+    installation_id: str = _OSS_TEST_INSTALLATION_ID,
+) -> list[str]:
+    return [
+        "telemetry",
+        "remote-enable",
+        "--intake-url",
+        intake_url,
+        "--api-key",
+        api_key,
+        "--installation-id",
+        installation_id,
+    ]
 
 
 def test_status_default_shows_remote_disabled(tmp_path, monkeypatch):
@@ -149,35 +168,29 @@ def test_status_default_shows_remote_disabled(tmp_path, monkeypatch):
     payload = json.loads(status.stdout)
     assert payload["remote_enabled"] is False
     assert payload["remote_intake_url"] is None
+    assert payload["remote_installation_id"] is None
     assert payload["remote_api_key_configured"] is False
 
 
 def test_remote_enable_persists_config_and_redacts_key_in_status(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
-    enabled = runner.invoke(
-        app,
-        [
-            "telemetry",
-            "remote-enable",
-            "--intake-url",
-            _OSS_TEST_INTAKE_URL,
-            "--api-key",
-            _OSS_TEST_API_KEY,
-        ],
-    )
+    enabled = runner.invoke(app, _remote_enable_argv())
     assert enabled.exit_code == 0
     assert _OSS_TEST_API_KEY not in enabled.stdout
+    assert _OSS_TEST_INSTALLATION_ID in enabled.stdout
 
     config = TelemetryService().load_config()
     assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
     assert config.remote_api_key == _OSS_TEST_API_KEY
+    assert config.remote_installation_id == _OSS_TEST_INSTALLATION_ID
 
     status = runner.invoke(app, ["telemetry", "status", "--json"])
     assert status.exit_code == 0
     payload = json.loads(status.stdout)
     assert payload["remote_enabled"] is True
     assert payload["remote_intake_url"] == _OSS_TEST_INTAKE_URL
+    assert payload["remote_installation_id"] == _OSS_TEST_INSTALLATION_ID
     assert payload["remote_api_key_configured"] is True
     assert "remote_api_key" not in payload
     assert _OSS_TEST_API_KEY not in status.stdout
@@ -185,17 +198,7 @@ def test_remote_enable_persists_config_and_redacts_key_in_status(tmp_path, monke
 
 def test_remote_disable_clears_config(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
-    runner.invoke(
-        app,
-        [
-            "telemetry",
-            "remote-enable",
-            "--intake-url",
-            _OSS_TEST_INTAKE_URL,
-            "--api-key",
-            _OSS_TEST_API_KEY,
-        ],
-    )
+    runner.invoke(app, _remote_enable_argv())
 
     disabled = runner.invoke(app, ["telemetry", "remote-disable"])
     assert disabled.exit_code == 0
@@ -203,45 +206,35 @@ def test_remote_disable_clears_config(tmp_path, monkeypatch):
     config = TelemetryService().load_config()
     assert config.remote_intake_url is None
     assert config.remote_api_key is None
+    assert config.remote_installation_id is None
 
 
 def test_remote_enable_rejects_empty_inputs(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
-    blank_url = runner.invoke(
-        app,
-        ["telemetry", "remote-enable", "--intake-url", "   ", "--api-key", _OSS_TEST_API_KEY],
-    )
+    blank_url = runner.invoke(app, _remote_enable_argv(intake_url="   "))
     assert blank_url.exit_code == 1
     assert "intake_url" in blank_url.stdout
 
-    blank_key = runner.invoke(
-        app,
-        ["telemetry", "remote-enable", "--intake-url", _OSS_TEST_INTAKE_URL, "--api-key", "   "],
-    )
+    blank_key = runner.invoke(app, _remote_enable_argv(api_key="   "))
     assert blank_key.exit_code == 1
     assert "api_key" in blank_key.stdout
+
+    blank_install = runner.invoke(app, _remote_enable_argv(installation_id="   "))
+    assert blank_install.exit_code == 1
+    assert "installation_id" in blank_install.stdout
 
     config = TelemetryService().load_config()
     assert config.remote_intake_url is None
     assert config.remote_api_key is None
+    assert config.remote_installation_id is None
 
 
 def test_local_capture_unchanged_when_remote_enabled(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
     runner.invoke(app, ["telemetry", "enable"])
-    runner.invoke(
-        app,
-        [
-            "telemetry",
-            "remote-enable",
-            "--intake-url",
-            _OSS_TEST_INTAKE_URL,
-            "--api-key",
-            _OSS_TEST_API_KEY,
-        ],
-    )
+    runner.invoke(app, _remote_enable_argv())
     heartbeat = runner.invoke(app, ["telemetry", "heartbeat"])
     assert heartbeat.exit_code == 0
 
@@ -256,17 +249,7 @@ def test_local_capture_unchanged_when_remote_enabled(tmp_path, monkeypatch):
 def test_remote_enable_does_not_toggle_local_enabled(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
-    runner.invoke(
-        app,
-        [
-            "telemetry",
-            "remote-enable",
-            "--intake-url",
-            _OSS_TEST_INTAKE_URL,
-            "--api-key",
-            _OSS_TEST_API_KEY,
-        ],
-    )
+    runner.invoke(app, _remote_enable_argv())
     config = TelemetryService().load_config()
     assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
     assert config.enabled is False
@@ -277,17 +260,7 @@ def test_remote_disable_does_not_clear_local_state(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
     runner.invoke(app, ["telemetry", "enable"])
-    runner.invoke(
-        app,
-        [
-            "telemetry",
-            "remote-enable",
-            "--intake-url",
-            _OSS_TEST_INTAKE_URL,
-            "--api-key",
-            _OSS_TEST_API_KEY,
-        ],
-    )
+    runner.invoke(app, _remote_enable_argv())
 
     install_id_before = TelemetryService().load_config().install_id
     runner.invoke(app, ["telemetry", "remote-disable"])
@@ -296,3 +269,118 @@ def test_remote_disable_does_not_clear_local_state(tmp_path, monkeypatch):
     assert config.enabled is True
     assert config.install_id == install_id_before
     assert config.remote_intake_url is None
+    assert config.remote_installation_id is None
+
+
+def _write_session(tmp_path, contents):
+    session_path = tmp_path / "session.json"
+    session_path.write_text(json.dumps(contents), encoding="utf-8")
+    return session_path
+
+
+def test_submit_session_happy_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path,
+        {
+            "session_id": "sess-1",
+            "prompts": ["secret"],
+            "responses": ["also secret"],
+            "user_identifiers": ["alice@example.test"],
+            "metadata": {"foo": "bar"},
+        },
+    )
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["installation_id"] = submission.installation_id
+        captured["payload_keys"] = sorted(submission.envelope.payload.keys())
+        captured["intake_url"] = config.intake_url
+        from driftshield.intake_contract import IntakeSubmissionResponse
+
+        return IntakeSubmissionResponse(submission_id="sub_xyz", processing_status="received")
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_submission",
+        fake_post,
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert "sub_xyz" in result.stdout
+    assert "received" in result.stdout
+    assert captured["installation_id"] == _OSS_TEST_INSTALLATION_ID
+    assert captured["intake_url"] == _OSS_TEST_INTAKE_URL
+    assert "prompts" not in captured["payload_keys"]
+    assert "responses" not in captured["payload_keys"]
+    assert "user_identifiers" not in captured["payload_keys"]
+    assert "metadata" in captured["payload_keys"]
+
+
+def test_submit_session_fails_when_remote_not_configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 1
+    assert "not configured" in result.stdout.lower()
+
+
+def test_submit_session_fails_on_invalid_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    bad_path = tmp_path / "session.json"
+    bad_path.write_text("not json at all", encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(bad_path)]
+    )
+
+    assert result.exit_code == 1
+    assert "not valid json" in result.stdout.lower()
+
+
+def test_submit_session_fails_on_non_object_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    array_path = tmp_path / "session.json"
+    array_path.write_text(json.dumps([{"session_id": "sess-1"}]), encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(array_path)]
+    )
+
+    assert result.exit_code == 1
+    assert "json object" in result.stdout.lower()
+
+
+def test_submit_session_surfaces_remote_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    from driftshield.remote_submission import RemoteSubmissionError
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        raise RemoteSubmissionError("intake HTTP 401: invalid_installation_credentials")
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_submission",
+        fake_post,
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 1
+    assert "401" in result.stdout
+    assert "invalid_installation_credentials" in result.stdout

--- a/driftshield/tests/test_intake_contract.py
+++ b/driftshield/tests/test_intake_contract.py
@@ -1,0 +1,157 @@
+"""Structural pin for the duplicated phase3f.v1 intake contract.
+
+Until the contract is promoted to a shared package (Phase 3i), this test
+locks the OSS-side models against a hardcoded reference snapshot copied
+from `driftshield-intel/src/driftshield_intel/intake_api.py:35-80`.
+
+If the canonical intel models change, update both the reference snapshot
+below AND `src/driftshield/intake_contract.py`, in lockstep. Otherwise the
+intake validator will reject submissions silently or with a misleading
+error code.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from driftshield.intake_contract import (
+    MAX_ENVELOPE_BYTES,
+    REDACTION_MANIFEST_VERSION,
+    REQUIRED_REDACTION_FIELDS,
+    SUPPORTED_CONTRACT_VERSION,
+    ConsentState,
+    IntakeSubmissionRequest,
+    RedactionManifest,
+    SubmissionEnvelope,
+)
+
+
+# Reference snapshot — keep in sync with intake_api.py:35-80.
+_REFERENCE_CONSTANTS = {
+    "SUPPORTED_CONTRACT_VERSION": "phase3f.v1",
+    "MAX_ENVELOPE_BYTES": 256_000,
+    "REDACTION_MANIFEST_VERSION": "redaction-manifest.v1",
+    "REQUIRED_REDACTION_FIELDS": frozenset({"prompts", "responses", "user_identifiers"}),
+}
+
+_REFERENCE_FIELDS = {
+    "RedactionManifest": {
+        "manifest_version",
+        "redaction_applied",
+        "redacted_fields",
+    },
+    "ConsentState": {
+        "consent_version",
+        "consent_granted",
+        "captured_at",
+        "revoked_at",
+    },
+    "SubmissionEnvelope": {
+        "source_system",
+        "source_session_id",
+        "source_report_id",
+        "workflow_reference",
+        "project_reference",
+        "schema_version",
+        "payload",
+        "payload_size_bytes",
+        "redaction_manifest",
+    },
+    "IntakeSubmissionRequest": {
+        "installation_id",
+        "envelope_contract_version",
+        "consent_state",
+        "envelope",
+    },
+}
+
+
+def test_contract_constants_match_canonical_snapshot():
+    assert SUPPORTED_CONTRACT_VERSION == _REFERENCE_CONSTANTS["SUPPORTED_CONTRACT_VERSION"]
+    assert MAX_ENVELOPE_BYTES == _REFERENCE_CONSTANTS["MAX_ENVELOPE_BYTES"]
+    assert REDACTION_MANIFEST_VERSION == _REFERENCE_CONSTANTS["REDACTION_MANIFEST_VERSION"]
+    assert REQUIRED_REDACTION_FIELDS == _REFERENCE_CONSTANTS["REQUIRED_REDACTION_FIELDS"]
+
+
+@pytest.mark.parametrize(
+    "model, expected_fields",
+    [
+        (RedactionManifest, _REFERENCE_FIELDS["RedactionManifest"]),
+        (ConsentState, _REFERENCE_FIELDS["ConsentState"]),
+        (SubmissionEnvelope, _REFERENCE_FIELDS["SubmissionEnvelope"]),
+        (IntakeSubmissionRequest, _REFERENCE_FIELDS["IntakeSubmissionRequest"]),
+    ],
+)
+def test_contract_field_set_matches_canonical_snapshot(model, expected_fields):
+    assert set(model.model_fields.keys()) == expected_fields
+
+
+def test_contract_rejects_extra_fields():
+    base_manifest = {
+        "manifest_version": REDACTION_MANIFEST_VERSION,
+        "redaction_applied": True,
+        "redacted_fields": ["prompts", "responses", "user_identifiers"],
+    }
+    base_consent = {
+        "consent_version": "phase3f.v1",
+        "consent_granted": True,
+        "captured_at": datetime.now(UTC).isoformat(),
+    }
+    base_envelope = {
+        "source_system": "oss",
+        "source_session_id": "sess-1",
+        "schema_version": "phase3f.v1",
+        "payload": {"foo": "bar"},
+        "payload_size_bytes": 13,
+        "redaction_manifest": base_manifest,
+    }
+    base_request = {
+        "installation_id": "oss-fallback-installation",
+        "envelope_contract_version": "phase3f.v1",
+        "consent_state": base_consent,
+        "envelope": base_envelope,
+    }
+
+    with pytest.raises(ValidationError):
+        RedactionManifest.model_validate({**base_manifest, "rogue": "x"})
+    with pytest.raises(ValidationError):
+        ConsentState.model_validate({**base_consent, "rogue": "x"})
+    with pytest.raises(ValidationError):
+        SubmissionEnvelope.model_validate({**base_envelope, "rogue": "x"})
+    with pytest.raises(ValidationError):
+        IntakeSubmissionRequest.model_validate({**base_request, "rogue": "x"})
+
+
+def test_redaction_manifest_requires_non_empty_redacted_fields():
+    with pytest.raises(ValidationError):
+        RedactionManifest.model_validate(
+            {
+                "manifest_version": REDACTION_MANIFEST_VERSION,
+                "redaction_applied": True,
+                "redacted_fields": [],
+            }
+        )
+
+
+def test_payload_size_bytes_bounds_match_canonical():
+    base = {
+        "source_system": "oss",
+        "source_session_id": "sess-1",
+        "schema_version": "phase3f.v1",
+        "payload": {"foo": "bar"},
+        "redaction_manifest": {
+            "manifest_version": REDACTION_MANIFEST_VERSION,
+            "redaction_applied": True,
+            "redacted_fields": ["prompts", "responses", "user_identifiers"],
+        },
+    }
+    with pytest.raises(ValidationError):
+        SubmissionEnvelope.model_validate({**base, "payload_size_bytes": 0})
+    with pytest.raises(ValidationError):
+        SubmissionEnvelope.model_validate({**base, "payload_size_bytes": MAX_ENVELOPE_BYTES + 1})
+
+    accepted = SubmissionEnvelope.model_validate({**base, "payload_size_bytes": 1})
+    assert accepted.payload_size_bytes == 1

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -1,0 +1,223 @@
+"""Unit tests for the OSS remote submission module (D8)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import io
+import json
+from typing import Any
+from urllib import error
+
+import pytest
+
+from driftshield.intake_contract import (
+    REDACTION_MANIFEST_VERSION,
+    REQUIRED_REDACTION_FIELDS,
+    SUPPORTED_CONTRACT_VERSION,
+    IntakeSubmissionRequest,
+)
+from driftshield.remote_submission import (
+    RemoteSubmissionConfig,
+    RemoteSubmissionError,
+    build_intake_request,
+    post_submission,
+    redact_payload,
+)
+
+
+_OSS_INTAKE_URL = "https://example.test/v1/intake"
+_OSS_API_KEY = "test-d8-api-key-not-real"
+_OSS_INSTALLATION_ID = "oss-fallback-installation"
+
+
+def _config() -> RemoteSubmissionConfig:
+    return RemoteSubmissionConfig(
+        intake_url=_OSS_INTAKE_URL,
+        api_key=_OSS_API_KEY,
+        installation_id=_OSS_INSTALLATION_ID,
+    )
+
+
+def test_redact_payload_strips_required_fields():
+    payload = {
+        "session_id": "sess-1",
+        "prompts": [{"role": "user", "content": "secret"}],
+        "responses": [{"role": "assistant", "content": "also secret"}],
+        "user_identifiers": ["alice@example.test"],
+        "metadata": {"foo": "bar"},
+    }
+
+    redacted, redacted_fields = redact_payload(payload)
+
+    assert "prompts" not in redacted
+    assert "responses" not in redacted
+    assert "user_identifiers" not in redacted
+    assert redacted["session_id"] == "sess-1"
+    assert redacted["metadata"] == {"foo": "bar"}
+    assert set(redacted_fields) == REQUIRED_REDACTION_FIELDS
+
+
+def test_redact_payload_manifest_advertises_superset_even_if_missing():
+    payload = {"session_id": "sess-1", "metadata": {"foo": "bar"}}
+
+    redacted, redacted_fields = redact_payload(payload)
+
+    assert redacted == payload
+    assert set(redacted_fields) == REQUIRED_REDACTION_FIELDS
+
+
+def test_build_intake_request_phase3f_v1_shape():
+    captured_at = datetime(2026, 5, 16, 8, 0, 0, tzinfo=UTC)
+    payload = {
+        "session_id": "sess-1",
+        "prompts": ["should be stripped"],
+        "responses": ["also stripped"],
+        "user_identifiers": ["alice@example.test"],
+        "metadata": {"foo": "bar"},
+    }
+
+    request = build_intake_request(
+        installation_id=_OSS_INSTALLATION_ID,
+        source_session_id="sess-1",
+        payload=payload,
+        captured_at=captured_at,
+    )
+
+    assert isinstance(request, IntakeSubmissionRequest)
+    assert request.installation_id == _OSS_INSTALLATION_ID
+    assert request.envelope_contract_version == SUPPORTED_CONTRACT_VERSION
+
+    assert request.consent_state.consent_version == SUPPORTED_CONTRACT_VERSION
+    assert request.consent_state.consent_granted is True
+    assert request.consent_state.captured_at == captured_at
+    assert request.consent_state.revoked_at is None
+
+    envelope = request.envelope
+    assert envelope.schema_version == SUPPORTED_CONTRACT_VERSION
+    assert envelope.source_session_id == "sess-1"
+    assert "prompts" not in envelope.payload
+    assert "responses" not in envelope.payload
+    assert "user_identifiers" not in envelope.payload
+    assert envelope.payload["session_id"] == "sess-1"
+    assert envelope.payload["metadata"] == {"foo": "bar"}
+
+    assert envelope.redaction_manifest.manifest_version == REDACTION_MANIFEST_VERSION
+    assert envelope.redaction_manifest.redaction_applied is True
+    assert set(envelope.redaction_manifest.redacted_fields) == REQUIRED_REDACTION_FIELDS
+
+
+def test_build_intake_request_payload_size_bytes_is_exact():
+    """payload_size_bytes must match the canonical encoding rule used by the intake validator."""
+    payload = {"session_id": "sess-1", "metadata": {"foo": "bar"}}
+
+    request = build_intake_request(
+        installation_id=_OSS_INSTALLATION_ID,
+        source_session_id="sess-1",
+        payload=payload,
+    )
+
+    expected = json.dumps(
+        request.envelope.payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    assert request.envelope.payload_size_bytes == len(expected)
+
+
+class _FakeHttpResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> "_FakeHttpResponse":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_post_submission_happy_path():
+    captured: dict[str, Any] = {}
+
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.headers)
+        captured["body"] = req.data
+        return _FakeHttpResponse(
+            json.dumps({"submission_id": "sub_abc", "processing_status": "received"}).encode("utf-8")
+        )
+
+    request = build_intake_request(
+        installation_id=_OSS_INSTALLATION_ID,
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    response = post_submission(config=_config(), submission=request, opener=fake_opener)
+
+    assert response.submission_id == "sub_abc"
+    assert response.processing_status == "received"
+    assert captured["url"] == _OSS_INTAKE_URL
+    assert captured["method"] == "POST"
+    # urllib.request lowercases header keys when stored on the Request object.
+    assert captured["headers"].get("X-api-key") == _OSS_API_KEY
+    assert captured["headers"].get("Content-type") == "application/json"
+    decoded = json.loads(captured["body"].decode("utf-8"))
+    assert decoded["installation_id"] == _OSS_INSTALLATION_ID
+    assert decoded["envelope_contract_version"] == SUPPORTED_CONTRACT_VERSION
+
+
+def test_post_submission_http_error_raises_remote_submission_error():
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        raise error.HTTPError(
+            url=_OSS_INTAKE_URL,
+            code=422,
+            msg="Unprocessable Content",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b'{"detail":"invalid_redaction_manifest"}'),
+        )
+
+    request = build_intake_request(
+        installation_id=_OSS_INSTALLATION_ID,
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    with pytest.raises(RemoteSubmissionError) as exc_info:
+        post_submission(config=_config(), submission=request, opener=fake_opener)
+    assert "HTTP 422" in str(exc_info.value)
+    assert "invalid_redaction_manifest" in str(exc_info.value)
+
+
+def test_post_submission_url_error_raises_remote_submission_error():
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        raise error.URLError("Name or service not known")
+
+    request = build_intake_request(
+        installation_id=_OSS_INSTALLATION_ID,
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    with pytest.raises(RemoteSubmissionError) as exc_info:
+        post_submission(config=_config(), submission=request, opener=fake_opener)
+    assert "unreachable" in str(exc_info.value)
+
+
+def test_post_submission_non_json_response_raises():
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        return _FakeHttpResponse(b"<html>oops</html>")
+
+    request = build_intake_request(
+        installation_id=_OSS_INSTALLATION_ID,
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    with pytest.raises(RemoteSubmissionError) as exc_info:
+        post_submission(config=_config(), submission=request, opener=fake_opener)
+    assert "non-JSON" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Add `driftshield telemetry submit-session --path SESSION_JSON` that reads the D7-persisted intake config (`remote_intake_url`, `remote_api_key`, `remote_installation_id`), redacts `prompts` / `responses` / `user_identifiers` from the payload, builds a `phase3f.v1` envelope with byte-exact `payload_size_bytes`, and POSTs once to the configured intake URL with `X-API-Key` auth. No retry on failure; non-2xx surfaces as a clean error.
- Duplicate the intake contract at `src/driftshield/intake_contract.py` (Pydantic models for `RedactionManifest`, `ConsentState`, `SubmissionEnvelope`, `IntakeSubmissionRequest`, `IntakeSubmissionResponse`). Header comment points to `driftshield-intel/src/driftshield_intel/intake_api.py:35-80` as the canonical source. Promote to a shared package in Phase 3i.
- Extend the D7 surface with `--installation-id` on `remote-enable`, persisted as `TelemetryConfig.remote_installation_id` and exposed via `telemetry status` (visible). API key value remains never-shown. D7 owns all remote-submission config in one place; D8 just reads it.
- New module `src/driftshield/remote_submission.py` holds the redaction, envelope builder, and single-POST helpers.

## Checkpoint scope (Option C supersedes this)

Per operator decision 2026-05-16, the manual `--api-key` + `--installation-id` flag surface is a stepping stone, not the final OSS UX. Option C (server-side `POST /v1/oss/installations` endpoint that lazily issues per-user keys + CLI auto-registration on `remote-enable`) will land before `tborys/driftshield-meta#157` (Phase 3h parent) closes. D8's envelope, redaction, and post code survive Option C unchanged; only the `remote-enable` flag surface is rewritten.

TeDe approved this checkpoint shape with 'D8 can still ship as the checkpoint you described, but meta#157 should stay open until Option C is live' (2026-05-16, relay group).

## Verification

- [x] Automated tests run — `uv run --extra dev pytest -q` → 453 passed, 3 skipped.
  - `tests/test_intake_contract.py` (5 cases) — pins every field name + constant against a hardcoded snapshot of `driftshield-intel/src/driftshield_intel/intake_api.py:35-80`. Catches duplicate-with-version-pin drift at OSS PR time.
  - `tests/test_remote_submission.py` (8 cases) — redaction, envelope builder, `payload_size_bytes` byte-exact, post happy path, HTTP error, URL error, non-JSON response.
  - `tests/cli/test_telemetry.py` (+5 new cases for `submit-session`, plus D7-ext updates for `--installation-id`) — happy path with mocked HTTP, fails-if-not-configured, fails-on-bad-JSON, fails-on-non-object-JSON, surfaces remote error.
- [x] CLI flow exercised — covered by tests above.
- [ ] Browser flow exercised if UI changed — n/a (CLI-only).
- [x] `ruff check` on touched files — passes.

## Links

Closes #85

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- **Option C handshake (locks meta#157)**: new `POST /v1/oss/installations` endpoint in `driftshield-intel`, route in `driftshield-infra`, `remote-enable` rewrite in `driftshield`. Three-slice issue chain to be filed after this PR lands.
- D9 (`tborys/driftshield-infra#30`) cuts from the resulting main once D8 is merged.