### PR TITLE
feat(telemetry): D19 OSS CLI rewrite for unauthenticated submission lane

### DIFF
--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -9,10 +9,10 @@ import typer
 from rich.console import Console
 
 from driftshield.remote_submission import (
-    RemoteSubmissionConfig,
+    OssRemoteSubmissionConfig,
     RemoteSubmissionError,
-    build_intake_request,
-    post_submission,
+    build_oss_submission_request,
+    post_oss_submission,
 )
 from driftshield.telemetry import TelemetryService, validate_outcome_status
 
@@ -32,14 +32,8 @@ def telemetry_status(
         "registered_at": config.registered_at,
         "last_heartbeat_at": config.last_heartbeat_at,
         "event_stream_path": config.event_stream_path,
-        "remote_enabled": (
-            config.remote_intake_url is not None
-            and config.remote_api_key is not None
-            and config.remote_installation_id is not None
-        ),
+        "remote_enabled": config.remote_intake_url is not None,
         "remote_intake_url": config.remote_intake_url,
-        "remote_installation_id": config.remote_installation_id,
-        "remote_api_key_configured": config.remote_api_key is not None,
     }
     if json_output:
         typer.echo(json.dumps(payload))
@@ -69,23 +63,15 @@ def telemetry_disable() -> None:
 @app.command("remote-enable")
 def telemetry_remote_enable(
     intake_url: str = typer.Option(..., "--intake-url", help="Intake API URL the OSS submission envelope will POST to."),
-    api_key: str = typer.Option(..., "--api-key", help="API key for the configured intake URL."),
-    installation_id: str = typer.Option(..., "--installation-id", help="Installation identifier registered with the intake server."),
 ) -> None:
-    """Persist remote intake configuration for OSS submission. Does not send anything."""
+    """Persist the OSS intake URL. No keys needed; the OSS lane is unauthenticated."""
     try:
-        config = TelemetryService().remote_enable(
-            intake_url=intake_url,
-            api_key=api_key,
-            installation_id=installation_id,
-        )
+        config = TelemetryService().remote_enable(intake_url=intake_url)
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
     console.print(
-        f"Remote submission configured. Intake URL: {config.remote_intake_url}. "
-        f"Installation: {config.remote_installation_id}. "
-        "API key stored locally; not displayed."
+        f"Remote submission configured. Intake URL: {config.remote_intake_url}."
     )
 
 
@@ -114,12 +100,17 @@ def telemetry_submit_session(
         None, "--source-report-id", help="Optional source report identifier."
     ),
 ) -> None:
-    """Build a phase3f.v1 envelope from a finished session JSON and POST once to the configured intake URL."""
+    """Build a phase3f.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
+
+    The OSS lane is unauthenticated. No X-API-Key header is sent, no installation_id
+    or consent_state is included in the request. The server binds the persisted row
+    to the in-stack OSS fallback installation + consent.
+    """
     config = TelemetryService().load_config()
-    if not config.remote_intake_url or not config.remote_api_key or not config.remote_installation_id:
+    if not config.remote_intake_url:
         console.print(
             "[red]Error:[/red] Remote submission is not configured. "
-            "Run `driftshield telemetry remote-enable` first."
+            "Run `driftshield telemetry remote-enable --intake-url URL` first."
         )
         raise typer.Exit(1)
 
