### PR TITLE
fix(db): convert 14 JSON columns to JSONB so local ingest doesn't crash

### DIFF
--- a/driftshield/src/driftshield/db/migrations/versions/20260516_03_json_to_jsonb_for_distinct_and_equality.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260516_03_json_to_jsonb_for_distinct_and_equality.py
@@ -1,0 +1,64 @@
+"""Convert all JSON columns to JSONB on Postgres.
+
+Revision ID: 20260516_03
+Revises: 20260512_02
+Create Date: 2026-05-16
+
+Postgres-native JSONB supports equality, DISTINCT, and GIN indexing.
+Bare JSON does not. The live behaviour-events SELECT DISTINCT query
+crashed against the auto-created and migrated schema because
+behaviour_event_subjects.metadata_json (and friends) shipped as JSON.
+
+Models now use `JSON().with_variant(JSONB(), 'postgresql')`. This
+migration brings the live Postgres schema in sync. On non-Postgres
+backends (SQLite tests, future SQLite fallback) this migration is
+a no-op because the columns are already generic JSON there.
+"""
+
+from alembic import op
+
+
+revision = "20260516_03"
+down_revision = "20260512_02"
+branch_labels = None
+depends_on = None
+
+
+_JSON_COLUMNS: list[tuple[str, str]] = [
+    ("sessions", "metadata_json"),
+    ("connectors", "metadata_json"),
+    ("decision_nodes", "inputs"),
+    ("decision_nodes", "outputs"),
+    ("decision_nodes", "metadata_json"),
+    ("decision_nodes", "risk_explanations"),
+    ("decision_nodes", "inflection_explanation"),
+    ("reports", "content_json"),
+    ("forensic_cases", "artifact_refs"),
+    ("forensic_cases", "review_refs"),
+    ("forensic_cases", "audit_refs"),
+    ("behaviour_event_subjects", "metadata_json"),
+    ("behaviour_events", "metadata_json"),
+    ("analyst_validations", "metadata_json"),
+]
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table, column in _JSON_COLUMNS:
+        op.execute(
+            f'ALTER TABLE {table} '
+            f'ALTER COLUMN {column} TYPE JSONB '
+            f'USING {column}::text::jsonb'
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table, column in _JSON_COLUMNS:
+        op.execute(
+            f'ALTER TABLE {table} '
+            f'ALTER COLUMN {column} TYPE JSON '
+            f'USING {column}::text::json'
+        )

--- a/driftshield/src/driftshield/db/models.py
+++ b/driftshield/src/driftshield/db/models.py
@@ -2,8 +2,16 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, JSON, String, Text
-from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+# Use Postgres JSONB on Postgres (supports DISTINCT, equality, GIN indexing)
+# and fall back to generic JSON elsewhere (SQLite for tests, future SQLite
+# fallback for first-run UX). Bare JSON on Postgres rejects equality
+# comparisons and breaks SELECT DISTINCT, which crashed live ingest on
+# behaviour_event_subjects (see driftshield#103-adjacent bug).
+JSON_FIELD = JSON().with_variant(JSONB(), "postgresql")
 
 
 class Base(DeclarativeBase):
@@ -29,7 +37,7 @@ class SessionModel(Base):
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     status: Mapped[str] = mapped_column(String, nullable=False)
-    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
     transcript_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     source_session_id: Mapped[str | None] = mapped_column(String, nullable=True)
     source_path: Mapped[str | None] = mapped_column(String, nullable=True)
@@ -55,7 +63,7 @@ class ConnectorModel(Base):
     consent_state: Mapped[str] = mapped_column(String, nullable=False, default="pending")
     status: Mapped[str] = mapped_column(String, nullable=False, default="proposed")
     watchable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
-    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
     last_scanned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_seen_activity_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -136,19 +144,19 @@ class DecisionNodeModel(Base):
     timestamp: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     event_type: Mapped[str] = mapped_column(String, nullable=False)
     action: Mapped[str | None] = mapped_column(String, nullable=True)
-    inputs: Mapped[dict | None] = mapped_column(JSON, nullable=True)
-    outputs: Mapped[dict | None] = mapped_column(JSON, nullable=True)
-    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    inputs: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
+    outputs: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
 
     assumption_mutation: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     policy_divergence: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     constraint_violation: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     context_contamination: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     coverage_gap: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
-    risk_explanations: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    risk_explanations: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
 
     is_inflection_node: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
-    inflection_explanation: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    inflection_explanation: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
 
 
 class ReportModel(Base):
@@ -163,7 +171,7 @@ class ReportModel(Base):
     generated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     report_type: Mapped[str] = mapped_column(String, nullable=False)
     content_markdown: Mapped[str | None] = mapped_column(Text, nullable=True)
-    content_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    content_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
     generated_by: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
@@ -184,9 +192,9 @@ class ForensicCaseModel(Base):
         PG_UUID(as_uuid=True), ForeignKey("reports.id"), nullable=True, index=True
     )
     state: Mapped[str] = mapped_column(String, nullable=False)
