### PR TITLE
fix(redactor): walk nested dicts and drop sensitive keys (driftshield#107)

### DIFF
--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -26,6 +26,13 @@ from driftshield.intake_contract import (
 
 _DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
 
+# Nested keys that carry prompt/response text inside real session transcripts
+# (Claude Code events[].content, message.content, etc.). Stripped at every
+# depth alongside REQUIRED_REDACTION_FIELDS. Implementation-only: the public
+# redaction_manifest contract still advertises REQUIRED_REDACTION_FIELDS.
+_NESTED_SENSITIVE_KEYS: frozenset[str] = frozenset({"content", "text"})
+_REDACTED_KEYS: frozenset[str] = REQUIRED_REDACTION_FIELDS | _NESTED_SENSITIVE_KEYS
+
 
 @dataclass(frozen=True, slots=True)
 class OssRemoteSubmissionConfig:
@@ -38,15 +45,29 @@ class RemoteSubmissionError(RuntimeError):
     """Raised when the remote submission cannot be assembled or accepted."""
 
 
-def redact_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
-    """Strip required-redaction fields from the top level of the payload.
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _redact_value(v) for k, v in value.items() if k not in _REDACTED_KEYS}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    return value
 
-    Returns (redacted_payload, redacted_fields). The manifest must always
-    advertise the full REQUIRED_REDACTION_FIELDS superset, even if the input
-    payload did not carry one of them, so the intake validator
-    (incomplete_redaction_manifest) is satisfied without lying about it.
+
+def redact_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Recursively strip sensitive keys from the payload.
+
+    Drops REQUIRED_REDACTION_FIELDS plus nested prompt/response-bearing keys
+    (`content`, `text`) at every depth. Real Claude Code session JSON keeps
+    prompts and responses inside events[].content, message.content and similar
+    nested structures, which top-level-only redaction missed (driftshield#107).
+
+    Returns (redacted_payload, redacted_fields). The manifest always advertises
+    the full REQUIRED_REDACTION_FIELDS superset so the intake validator
+    (incomplete_redaction_manifest) is satisfied without lying about it. The
+    nested key set is implementation-only and intentionally not advertised
+    on the public contract.
     """
-    redacted = {k: v for k, v in payload.items() if k not in REQUIRED_REDACTION_FIELDS}
+    redacted = _redact_value(payload)
     return redacted, sorted(REQUIRED_REDACTION_FIELDS)
 
 

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -50,6 +50,125 @@ def test_redact_payload_strips_required_fields():
     assert set(redacted_fields) == REQUIRED_REDACTION_FIELDS
 
 
+def test_redact_payload_strips_nested_content_and_text_keys():
+    payload = {
+        "session_id": "sess-1",
+        "events": [
+            {"type": "user", "content": "MY SECRET PROMPT", "ts": 1},
+            {"type": "assistant", "text": "MY SECRET RESPONSE", "ts": 2},
+        ],
+    }
+
+    redacted, _ = redact_payload(payload)
+
+    serialised = json.dumps(redacted)
+    assert "MY SECRET PROMPT" not in serialised
+    assert "MY SECRET RESPONSE" not in serialised
+    assert redacted["session_id"] == "sess-1"
+    assert [e["type"] for e in redacted["events"]] == ["user", "assistant"]
+    assert [e["ts"] for e in redacted["events"]] == [1, 2]
+    for event in redacted["events"]:
+        assert "content" not in event
+        assert "text" not in event
+
+
+def test_redact_payload_strips_deeply_nested_sensitive_keys():
+    payload = {
+        "level_1": {
+            "level_2": {
+                "level_3": {
+                    "level_4": {
+                        "content": "DEEP_SECRET",
+                        "keep": "safe_value",
+                    }
+                }
+            }
+        }
+    }
+
+    redacted, _ = redact_payload(payload)
+
+    assert "DEEP_SECRET" not in json.dumps(redacted)
+    assert redacted["level_1"]["level_2"]["level_3"]["level_4"] == {"keep": "safe_value"}
+
+
+def test_redact_payload_removes_claude_code_prompt_response_strings():
+    """Realistic Claude Code session shape: events[].content carries prompts/responses."""
+    payload = {
+        "session_id": "claude-sess-abc",
+        "events": [
+            {
+                "type": "user",
+                "content": "Please refactor the auth middleware to use JWT",
+                "timestamp": "2026-05-17T10:00:00Z",
+            },
+            {
+                "type": "assistant",
+                "content": "Here's the refactored middleware with JWT validation...",
+                "timestamp": "2026-05-17T10:00:05Z",
+                "tool_calls": [
+                    {"name": "edit", "arguments": {"file": "/src/auth.py"}},
+                ],
+            },
+        ],
+        "metadata": {"model": "claude-opus-4-7"},
+    }
+
+    redacted, _ = redact_payload(payload)
+    serialised = json.dumps(redacted)
+
+    assert "Please refactor the auth middleware to use JWT" not in serialised
+    assert "Here's the refactored middleware with JWT validation..." not in serialised
+    assert redacted["session_id"] == "claude-sess-abc"
+    assert redacted["metadata"] == {"model": "claude-opus-4-7"}
+    assert [e["type"] for e in redacted["events"]] == ["user", "assistant"]
+
+
+def test_redact_payload_handles_none_and_empty_values():
+    payload = {
+        "session_id": "sess-1",
+        "empty_dict": {},
+        "empty_list": [],
+        "none_value": None,
+        "events": [],
+    }
+
+    redacted, _ = redact_payload(payload)
+
+    assert redacted == payload
+
+
+def test_build_oss_submission_request_redacts_nested_content_before_manifest():
+    """The envelope-building path must redact nested content before the manifest is built."""
+    payload = {
+        "session_id": "sess-1",
+        "events": [
+            {"type": "user", "content": "LEAK_CANARY_PROMPT"},
+            {"type": "assistant", "content": "LEAK_CANARY_RESPONSE"},
+        ],
+    }
+
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload=payload,
+    )
+
+    serialised = request.envelope.model_dump_json()
+    assert "LEAK_CANARY_PROMPT" not in serialised
+    assert "LEAK_CANARY_RESPONSE" not in serialised
+    # Public manifest contract is unchanged: still advertises REQUIRED_REDACTION_FIELDS.
+    assert set(request.envelope.redaction_manifest.redacted_fields) == REQUIRED_REDACTION_FIELDS
+    assert request.envelope.redaction_manifest.redaction_applied is True
+    # payload_size_bytes must reflect the redacted payload, not the original.
+    expected_bytes = json.dumps(
+        request.envelope.payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    assert request.envelope.payload_size_bytes == len(expected_bytes)
+
+
 def test_redact_payload_manifest_advertises_superset_even_if_missing():
     payload = {"session_id": "sess-1", "metadata": {"foo": "bar"}}
 


### PR DESCRIPTION
## Summary

`redact_payload()` now walks dicts and lists recursively, dropping `prompts` / `responses` / `user_identifiers` and the nested transcript keys `content` / `text` at every depth. Real Claude Code session JSON keeps prompt/response text inside `events[].content`, which top-level-only redaction missed, defeating the `redaction_applied: true` claim.

Closes #107.

## Spec

- Issue: https://github.com/tborys/driftshield/issues/107
- Authoritative spec comment by reviewer agent (2026-05-17): https://github.com/tborys/driftshield/issues/107#issuecomment-4472569503
- Parent meta-issue: tborys/driftshield-meta#215 (recursive redactor hard gate, this PR is Iteration 1)

## Changes

- `src/driftshield/remote_submission.py`
  - Added `_NESTED_SENSITIVE_KEYS = {"content", "text"}` (implementation-only, kept off the public manifest contract).
  - Added `_redact_value()` recursive walker over dicts and lists; primitives and `None` pass through unchanged.
  - `redact_payload()` now uses the recursive walker and still returns `sorted(REQUIRED_REDACTION_FIELDS)` as the advertised contract.
  - Public `redacted_fields` contract is unchanged (still 3 items). The widened key set is internal.

## Tests

- `tests/test_remote_submission.py:test_redact_payload_strips_nested_content_and_text_keys`, pins nested `content`/`text` are dropped while sibling metadata (`type`, `ts`) survives.
- `tests/test_remote_submission.py:test_redact_payload_strips_deeply_nested_sensitive_keys`, 4-level nesting, confirms `content` is stripped at depth 4.
- `tests/test_remote_submission.py:test_redact_payload_removes_claude_code_prompt_response_strings`, realistic Claude Code shape, asserts original prompt/response strings do not appear in `json.dumps()` of the redacted output.
- `tests/test_remote_submission.py:test_redact_payload_handles_none_and_empty_values`, `None`, empty dicts, empty lists pass through unchanged.
- `tests/test_remote_submission.py:test_build_oss_submission_request_redacts_nested_content_before_manifest`, envelope-building path serialisation has no canary strings, `redacted_fields` still equals `REQUIRED_REDACTION_FIELDS`, `payload_size_bytes` matches the redacted-payload encoding.

Existing tests (`test_redact_payload_strips_required_fields`, `test_redact_payload_manifest_advertises_superset_even_if_missing`, `test_build_oss_submission_request_phase3f_v1_shape`, etc.) continue to pass unchanged.

## Verification

- `uv run --extra dev pytest tests/test_remote_submission.py -q` → 14 passed
- `uv run --extra dev pytest tests/ -q` → 475 passed, 3 skipped (no regressions)
- `uv run --extra dev ruff check src/driftshield/remote_submission.py tests/test_remote_submission.py` → clean

## Deviation from spec

None. Stayed strictly inside the spec comment's scope:
- only the two nested key families `content` and `text` (did not silently widen to `message`, `value`, `input`, `output`).
- no server-side validation, no contract bump, no manifest schema widening, those stay under meta#215.

## Test plan

- [x] Unit tests green locally
- [x] CI green on PR
- [x] Reviewer agent review verdict