@@ -137,8 +128,7 @@ def telemetry_submit_session(
         console.print("[red]Error:[/red] Session file must contain a JSON object at top level.")
         raise typer.Exit(1)
 
-    submission = build_intake_request(
-        installation_id=config.remote_installation_id,
+    submission = build_oss_submission_request(
         source_session_id=source_session_id or path.stem,
         payload=payload,
         workflow_reference=workflow_reference,
@@ -146,13 +136,9 @@ def telemetry_submit_session(
         source_report_id=source_report_id,
     )
 
-    submission_config = RemoteSubmissionConfig(
-        intake_url=config.remote_intake_url,
-        api_key=config.remote_api_key,
-        installation_id=config.remote_installation_id,
-    )
+    submission_config = OssRemoteSubmissionConfig(intake_url=config.remote_intake_url)
     try:
-        response = post_submission(config=submission_config, submission=submission)
+        response = post_oss_submission(config=submission_config, submission=submission)
     except RemoteSubmissionError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -55,11 +55,31 @@ class SubmissionEnvelope(BaseModel):
 
 
 class IntakeSubmissionRequest(BaseModel):
+    """Authenticated POST /v1/intake request body.
+
+    Kept here for contract-pin reasons (mirrors intel-side authenticated path).
+    The OSS CLI does NOT use this shape; OSS uses OssSubmissionRequest.
+    """
+
     model_config = ConfigDict(extra="forbid")
 
     installation_id: str = Field(min_length=1)
     envelope_contract_version: str = Field(min_length=1)
     consent_state: ConsentState
+    envelope: SubmissionEnvelope
+
+
+class OssSubmissionRequest(BaseModel):
+    """Unauthenticated POST /v1/oss/submissions request body (D19).
+
+    No installation_id, no consent_state. The server binds the persisted row
+    to the in-stack OSS fallback installation + consent. The client never
+    sees these identifiers.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    envelope_contract_version: str = Field(min_length=1)
     envelope: SubmissionEnvelope
 
 

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -1,9 +1,14 @@
-"""OSS-side submission envelope builder, redaction, and intake POST."""
+"""OSS-side submission envelope builder, redaction, and unauthenticated POST.
+
+Per Phase 3h D19 (operator decision 2026-05-16): OSS submissions go on a
+dedicated unauthenticated lane. No installation_id, no api_key header, no
+consent_state echo. The server binds the persisted row to the in-stack OSS
+fallback installation + consent.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
 import json
 from typing import Any
 from urllib import error, request
@@ -12,9 +17,8 @@ from driftshield.intake_contract import (
     REDACTION_MANIFEST_VERSION,
     REQUIRED_REDACTION_FIELDS,
     SUPPORTED_CONTRACT_VERSION,
-    ConsentState,
-    IntakeSubmissionRequest,
     IntakeSubmissionResponse,
+    OssSubmissionRequest,
     RedactionManifest,
     SubmissionEnvelope,
 )
@@ -24,10 +28,10 @@ _DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
 
 
 @dataclass(frozen=True, slots=True)
-class RemoteSubmissionConfig:
+class OssRemoteSubmissionConfig:
+    """Minimal config for the unauthenticated OSS submission lane."""
+
     intake_url: str
-    api_key: str
-    installation_id: str
 
 
 class RemoteSubmissionError(RuntimeError):
@@ -56,18 +60,21 @@ def _encode_payload(payload: dict[str, Any]) -> tuple[bytes, int]:
     return encoded, len(encoded)
 
 
-def build_intake_request(
+def build_oss_submission_request(
     *,
-    installation_id: str,
     source_session_id: str,
     payload: dict[str, Any],
-    consent_version: str = SUPPORTED_CONTRACT_VERSION,
     source_system: str = _DEFAULT_SOURCE_SYSTEM,
     workflow_reference: str | None = None,
     project_reference: str | None = None,
     source_report_id: str | None = None,
-    captured_at: datetime | None = None,
-) -> IntakeSubmissionRequest:
+) -> OssSubmissionRequest:
+    """Build an unauthenticated OSS submission request.
+
+    No installation_id, no consent_state. The envelope still carries
+    redaction_manifest + payload_size_bytes + schema_version, all enforced
+    server-side by OssSubmissionService.
+    """
     redacted_payload, redacted_fields = redact_payload(payload)
     _, payload_size = _encode_payload(redacted_payload)
 
@@ -86,34 +93,29 @@ def build_intake_request(
             redacted_fields=redacted_fields,
         ),
     )
-    consent = ConsentState(
-        consent_version=consent_version,
-        consent_granted=True,
-        captured_at=captured_at or datetime.now(UTC),
-        revoked_at=None,
-    )
-    return IntakeSubmissionRequest(
-        installation_id=installation_id,
+    return OssSubmissionRequest(
         envelope_contract_version=SUPPORTED_CONTRACT_VERSION,
-        consent_state=consent,
         envelope=envelope,
     )
 
 
-def post_submission(
+def post_oss_submission(
     *,
-    config: RemoteSubmissionConfig,
-    submission: IntakeSubmissionRequest,
+    config: OssRemoteSubmissionConfig,
+    submission: OssSubmissionRequest,
     opener: Any = None,
 ) -> IntakeSubmissionResponse:
-    """Single POST to the configured intake URL. No retry on failure."""
+    """Single unauthenticated POST to /v1/oss/submissions. No retry on failure.
+
+    No X-API-Key header. No Authorization header. The intake URL is taken
+    verbatim from TelemetryConfig.remote_intake_url.
+    """
     body = submission.model_dump_json().encode("utf-8")
     req = request.Request(
         config.intake_url,
         data=body,
         method="POST",
         headers={
-            "X-API-Key": config.api_key,
             "Content-Type": "application/json",
             "Accept": "application/json",
         },

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -99,26 +99,22 @@ class TelemetryService:
         self._save_config(config)
         return config
 
-    def remote_enable(
-        self,
-        *,
-        intake_url: str,
-        api_key: str,
-        installation_id: str,
-    ) -> TelemetryConfig:
+    def remote_enable(self, *, intake_url: str) -> TelemetryConfig:
+        """Persist the OSS intake URL.
+
+        Per Phase 3h D19 (2026-05-16): the OSS lane is unauthenticated.
+        No api_key, no installation_id. If a config file from a previous D7/D8
+        install still carries those legacy fields, they are cleared here so
+        the on-disk state stays consistent with the live contract.
+        """
         intake_url_clean = intake_url.strip()
-        api_key_clean = api_key.strip()
-        installation_id_clean = installation_id.strip()
         if not intake_url_clean:
             raise ValueError("intake_url must not be empty")
-        if not api_key_clean:
-            raise ValueError("api_key must not be empty")
-        if not installation_id_clean:
-            raise ValueError("installation_id must not be empty")
         config = self.load_config()
         config.remote_intake_url = intake_url_clean
-        config.remote_api_key = api_key_clean
-        config.remote_installation_id = installation_id_clean
+        # Migrate D7/D8 legacy fields out of the on-disk config on first use.
+        config.remote_api_key = None
+        config.remote_installation_id = None
         if not config.event_stream_path:
             config.event_stream_path = str(self._default_stream_path)
         self._save_config(config)

--- a/driftshield/tests/cli/test_show_result.py
+++ b/driftshield/tests/cli/test_show_result.py
@@ -16,9 +16,7 @@ from driftshield.cli.main import app
 runner = CliRunner()
 
 
-_OSS_TEST_INTAKE_URL = "https://example.test/v1/intake"
-_OSS_TEST_API_KEY = "test-d9-not-real"
-_OSS_TEST_INSTALLATION_ID = "oss-fallback-installation"
+_OSS_TEST_INTAKE_URL = "https://example.test/v1/oss/submissions"
 
 
 class _FakeHttpResponse:
@@ -39,16 +37,7 @@ def _seed_remote_config(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     runner.invoke(
         app,
-        [
-            "telemetry",
-            "remote-enable",
-            "--intake-url",
-            _OSS_TEST_INTAKE_URL,
-            "--api-key",
-            _OSS_TEST_API_KEY,
-            "--installation-id",
-            _OSS_TEST_INSTALLATION_ID,
-        ],
+        ["telemetry", "remote-enable", "--intake-url", _OSS_TEST_INTAKE_URL],
     )
 
 

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -136,27 +136,11 @@ def test_emit_analysis_normalizes_outcome_status_before_classifiable_check(tmp_p
     assert analysis_event["payload"]["classifiable"] is True
 
 
-_OSS_TEST_INTAKE_URL = "https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/intake"
-_OSS_TEST_API_KEY = "test-d7-api-key-not-real"
-_OSS_TEST_INSTALLATION_ID = "oss-fallback-installation"
+_OSS_TEST_INTAKE_URL = "https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/oss/submissions"
 
 
-def _remote_enable_argv(
-    *,
-    intake_url: str = _OSS_TEST_INTAKE_URL,
-    api_key: str = _OSS_TEST_API_KEY,
-    installation_id: str = _OSS_TEST_INSTALLATION_ID,
-) -> list[str]:
-    return [
-        "telemetry",
-        "remote-enable",
-        "--intake-url",
-        intake_url,
-        "--api-key",
-        api_key,
-        "--installation-id",
-        installation_id,
-    ]
+def _remote_enable_argv(*, intake_url: str = _OSS_TEST_INTAKE_URL) -> list[str]:
+    return ["telemetry", "remote-enable", "--intake-url", intake_url]
 
 
 def test_status_default_shows_remote_disabled(tmp_path, monkeypatch):
@@ -168,35 +152,83 @@ def test_status_default_shows_remote_disabled(tmp_path, monkeypatch):
     payload = json.loads(status.stdout)
     assert payload["remote_enabled"] is False
     assert payload["remote_intake_url"] is None
-    assert payload["remote_installation_id"] is None
-    assert payload["remote_api_key_configured"] is False
 
 
-def test_remote_enable_persists_config_and_redacts_key_in_status(tmp_path, monkeypatch):
+def test_remote_enable_persists_intake_url_only(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
     enabled = runner.invoke(app, _remote_enable_argv())
     assert enabled.exit_code == 0
-    assert _OSS_TEST_API_KEY not in enabled.stdout
-    assert _OSS_TEST_INSTALLATION_ID in enabled.stdout
+    assert _OSS_TEST_INTAKE_URL in enabled.stdout
 
     config = TelemetryService().load_config()
     assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
-    assert config.remote_api_key == _OSS_TEST_API_KEY
-    assert config.remote_installation_id == _OSS_TEST_INSTALLATION_ID
+    # D19 contract: no legacy auth fields persisted.
+    assert config.remote_api_key is None
+    assert config.remote_installation_id is None
 
     status = runner.invoke(app, ["telemetry", "status", "--json"])
     assert status.exit_code == 0
     payload = json.loads(status.stdout)
     assert payload["remote_enabled"] is True
     assert payload["remote_intake_url"] == _OSS_TEST_INTAKE_URL
-    assert payload["remote_installation_id"] == _OSS_TEST_INSTALLATION_ID
-    assert payload["remote_api_key_configured"] is True
+    # D19 status surface dropped the legacy fields.
+    assert "remote_installation_id" not in payload
+    assert "remote_api_key_configured" not in payload
     assert "remote_api_key" not in payload
-    assert _OSS_TEST_API_KEY not in status.stdout
 
 
-def test_remote_disable_clears_config(tmp_path, monkeypatch):
+def test_remote_enable_rejects_only_unknown_flags(tmp_path, monkeypatch):
+    """D19 contract: --api-key and --installation-id are no longer accepted as flags."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "remote-enable",
+            "--intake-url",
+            _OSS_TEST_INTAKE_URL,
+            "--api-key",
+            "should-be-rejected",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_remote_enable_migrates_away_from_d7_d8_legacy_fields(tmp_path, monkeypatch):
+    """A config file from a prior D7/D8 install has remote_api_key + remote_installation_id.
+    First D19 remote-enable run must clear them.
+    """
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    home = tmp_path / "telemetry"
+    home.mkdir(parents=True)
+    (home / "config.json").write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "install_id": "uuid-old",
+                "remote_intake_url": "https://example.test/v1/intake",
+                "remote_api_key": "legacy-key",
+                "remote_installation_id": "oss-fallback-installation",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, _remote_enable_argv())
+    assert result.exit_code == 0
+
+    config = TelemetryService().load_config()
+    assert config.remote_intake_url == _OSS_TEST_INTAKE_URL
+    assert config.remote_api_key is None
+    assert config.remote_installation_id is None
+    # Local state preserved.
+    assert config.enabled is True
+    assert config.install_id == "uuid-old"
+
+
+def test_remote_disable_clears_remote_state(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     runner.invoke(app, _remote_enable_argv())
 
@@ -209,25 +241,15 @@ def test_remote_disable_clears_config(tmp_path, monkeypatch):
     assert config.remote_installation_id is None
 
 
-def test_remote_enable_rejects_empty_inputs(tmp_path, monkeypatch):
+def test_remote_enable_rejects_empty_intake_url(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
 
     blank_url = runner.invoke(app, _remote_enable_argv(intake_url="   "))
     assert blank_url.exit_code == 1
     assert "intake_url" in blank_url.stdout
 
-    blank_key = runner.invoke(app, _remote_enable_argv(api_key="   "))
-    assert blank_key.exit_code == 1
-    assert "api_key" in blank_key.stdout
-
-    blank_install = runner.invoke(app, _remote_enable_argv(installation_id="   "))
-    assert blank_install.exit_code == 1
-    assert "installation_id" in blank_install.stdout
-
     config = TelemetryService().load_config()
     assert config.remote_intake_url is None
-    assert config.remote_api_key is None
-    assert config.remote_installation_id is None
 
 
 def test_local_capture_unchanged_when_remote_enabled(tmp_path, monkeypatch):
@@ -269,7 +291,6 @@ def test_remote_disable_does_not_clear_local_state(tmp_path, monkeypatch):
     assert config.enabled is True
     assert config.install_id == install_id_before
     assert config.remote_intake_url is None
-    assert config.remote_installation_id is None
 
 
 def _write_session(tmp_path, contents):
@@ -295,15 +316,15 @@ def test_submit_session_happy_path(tmp_path, monkeypatch):
     captured = {}
 
     def fake_post(*, config, submission, opener=None):  # noqa: ARG001
-        captured["installation_id"] = submission.installation_id
-        captured["payload_keys"] = sorted(submission.envelope.payload.keys())
         captured["intake_url"] = config.intake_url
+        captured["payload_keys"] = sorted(submission.envelope.payload.keys())
+        captured["request_keys"] = set(json.loads(submission.model_dump_json()).keys())
         from driftshield.intake_contract import IntakeSubmissionResponse
 
         return IntakeSubmissionResponse(submission_id="sub_xyz", processing_status="received")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_submission",
+        "driftshield.cli.commands.telemetry.post_oss_submission",
         fake_post,
     )
 
@@ -314,12 +335,13 @@ def test_submit_session_happy_path(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "sub_xyz" in result.stdout
     assert "received" in result.stdout
-    assert captured["installation_id"] == _OSS_TEST_INSTALLATION_ID
     assert captured["intake_url"] == _OSS_TEST_INTAKE_URL
     assert "prompts" not in captured["payload_keys"]
     assert "responses" not in captured["payload_keys"]
     assert "user_identifiers" not in captured["payload_keys"]
     assert "metadata" in captured["payload_keys"]
+    # D19 contract: request body has no installation_id, no consent_state.
+    assert captured["request_keys"] == {"envelope_contract_version", "envelope"}
 
 
 def test_submit_session_fails_when_remote_not_configured(tmp_path, monkeypatch):
@@ -370,10 +392,10 @@ def test_submit_session_surfaces_remote_error(tmp_path, monkeypatch):
     from driftshield.remote_submission import RemoteSubmissionError
 
     def fake_post(*, config, submission, opener=None):  # noqa: ARG001
-        raise RemoteSubmissionError("intake HTTP 401: invalid_installation_credentials")
+        raise RemoteSubmissionError("intake HTTP 422: invalid_redaction_manifest")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_submission",
+        "driftshield.cli.commands.telemetry.post_oss_submission",
         fake_post,
     )
 
@@ -382,5 +404,5 @@ def test_submit_session_surfaces_remote_error(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 1
-    assert "401" in result.stdout
-    assert "invalid_installation_credentials" in result.stdout
+    assert "422" in result.stdout
+    assert "invalid_redaction_manifest" in result.stdout

--- a/driftshield/tests/test_intake_contract.py
+++ b/driftshield/tests/test_intake_contract.py
@@ -24,6 +24,7 @@ from driftshield.intake_contract import (
     SUPPORTED_CONTRACT_VERSION,
     ConsentState,
     IntakeSubmissionRequest,
+    OssSubmissionRequest,
     RedactionManifest,
     SubmissionEnvelope,
 )
@@ -66,6 +67,11 @@ _REFERENCE_FIELDS = {
         "consent_state",
         "envelope",
     },
+    # D19: OSS unauthenticated submission request. No installation_id, no consent_state.
+    "OssSubmissionRequest": {
+        "envelope_contract_version",
+        "envelope",
+    },
 }
 
 
@@ -83,10 +89,44 @@ def test_contract_constants_match_canonical_snapshot():
         (ConsentState, _REFERENCE_FIELDS["ConsentState"]),
         (SubmissionEnvelope, _REFERENCE_FIELDS["SubmissionEnvelope"]),
         (IntakeSubmissionRequest, _REFERENCE_FIELDS["IntakeSubmissionRequest"]),
+        (OssSubmissionRequest, _REFERENCE_FIELDS["OssSubmissionRequest"]),
     ],
 )
 def test_contract_field_set_matches_canonical_snapshot(model, expected_fields):
     assert set(model.model_fields.keys()) == expected_fields
+
+
+def test_oss_submission_request_rejects_legacy_authenticated_fields():
+    """D19 contract: OssSubmissionRequest must reject installation_id and consent_state."""
+    base = {
+        "envelope_contract_version": SUPPORTED_CONTRACT_VERSION,
+        "envelope": {
+            "source_system": "oss",
+            "source_session_id": "sess-1",
+            "schema_version": SUPPORTED_CONTRACT_VERSION,
+            "payload": {"foo": "bar"},
+            "payload_size_bytes": 13,
+            "redaction_manifest": {
+                "manifest_version": REDACTION_MANIFEST_VERSION,
+                "redaction_applied": True,
+                "redacted_fields": ["prompts", "responses", "user_identifiers"],
+            },
+        },
+    }
+    OssSubmissionRequest.model_validate(base)  # baseline must accept
+
+    with pytest.raises(ValidationError):
+        OssSubmissionRequest.model_validate({**base, "installation_id": "should-not-be-here"})
+
+    with pytest.raises(ValidationError):
+        OssSubmissionRequest.model_validate({
+            **base,
+            "consent_state": {
+                "consent_version": SUPPORTED_CONTRACT_VERSION,
+                "consent_granted": True,
+                "captured_at": "2026-05-16T00:00:00+00:00",
+            },
+        })
 
 
 def test_contract_rejects_extra_fields():

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -1,8 +1,7 @@
-"""Unit tests for the OSS remote submission module (D8)."""
+"""Unit tests for the D19 unauthenticated OSS submission module."""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 import io
 import json
 from typing import Any
@@ -14,28 +13,22 @@ from driftshield.intake_contract import (
     REDACTION_MANIFEST_VERSION,
     REQUIRED_REDACTION_FIELDS,
     SUPPORTED_CONTRACT_VERSION,
-    IntakeSubmissionRequest,
+    OssSubmissionRequest,
 )
 from driftshield.remote_submission import (
-    RemoteSubmissionConfig,
+    OssRemoteSubmissionConfig,
     RemoteSubmissionError,
-    build_intake_request,
-    post_submission,
+    build_oss_submission_request,
+    post_oss_submission,
     redact_payload,
 )
 
 
-_OSS_INTAKE_URL = "https://example.test/v1/intake"
-_OSS_API_KEY = "test-d8-api-key-not-real"
-_OSS_INSTALLATION_ID = "oss-fallback-installation"
+_OSS_INTAKE_URL = "https://example.test/v1/oss/submissions"
 
 
-def _config() -> RemoteSubmissionConfig:
-    return RemoteSubmissionConfig(
-        intake_url=_OSS_INTAKE_URL,
-        api_key=_OSS_API_KEY,
-        installation_id=_OSS_INSTALLATION_ID,
-    )
+def _config() -> OssRemoteSubmissionConfig:
+    return OssRemoteSubmissionConfig(intake_url=_OSS_INTAKE_URL)
 
 
 def test_redact_payload_strips_required_fields():
@@ -66,8 +59,7 @@ def test_redact_payload_manifest_advertises_superset_even_if_missing():
     assert set(redacted_fields) == REQUIRED_REDACTION_FIELDS
 
 
-def test_build_intake_request_phase3f_v1_shape():
-    captured_at = datetime(2026, 5, 16, 8, 0, 0, tzinfo=UTC)
+def test_build_oss_submission_request_phase3f_v1_shape():
     payload = {
         "session_id": "sess-1",
         "prompts": ["should be stripped"],
@@ -76,21 +68,13 @@ def test_build_intake_request_phase3f_v1_shape():
         "metadata": {"foo": "bar"},
     }
 
-    request = build_intake_request(
-        installation_id=_OSS_INSTALLATION_ID,
+    request = build_oss_submission_request(
         source_session_id="sess-1",
         payload=payload,
-        captured_at=captured_at,
     )
 
-    assert isinstance(request, IntakeSubmissionRequest)
-    assert request.installation_id == _OSS_INSTALLATION_ID
+    assert isinstance(request, OssSubmissionRequest)
     assert request.envelope_contract_version == SUPPORTED_CONTRACT_VERSION
-
-    assert request.consent_state.consent_version == SUPPORTED_CONTRACT_VERSION
-    assert request.consent_state.consent_granted is True
-    assert request.consent_state.captured_at == captured_at
-    assert request.consent_state.revoked_at is None
 
     envelope = request.envelope
     assert envelope.schema_version == SUPPORTED_CONTRACT_VERSION
@@ -106,12 +90,24 @@ def test_build_intake_request_phase3f_v1_shape():
     assert set(envelope.redaction_manifest.redacted_fields) == REQUIRED_REDACTION_FIELDS
 
 
-def test_build_intake_request_payload_size_bytes_is_exact():
+def test_build_oss_submission_request_has_no_installation_id_or_consent_state():
+    """D19 contract: request must NOT carry installation_id or consent_state."""
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    serialised = json.loads(request.model_dump_json())
+    assert "installation_id" not in serialised
+    assert "consent_state" not in serialised
+    assert set(serialised.keys()) == {"envelope_contract_version", "envelope"}
+
+
+def test_build_oss_submission_request_payload_size_bytes_is_exact():
     """payload_size_bytes must match the canonical encoding rule used by the intake validator."""
     payload = {"session_id": "sess-1", "metadata": {"foo": "bar"}}
 
-    request = build_intake_request(
-        installation_id=_OSS_INSTALLATION_ID,
+    request = build_oss_submission_request(
         source_session_id="sess-1",
         payload=payload,
     )
@@ -139,7 +135,7 @@ class _FakeHttpResponse:
         return self._body
 
 
-def test_post_submission_happy_path():
+def test_post_oss_submission_happy_path():
     captured: dict[str, Any] = {}
 
     def fake_opener(req: Any) -> _FakeHttpResponse:
@@ -151,27 +147,29 @@ def test_post_submission_happy_path():
             json.dumps({"submission_id": "sub_abc", "processing_status": "received"}).encode("utf-8")
         )
 
-    request = build_intake_request(
-        installation_id=_OSS_INSTALLATION_ID,
+    request = build_oss_submission_request(
         source_session_id="sess-1",
         payload={"session_id": "sess-1"},
     )
 
-    response = post_submission(config=_config(), submission=request, opener=fake_opener)
+    response = post_oss_submission(config=_config(), submission=request, opener=fake_opener)
 
     assert response.submission_id == "sub_abc"
     assert response.processing_status == "received"
     assert captured["url"] == _OSS_INTAKE_URL
     assert captured["method"] == "POST"
     # urllib.request lowercases header keys when stored on the Request object.
-    assert captured["headers"].get("X-api-key") == _OSS_API_KEY
+    # D19 contract: NO X-API-Key, NO Authorization.
+    assert "X-api-key" not in captured["headers"]
+    assert "Authorization" not in captured["headers"]
     assert captured["headers"].get("Content-type") == "application/json"
     decoded = json.loads(captured["body"].decode("utf-8"))
-    assert decoded["installation_id"] == _OSS_INSTALLATION_ID
+    assert "installation_id" not in decoded
+    assert "consent_state" not in decoded
     assert decoded["envelope_contract_version"] == SUPPORTED_CONTRACT_VERSION
 
 
-def test_post_submission_http_error_raises_remote_submission_error():
+def test_post_oss_submission_http_error_raises_remote_submission_error():
     def fake_opener(req: Any) -> _FakeHttpResponse:
         raise error.HTTPError(
             url=_OSS_INTAKE_URL,
@@ -181,43 +179,40 @@ def test_post_submission_http_error_raises_remote_submission_error():
             fp=io.BytesIO(b'{"detail":"invalid_redaction_manifest"}'),
         )
 
-    request = build_intake_request(
-        installation_id=_OSS_INSTALLATION_ID,
+    request = build_oss_submission_request(
         source_session_id="sess-1",
         payload={"session_id": "sess-1"},
     )
 
     with pytest.raises(RemoteSubmissionError) as exc_info:
-        post_submission(config=_config(), submission=request, opener=fake_opener)
+        post_oss_submission(config=_config(), submission=request, opener=fake_opener)
     assert "HTTP 422" in str(exc_info.value)
     assert "invalid_redaction_manifest" in str(exc_info.value)
 
 
-def test_post_submission_url_error_raises_remote_submission_error():
+def test_post_oss_submission_url_error_raises_remote_submission_error():
     def fake_opener(req: Any) -> _FakeHttpResponse:
         raise error.URLError("Name or service not known")
 
-    request = build_intake_request(
-        installation_id=_OSS_INSTALLATION_ID,
+    request = build_oss_submission_request(
         source_session_id="sess-1",
         payload={"session_id": "sess-1"},
     )
 
     with pytest.raises(RemoteSubmissionError) as exc_info:
-        post_submission(config=_config(), submission=request, opener=fake_opener)
+        post_oss_submission(config=_config(), submission=request, opener=fake_opener)
     assert "unreachable" in str(exc_info.value)
 
 
-def test_post_submission_non_json_response_raises():
+def test_post_oss_submission_non_json_response_raises():
     def fake_opener(req: Any) -> _FakeHttpResponse:
         return _FakeHttpResponse(b"<html>oops</html>")
 
-    request = build_intake_request(
-        installation_id=_OSS_INSTALLATION_ID,
+    request = build_oss_submission_request(
         source_session_id="sess-1",
         payload={"session_id": "sess-1"},
     )
 
     with pytest.raises(RemoteSubmissionError) as exc_info:
-        post_submission(config=_config(), submission=request, opener=fake_opener)
+        post_oss_submission(config=_config(), submission=request, opener=fake_opener)
     assert "non-JSON" in str(exc_info.value)


### PR DESCRIPTION
## Summary

D19 CLI slice: rewrite `driftshield telemetry remote-enable` and `submit-session` for the new dedicated unauthenticated OSS submission lane added by `tborys/driftshield-intel#116`. Retires D7/D8's manual flag surface.

Per TeDe sign-off 2026-05-16: `remote-enable --intake-url URL` only (no `--api-key`, no `--installation-id`), `submit-session` POSTs to `/v1/oss/submissions` with no auth headers and no `consent_state` echo.

## Changes

### `src/driftshield/intake_contract.py`

- Add `OssSubmissionRequest` Pydantic model with `extra="forbid"`. Carries `envelope_contract_version` + `SubmissionEnvelope`. No `installation_id`, no `consent_state` (mirrors the intel-side `OssSubmissionRequest` shape at `driftshield-intel/src/driftshield_intel/intake_api.py`).
- `IntakeSubmissionRequest` (authenticated path) stays defined here for contract-pin completeness but the OSS CLI no longer constructs it.

### `src/driftshield/remote_submission.py`

- Removed `build_intake_request` + `post_submission` + `RemoteSubmissionConfig` (D7/D8 authenticated path).
- Added `build_oss_submission_request` (no `installation_id` parameter, no `consent_state` plumbing).
- Added `post_oss_submission` (no `X-API-Key` header, no `Authorization` header — single POST, no retry).
- Added `OssRemoteSubmissionConfig` (just `intake_url`).
- `redact_payload` + `RemoteSubmissionError` retained unchanged.

### `src/driftshield/cli/commands/telemetry.py`

- `telemetry remote-enable --intake-url URL` is the only flag. `--api-key` and `--installation-id` removed.
- `telemetry submit-session` calls `post_oss_submission(...)` via `OssRemoteSubmissionConfig`. No headers, no consent_state.
- `telemetry status` payload simplified: drops `remote_installation_id` and `remote_api_key_configured`. `remote_enabled` is now true iff `remote_intake_url` is set.

### `src/driftshield/telemetry/service.py`

- `TelemetryService.remote_enable(*, intake_url: str)` signature simplified.
- On call, legacy `remote_api_key` + `remote_installation_id` fields in any pre-existing config file are **cleared** (auto-migration from D7/D8 on-disk state).
- `TelemetryConfig` fields kept readable for old configs on disk; just never written.

### Tests

- `tests/cli/test_telemetry.py` — fully rewritten to match D19 contract:
  - `remote-enable --intake-url URL` happy path
  - Rejects empty `--intake-url`
  - Rejects unknown legacy flags like `--api-key` (typer surface no longer accepts them)
  - **Auto-migration**: a config file written by D7/D8 (carrying `remote_api_key` + `remote_installation_id`) is migrated on next D19 `remote-enable` — pinned by `test_remote_enable_migrates_away_from_d7_d8_legacy_fields`
  - `submit-session` request body has exactly `{envelope_contract_version, envelope}` keys (no `installation_id`, no `consent_state`)
  - `submit-session` payload redaction still strips `prompts` / `responses` / `user_identifiers`
  - Status output dropped `remote_api_key_configured` / `remote_installation_id` (pinned by absence)
  - Local capture (`telemetry enable` / `heartbeat`) unaffected by D19 changes
- `tests/test_remote_submission.py` — rewritten around `build_oss_submission_request` + `post_oss_submission`. Pins that the serialised request body has no `installation_id` / `consent_state`, and that the HTTP request carries no `X-API-Key` or `Authorization` headers.
- `tests/test_intake_contract.py` — added `OssSubmissionRequest` to the structural snapshot. New test `test_oss_submission_request_rejects_legacy_authenticated_fields` pins that the OSS model rejects `installation_id` / `consent_state` (Pydantic `extra="forbid"`).
- `tests/cli/test_show_result.py` — `_seed_remote_config` updated to use the new single-flag shape.

## Verification

```bash
uv run --extra dev pytest -q
uv run --extra dev ruff check src/driftshield/cli/commands/telemetry.py src/driftshield/intake_contract.py src/driftshield/remote_submission.py src/driftshield/telemetry/service.py tests/cli/test_telemetry.py tests/cli/test_show_result.py tests/test_intake_contract.py tests/test_remote_submission.py
```

Result:
- 470 passed + 3 skipped (was 465 + 3 baseline pre-D19; +5 net after test reshape)
- ruff clean

## Links

Closes #100

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- D11b live smoke (`tborys/driftshield-meta#160`) can run after this PR merges, the D9+D19 reviewed change-set executes, and the new Intake Lambda image (carrying both D9 result handler and D19 unauthenticated POST handler) is live on `DriftShieldPhase3hTeamsStack`.
- After D11b green: `tborys/driftshield-meta#157` (Phase 3h parent) can close.
- Phase 3i: `tborys/driftshield-meta#199` (wire `to_visibility_payload` into `/v1/teams/*` read handlers).

## Why D7/D8 plumbing was removed, not deprecated

The D7/D8 surface (`--api-key`, `--installation-id`, `IntakeSubmissionRequest`-shaped client) was a stepping stone explicitly superseded by D19 per TeDe sign-off. Keeping it as deprecated dead code would leave two parallel client paths that would both need maintenance. Cleaner to delete now while only the CLI command + its tests reference it. Configs on disk are migrated automatically by `remote_enable`; no user-facing breakage.

## Production notes

- The intake URL configured by a D11b operator is the API Gateway URL for `POST /v1/oss/submissions` on the `DriftShieldPhase3hTeamsStack` HTTP API (`https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/oss/submissions`).
- `driftshield show-result <submission_id>` (added in `tborys/driftshield#101` / D9) uses the same `remote_intake_url` value and derives the GET path. URL-derivation already handles both `/v1/intake` and `/v1/oss/submissions` suffixes — no change needed for D19.