-    artifact_refs: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
-    review_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
-    audit_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    artifact_refs: Mapped[list[dict]] = mapped_column(JSON_FIELD, nullable=False, default=list)
+    review_refs: Mapped[list[str]] = mapped_column(JSON_FIELD, nullable=False, default=list)
+    audit_refs: Mapped[list[str]] = mapped_column(JSON_FIELD, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
@@ -206,7 +214,7 @@ class AnalystValidationModel(Base):
     confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
     reviewer: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
-    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
     shareable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
@@ -229,7 +237,7 @@ class BehaviourEventSubjectModel(Base):
     trust_band: Mapped[str] = mapped_column(String, nullable=False)
     surface: Mapped[str] = mapped_column(String, nullable=False)
     first_exposed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)
 
 
 class BehaviourEventModel(Base):
@@ -256,4 +264,4 @@ class BehaviourEventModel(Base):
     linked_session_id: Mapped[uuid.UUID | None] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey("sessions.id"), nullable=True
     )
-    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON_FIELD, nullable=True)


### PR DESCRIPTION
## Summary

Local OSS ingest of any real Claude Code session crashes today. This PR fixes the cause.

## Symptom (caught on a 2026-05-16 fresh install walkthrough)

```
psycopg2.errors.UndefinedFunction: could not identify an equality operator
for type json

SELECT DISTINCT behaviour_event_subjects.id, behaviour_event_subjects.session_id,
  behaviour_event_subjects.subject_type, ...
  behaviour_event_subjects.metadata_json
FROM behaviour_event_subjects JOIN behaviour_events
  ON behaviour_events.subject_id = behaviour_event_subjects.id
WHERE ...
```

The headline local-analysis feature is broken for any non-trivial session because the parser produces behaviour events, the ingest pipeline runs a `SELECT DISTINCT` over a `JSON` column, and Postgres rejects equality comparisons on bare `json`.

## Cause

`behaviour_event_subjects.metadata_json` (and 13 other columns across `sessions`, `decision_nodes`, `reports`, `forensic_cases`, `connectors`, `analyst_validations`, `behaviour_events`) were declared as generic SQLAlchemy `JSON`. On Postgres that renders as bare `json`, which:

- rejects equality comparisons
- rejects `SELECT DISTINCT`
- can't be indexed with GIN

`JSONB` supports all of the above natively.

## Fix

1. Introduce `JSON_FIELD = JSON().with_variant(JSONB(), "postgresql")` in `db/models.py`. Renders as `JSONB` on Postgres, falls back to generic `JSON` everywhere else (SQLite tests today, future SQLite fallback for first-run UX — see driftshield#103).
2. Convert all 14 affected columns to use `JSON_FIELD`.
3. Migration `20260516_03_json_to_jsonb_for_distinct_and_equality.py` runs `ALTER COLUMN ... TYPE JSONB USING ::text::jsonb` for each. No-op on non-Postgres dialects.

## Verification

- All 57 DB unit tests pass on SQLite (default test backend).
- Local ingest of two real Claude Code session JSONL files (18 events and 45 events respectively) against the migrated Postgres schema:
  - both POST `/api/ingest` returns `status=created`
  - both persist to the `sessions` table with correct event counts
  - both appear in `GET /api/sessions`
  - frontend dashboard at `http://localhost:5173` renders both sessions
- `information_schema.columns` shows 0 `json` columns post-migration; all 14 are now `jsonb`.

## Test plan

- [x] DB unit tests pass on SQLite (current default test backend)
- [x] Real Claude Code session ingests cleanly against Postgres with migration applied
- [x] Dashboard renders persisted sessions
- [ ] CI green on this PR

## Relates to

- Discovered during fresh-install walkthrough alongside `driftshield#103` (first-run Postgres crash) and `driftshield#104` (ChatGPT parser gap), and `driftshield-meta#204` (local vs cloud pipeline split).
- This is the second of three onboarding bugs caught tonight that block real OSS users from using the headline feature on a clean install.