### PR TITLE
chore(frontend): pin npm registry to npmjs.org

### DIFF
--- a/driftshield/frontend/.npmrc
+++ b/driftshield/frontend/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

Without this, `npm install` in `frontend/` fails on any machine configured against a corporate internal npm proxy. DriftShield's frontend deps live on the public npm registry. The standard fix is a repo-local `.npmrc` pinning `registry.npmjs.org`.

No-op for contributors who already use the public registry by default.

## Why this matters

This was the next blocker after `driftshield#105` (DB JSONB bug). With both fixes applied, a fresh DriftShield install on any laptop completes cleanly:

1. `pip install -e .`
2. Run migrations + `driftshield-api`
3. `cd frontend && npm install`
4. `npm run dev` + open `http://localhost:5173`

Without this PR, step 3 can fail for any contributor whose `npm` is pointed at a private registry that doesn't mirror the public one.

## Test plan

- [x] `npm install` succeeds in `frontend/` from a clean checkout.
- [x] Vite dev server starts at `http://localhost:5173`.