### PR TITLE
feat(cli): D9 show-result command for OSS submission result query

### DIFF
--- a/driftshield/src/driftshield/cli/commands/show_result.py
+++ b/driftshield/src/driftshield/cli/commands/show_result.py
@@ -1,0 +1,97 @@
+"""Show-result command: read the OSS-safe result triple for a submission."""
+
+from __future__ import annotations
+
+import json
+from urllib import error, request
+
+import typer
+from rich.console import Console
+
+from driftshield.telemetry import TelemetryService
+
+
+console = Console(force_terminal=True)
+
+
+def show_result(
+    submission_id: str = typer.Argument(..., help="Submission ID returned by `telemetry submit-session`."),
+    intake_url: str | None = typer.Option(
+        None,
+        "--intake-url",
+        help="Override the intake URL. Defaults to the value persisted by `telemetry remote-enable`.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print the raw JSON response."),
+) -> None:
+    """Fetch the OSS-safe result triple for a submission from the configured intake URL."""
+    base_url = intake_url
+    if base_url is None:
+        config = TelemetryService().load_config()
+        base_url = config.remote_intake_url
+    if not base_url:
+        console.print(
+            "[red]Error:[/red] No intake URL configured. "
+            "Run `driftshield telemetry remote-enable --intake-url URL` first, "
+            "or pass --intake-url."
+        )
+        raise typer.Exit(1)
+
+    submission_url = _derive_submission_url(base_url, submission_id)
+    req = request.Request(
+        submission_url,
+        method="GET",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        with request.urlopen(req) as resp:
+            raw = resp.read().decode("utf-8")
+    except error.HTTPError as exc:
+        if exc.code == 404:
+            console.print(f"[red]Error:[/red] Submission not found: {submission_id}")
+        else:
+            detail = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else str(exc)
+            console.print(f"[red]Error:[/red] intake HTTP {exc.code}: {detail}")
+        raise typer.Exit(1) from exc
+    except error.URLError as exc:
+        console.print(f"[red]Error:[/red] intake unreachable: {exc.reason}")
+        raise typer.Exit(1) from exc
+
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        console.print(f"[red]Error:[/red] intake returned non-JSON body: {raw!r}")
+        raise typer.Exit(1) from exc
+
+    if json_output:
+        typer.echo(json.dumps(body))
+        return
+
+    console.print(f"Submission: {body.get('submission_id')}")
+    console.print(f"Status: {body.get('processing_status')}")
+    signature_label = body.get("signature_label")
+    signature_family = body.get("signature_family")
+    if signature_label is None:
+        console.print("Signature: (not yet matched)")
+    else:
+        family_display = signature_family if signature_family is not None else "unknown"
+        console.print(f"Signature: {signature_label} ({family_display})")
+    confidence_band = body.get("confidence_band")
+    if confidence_band is None:
+        console.print("Confidence: (not yet evaluated)")
+    else:
+        console.print(f"Confidence: {confidence_band}")
+
+
+def _derive_submission_url(base_url: str, submission_id: str) -> str:
+    """Derive the GET /v1/oss/submissions/{submission_id} URL from the configured intake URL.
+
+    The intake URL is expected to end with /v1/intake or /v1/oss/submissions. Strip the suffix
+    (so we don't double-append), then re-append the OSS-result path. If neither suffix is
+    present, fall back to appending /v1/oss/submissions/{id} to the base.
+    """
+    trimmed = base_url.rstrip("/")
+    for suffix in ("/v1/intake", "/v1/oss/submissions"):
+        if trimmed.endswith(suffix):
+            trimmed = trimmed[: -len(suffix)]
+            break
+    return f"{trimmed}/v1/oss/submissions/{submission_id}"

--- a/driftshield/src/driftshield/cli/main.py
+++ b/driftshield/src/driftshield/cli/main.py
@@ -11,6 +11,7 @@ from driftshield.cli.commands.ingest import ingest
 from driftshield.cli.commands.inspect import inspect
 from driftshield.cli.commands.list import list_sessions
 from driftshield.cli.commands.report import report_command
+from driftshield.cli.commands.show_result import show_result
 from driftshield.cli.commands.signatures import app as signatures_app
 from driftshield.cli.commands.telemetry import app as telemetry_app
 
@@ -28,6 +29,7 @@ app.command(name="report")(report_command)
 app.command(name="export-validations")(export_validations)
 app.command(name="generate-fixtures")(generate_fixtures)
 app.command()(ingest)
+app.command(name="show-result")(show_result)
 app.add_typer(connectors_app, name="connectors")
 app.add_typer(signatures_app, name="signatures")
 app.add_typer(telemetry_app, name="telemetry")

--- a/driftshield/tests/cli/test_show_result.py
+++ b/driftshield/tests/cli/test_show_result.py
@@ -1,0 +1,251 @@
+"""Tests for the `driftshield show-result` command."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from urllib import error
+
+from typer.testing import CliRunner
+
+from driftshield.cli.commands.show_result import _derive_submission_url
+from driftshield.cli.main import app
+
+
+runner = CliRunner()
+
+
+_OSS_TEST_INTAKE_URL = "https://example.test/v1/intake"
+_OSS_TEST_API_KEY = "test-d9-not-real"
+_OSS_TEST_INSTALLATION_ID = "oss-fallback-installation"
+
+
+class _FakeHttpResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> "_FakeHttpResponse":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _seed_remote_config(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            _OSS_TEST_API_KEY,
+            "--installation-id",
+            _OSS_TEST_INSTALLATION_ID,
+        ],
+    )
+
+
+def test_derive_submission_url_strips_v1_intake_suffix():
+    assert (
+        _derive_submission_url("https://example.test/v1/intake", "sub_abc")
+        == "https://example.test/v1/oss/submissions/sub_abc"
+    )
+
+
+def test_derive_submission_url_strips_v1_oss_submissions_suffix():
+    assert (
+        _derive_submission_url("https://example.test/v1/oss/submissions", "sub_abc")
+        == "https://example.test/v1/oss/submissions/sub_abc"
+    )
+
+
+def test_derive_submission_url_appends_when_no_known_suffix():
+    assert (
+        _derive_submission_url("https://example.test", "sub_abc")
+        == "https://example.test/v1/oss/submissions/sub_abc"
+    )
+
+
+def test_derive_submission_url_strips_trailing_slash():
+    assert (
+        _derive_submission_url("https://example.test/", "sub_abc")
+        == "https://example.test/v1/oss/submissions/sub_abc"
+    )
+
+
+def test_show_result_happy_path(tmp_path, monkeypatch):
+    _seed_remote_config(tmp_path, monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.headers)
+        return _FakeHttpResponse(
+            json.dumps({
+                "submission_id": "sub_abc",
+                "processing_status": "processed",
+                "signature_label": "drift_signature_v1",
+                "signature_family": "tool_misuse",
+                "confidence_band": "high",
+            }).encode("utf-8")
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_abc"])
+
+    assert result.exit_code == 0
+    assert "sub_abc" in result.stdout
+    assert "processed" in result.stdout
+    assert "drift_signature_v1" in result.stdout
+    assert "tool_misuse" in result.stdout
+    assert "high" in result.stdout
+
+    assert captured["url"] == "https://example.test/v1/oss/submissions/sub_abc"
+    assert captured["method"] == "GET"
+    # urllib stores X-API-Key under "X-api-key" — assert it's NOT present (Option A: no auth header).
+    assert "X-api-key" not in captured["headers"]
+    assert "Authorization" not in captured["headers"]
+
+
+def test_show_result_renders_nulls_gracefully(tmp_path, monkeypatch):
+    _seed_remote_config(tmp_path, monkeypatch)
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        return _FakeHttpResponse(
+            json.dumps({
+                "submission_id": "sub_pending",
+                "processing_status": "processing",
+                "signature_label": None,
+                "signature_family": None,
+                "confidence_band": None,
+            }).encode("utf-8")
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_pending"])
+
+    assert result.exit_code == 0
+    assert "sub_pending" in result.stdout
+    assert "processing" in result.stdout
+    assert "not yet matched" in result.stdout
+    assert "not yet evaluated" in result.stdout
+
+
+def test_show_result_json_output(tmp_path, monkeypatch):
+    _seed_remote_config(tmp_path, monkeypatch)
+
+    body = {
+        "submission_id": "sub_abc",
+        "processing_status": "processed",
+        "signature_label": "drift_signature_v1",
+        "signature_family": "tool_misuse",
+        "confidence_band": "high",
+    }
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        return _FakeHttpResponse(json.dumps(body).encode("utf-8"))
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_abc", "--json"])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.stdout.strip())
+    assert parsed == body
+
+
+def test_show_result_overrides_intake_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    # No remote-enable; passing --intake-url instead.
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        captured["url"] = req.full_url
+        return _FakeHttpResponse(
+            json.dumps({
+                "submission_id": "sub_abc",
+                "processing_status": "processed",
+                "signature_label": "drift_signature_v1",
+                "signature_family": "tool_misuse",
+                "confidence_band": "high",
+            }).encode("utf-8")
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(
+        app,
+        ["show-result", "sub_abc", "--intake-url", "https://override.example.test/v1/intake"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["url"] == "https://override.example.test/v1/oss/submissions/sub_abc"
+
+
+def test_show_result_fails_when_no_url_configured_or_provided(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["show-result", "sub_abc"])
+
+    assert result.exit_code == 1
+    assert "no intake url configured" in result.stdout.lower()
+
+
+def test_show_result_404_renders_not_found(tmp_path, monkeypatch):
+    _seed_remote_config(tmp_path, monkeypatch)
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        raise error.HTTPError(
+            url="https://example.test/v1/oss/submissions/sub_missing",
+            code=404,
+            msg="Not Found",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b'{"detail":"submission_not_found"}'),
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_missing"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.stdout.lower()
+
+
+def test_show_result_url_error(tmp_path, monkeypatch):
+    _seed_remote_config(tmp_path, monkeypatch)
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        raise error.URLError("name resolution failed")
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_abc"])
+
+    assert result.exit_code == 1
+    assert "unreachable" in result.stdout.lower()
+
+
+def test_show_result_non_json_response(tmp_path, monkeypatch):
+    _seed_remote_config(tmp_path, monkeypatch)
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        return _FakeHttpResponse(b"<html>oops</html>")
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_abc"])
+
+    assert result.exit_code == 1
+    assert "non-json" in result.stdout.lower()


### PR DESCRIPTION
## Summary

- Add top-level `driftshield show-result <submission_id>` command. Calls `GET /v1/oss/submissions/{submission_id}` on the configured intake URL and renders the OSS-safe result triple (`signature_label`, `signature_family`, `confidence_band`) plus `processing_status`.
- New module `src/driftshield/cli/commands/show_result.py`. URL derivation strips a trailing `/v1/intake` or `/v1/oss/submissions` suffix from `TelemetryConfig.remote_intake_url` and re-appends the OSS-result path.
- No auth header sent (Option A per `tborys/driftshield-infra#30` and the intel handler in `tborys/driftshield-intel#115`). The `submission_id` in the path is the credential.
- `--intake-url URL` override flag for environments without a persisted config; `--json` for machine-parseable output.
- Renders nulls gracefully: "not yet matched" / "not yet evaluated" when the worker hasn't produced a signature/confidence yet.
- 404 from the intake renders "Submission not found"; network errors render cleanly with non-zero exit; no retry-on-flake.

This PR is the D9 CLI slice. The other slices:
- `tborys/driftshield-intel#115` — D9 intel handler (the route this command calls)
- `tborys/driftshield-infra#54` — D9 infra route + integration on phase-3h-teams-stack

## Verification

- [x] Automated tests run — `uv run --extra dev pytest -q` → 465 passed, 3 skipped. New cases in `tests/cli/test_show_result.py` (12):
  - URL derivation: strips `/v1/intake`, strips `/v1/oss/submissions`, falls back when neither, strips trailing slash
  - Happy path: command renders fields + no auth header sent
  - Renders nulls as friendly placeholders
  - `--json` returns raw response
  - `--intake-url` override works without a persisted config
  - Fails cleanly when no URL configured or provided
  - 404 renders "Submission not found"
  - URLError renders "unreachable"
  - Non-JSON response renders clean error
- [x] CLI flow exercised — covered by tests.
- [ ] Browser flow exercised if UI changed — n/a (CLI-only).
- [x] `ruff check` on touched files — passes.

## Links

Closes part of #30 (the CLI slice; intel + infra ship separately)

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- D11b live smoke (`tborys/driftshield-meta#160`) will exercise this command end-to-end after the D9 reviewed change-set executes and the new image flips.
- D19 CLI slice (`tborys/driftshield#100`) rewrites `remote-enable` + `submit-session` for the unauthenticated OSS lane. `show-result` shipped here is unaffected by that pivot.