### PR TITLE
feat(redactor): recursive v2 with tool-IO, regex secrets, path-shape, corpus, CLI flags

### DIFF
--- a/driftshield/docs/redactor-v2.md
+++ b/driftshield/docs/redactor-v2.md
@@ -61,17 +61,16 @@ The redactor does not touch:
 - Non-sensitive structural keys: `events[].type`, `events[].ts`, `tool_use[].name`, `messages[].role`, IDs that do not contain PII.
 - Free-text strings that match none of the regex categories above. Free-text content not under a redacted key is passed through verbatim.
 
-Server-side coverage for free-text content with leaked secrets that escaped the
-client redactor is the job of the intake backstop scanner
-(driftshield-intel#131), not the client.
+Server-side coverage for free-text content with leaked secrets that escaped
+the client redactor is the job of the server-side intake backstop scanner,
+not the client.
 
 ## Public manifest claim
 
 The redaction manifest accompanying every envelope advertises only the v1
 public superset (`prompts`, `responses`, `user_identifiers`). The v2 internal
 ruleset is implementation-only and intentionally not surfaced on the public
-contract. A future contract bump
-(driftshield-intel#132, `redaction-manifest.v2`) will add
+contract. A future `redaction-manifest.v2` contract bump will add
 `redactor_version` and `redaction_ruleset_version` fields so server-side can
 identify which redactor produced a given payload.
 

--- a/driftshield/docs/redactor-v2.md
+++ b/driftshield/docs/redactor-v2.md
@@ -1,0 +1,119 @@
+# Recursive redactor v2
+
+The OSS submission lane runs every payload through a recursive redactor before
+posting to the intake API. Redactor v2 (driftshield#109) replaces the v1
+field-name-only rule set with a depth-walking ruleset that covers tool-call
+shapes, embedded secrets, and identifying paths.
+
+## What gets redacted
+
+The redactor applies the following rules to every value at every depth.
+
+### Dropped keys
+
+The following keys are removed from any object, regardless of depth, before
+the rest of the rules run.
+
+| Key | Behaviour |
+|-----|-----------|
+| `prompts`, `responses`, `user_identifiers` | Dropped. Public manifest claim. |
+| `content`, `text` | Dropped. Nested prompt/response carriers in real session shapes. |
+
+### Tool-IO keys (value replaced with placeholder)
+
+Tool-call payloads are kept structurally intact so downstream analysers can
+still see the shape of the call. The value at any of these keys is replaced
+with `<REDACTED:tool_io:<hash>>` rather than dropped entirely.
+
+| Key | Reason |
+|-----|--------|
+| `arguments`, `input`, `parameters` | Tool-call inputs may contain user data, file contents, credentials. |
+| `result`, `output`, `tool_output`, `function_result` | Tool-call results may contain returned data, error traces, file contents. |
+| `file_content` | Raw file contents that should never reach the intake. |
+| `tool_input`, `function_args` | Tool-call inputs across frameworks. |
+
+### Regex-detected secrets (replaced inline in any string)
+
+The following high-confidence patterns are detected in any string value at
+any depth and replaced with `<REDACTED:<category>:<hash>>` placeholders.
+
+| Category | Pattern shape |
+|----------|---------------|
+| `aws_access_key` | `AKIA[0-9A-Z]{16}` |
+| `github_pat` | `ghp_[A-Za-z0-9]{36}` |
+| `openai_key` | `sk-[A-Za-z0-9]{20,}` |
+| `jwt` | `eyJ...payload...signature` |
+| `ssn` | `\d{3}-\d{2}-\d{4}` |
+| `credit_card` | 13-19 digits, Luhn-validated only |
+
+### Identifying strings (replaced inline)
+
+| Category | Pattern shape |
+|----------|---------------|
+| `home_path` | `/Users/<username>`, `/home/<username>`, `C:\Users\<username>` |
+| `email` | RFC-5322-light email regex |
+
+## What does NOT get redacted
+
+The redactor does not touch:
+
+- Envelope metadata: `source_system`, `source_session_id`, `workflow_reference`, `project_reference`, `schema_version`, timestamps.
+- Non-sensitive structural keys: `events[].type`, `events[].ts`, `tool_use[].name`, `messages[].role`, IDs that do not contain PII.
+- Free-text strings that match none of the regex categories above. Free-text content not under a redacted key is passed through verbatim.
+
+Server-side coverage for free-text content with leaked secrets that escaped the
+client redactor is the job of the intake backstop scanner
+(driftshield-intel#131), not the client.
+
+## Public manifest claim
+
+The redaction manifest accompanying every envelope advertises only the v1
+public superset (`prompts`, `responses`, `user_identifiers`). The v2 internal
+ruleset is implementation-only and intentionally not surfaced on the public
+contract. A future contract bump
+(driftshield-intel#132, `redaction-manifest.v2`) will add
+`redactor_version` and `redaction_ruleset_version` fields so server-side can
+identify which redactor produced a given payload.
+
+The redactor pins both values as module-level constants:
+
+```python
+REDACTOR_VERSION = "recursive-redactor.v2.0.0"
+REDACTION_RULESET_VERSION = "ruleset.v1"
+```
+
+## CLI inspection
+
+Two flags on `driftshield telemetry submit-session` let you inspect the
+redactor's behaviour without submitting:
+
+```sh
+# Print the structured list of redaction entries that would apply.
+driftshield telemetry submit-session --path session.json --dry-run-redaction
+
+# Print the manifest that would accompany the submission.
+driftshield telemetry submit-session --path session.json --show-manifest
+```
+
+Both flags exit 0 without posting to the intake URL.
+
+## Unknown shapes
+
+The redactor was designed against six known transcript shapes: Claude Code,
+Claude Desktop, Codex, OpenAI Chat Completions, LangChain, CrewAI, plus a
+`generic_session` fallback keyed on a top-level `session_id` field. A payload
+whose top-level shape matches none of these is refused with
+`UnknownTranscriptShapeError`.
+
+Override the refusal with `--force-unknown-shape` only if you have manually
+verified that the redactor's rule set covers every sensitive position in your
+payload. Silent under-redaction on unrecognised shapes is the failure mode
+this gate exists to prevent.
+
+## Adding new rules
+
+Future phases will likely add categories. Each new rule belongs in
+`src/driftshield/recursive_redactor.py` as a precompiled regex (or, for
+field-name rules, a frozenset entry) and a corresponding unit test in
+`tests/test_recursive_redactor.py`. Bump `REDACTION_RULESET_VERSION` whenever
+the public detection surface changes.

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -11,8 +11,11 @@ from rich.console import Console
 from driftshield.remote_submission import (
     OssRemoteSubmissionConfig,
     RemoteSubmissionError,
+    UnknownTranscriptShapeError,
     build_oss_submission_request,
+    detect_shape,
     post_oss_submission,
+    redact_payload_with_manifest,
 )
 from driftshield.telemetry import TelemetryService, validate_outcome_status
 
@@ -99,6 +102,21 @@ def telemetry_submit_session(
     source_report_id: str | None = typer.Option(
         None, "--source-report-id", help="Optional source report identifier."
     ),
+    dry_run_redaction: bool = typer.Option(
+        False,
+        "--dry-run-redaction",
+        help="Run the recursive redactor, print the redaction entries, exit without submitting.",
+    ),
+    show_manifest: bool = typer.Option(
+        False,
+        "--show-manifest",
+        help="Print the redaction manifest that would accompany the submission, exit without submitting.",
+    ),
+    force_unknown_shape: bool = typer.Option(
+        False,
+        "--force-unknown-shape",
+        help="Submit even if the transcript top-level shape is not recognised by the redactor.",
+    ),
 ) -> None:
     """Build a phase3f.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
 
@@ -106,14 +124,6 @@ def telemetry_submit_session(
     or consent_state is included in the request. The server binds the persisted row
     to the in-stack OSS fallback installation + consent.
     """
-    config = TelemetryService().load_config()
-    if not config.remote_intake_url:
-        console.print(
-            "[red]Error:[/red] Remote submission is not configured. "
-            "Run `driftshield telemetry remote-enable --intake-url URL` first."
-        )
-        raise typer.Exit(1)
-
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -128,13 +138,62 @@ def telemetry_submit_session(
         console.print("[red]Error:[/red] Session file must contain a JSON object at top level.")
         raise typer.Exit(1)
 
-    submission = build_oss_submission_request(
-        source_session_id=source_session_id or path.stem,
-        payload=payload,
-        workflow_reference=workflow_reference,
-        project_reference=project_reference,
-        source_report_id=source_report_id,
-    )
+    if dry_run_redaction or show_manifest:
+        result = redact_payload_with_manifest(payload)
+        shape = detect_shape(payload) or "unknown"
+        if dry_run_redaction:
+            entries = [
+                {
+                    "path": entry.path,
+                    "category": entry.category,
+                    "sample_hash": entry.sample_hash,
+                }
+                for entry in result.entries
+            ]
+            typer.echo(
+                json.dumps(
+                    {"detected_shape": shape, "entries": entries},
+                    indent=2,
+                )
+            )
+        if show_manifest:
+            typer.echo(
+                json.dumps(
+                    {
+                        "manifest_version": "redaction-manifest.v1",
+                        "redaction_applied": True,
+                        "redacted_fields": sorted(["prompts", "responses", "user_identifiers"]),
+                        "detected_shape": shape,
+                        "ruleset_entry_count": len(result.entries),
+                    },
+                    indent=2,
+                )
+            )
+        return
+
+    config = TelemetryService().load_config()
+    if not config.remote_intake_url:
+        console.print(
+            "[red]Error:[/red] Remote submission is not configured. "
+            "Run `driftshield telemetry remote-enable --intake-url URL` first."
+        )
+        raise typer.Exit(1)
+
+    try:
+        submission = build_oss_submission_request(
+            source_session_id=source_session_id or path.stem,
+            payload=payload,
+            workflow_reference=workflow_reference,
+            project_reference=project_reference,
+            source_report_id=source_report_id,
+            force_unknown_shape=force_unknown_shape,
+        )
+    except UnknownTranscriptShapeError as exc:
+        console.print(
+            f"[red]Error:[/red] {exc} "
+            "Inspect the payload with --dry-run-redaction first."
+        )
+        raise typer.Exit(1) from exc
 
     submission_config = OssRemoteSubmissionConfig(intake_url=config.remote_intake_url)
     try:

--- a/driftshield/src/driftshield/recursive_redactor.py
+++ b/driftshield/src/driftshield/recursive_redactor.py
@@ -1,0 +1,180 @@
+"""Recursive redactor v2 for OSS submission payloads.
+
+driftshield#109 hard-gate scope. Extends the v1 redactor (driftshield#107,
+remote_submission.redact_payload) which only drops the top-level
+REQUIRED_REDACTION_FIELDS plus nested ``content`` / ``text`` keys.
+
+What v2 adds:
+
+* tool-IO key-value redaction at any depth (``arguments``, ``input``,
+  ``parameters``, ``result``, ``output``, ``file_content``, ``tool_input``,
+  ``tool_output``, ``function_args``, ``function_result``)
+* regex-based secret patterns in any string value (AWS access key, GitHub PAT,
+  OpenAI key, JWT, SSN, Luhn-validated credit card)
+* path-shape detection (``/Users/...``, ``/home/...``, ``C:\\Users\\...``)
+* free-text email replacement
+
+The public envelope contract continues to advertise the v1 manifest claim
+(``REQUIRED_REDACTION_FIELDS``). The internal rule set is implementation-only
+and intentionally not surfaced on the manifest. A future contract bump
+(driftshield-intel#132) will add ``redactor_version`` and
+``redaction_ruleset_version`` provenance fields.
+
+Tool-IO values are replaced (not deleted) with a stable hash placeholder so
+downstream analysers can keep their structural assumptions about tool-call
+shapes. Pure prompt/response keys (``content``, ``text``) still delete to
+match v1 behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import sha256
+import re
+from typing import Any
+
+from driftshield.intake_contract import REQUIRED_REDACTION_FIELDS
+
+
+REDACTOR_VERSION = "recursive-redactor.v2.0.0"
+REDACTION_RULESET_VERSION = "ruleset.v1"
+
+_TOOL_IO_KEYS: frozenset[str] = frozenset(
+    {
+        "arguments",
+        "input",
+        "parameters",
+        "result",
+        "output",
+        "file_content",
+        "tool_input",
+        "tool_output",
+        "function_args",
+        "function_result",
+    }
+)
+
+_PROMPT_RESPONSE_KEYS: frozenset[str] = frozenset({"content", "text"})
+
+_DROPPED_KEYS: frozenset[str] = REQUIRED_REDACTION_FIELDS | _PROMPT_RESPONSE_KEYS
+
+
+_AWS_ACCESS_KEY = re.compile(r"AKIA[0-9A-Z]{16}")
+_GITHUB_PAT = re.compile(r"ghp_[A-Za-z0-9]{36}")
+_OPENAI_KEY = re.compile(r"sk-[A-Za-z0-9]{20,}")
+_JWT = re.compile(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+_SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+_CARD_CANDIDATE = re.compile(r"\b\d{13,19}\b")
+_HOME_PATH_UNIX = re.compile(r"/(?:Users|home)/[A-Za-z0-9_.-]+")
+_HOME_PATH_WIN = re.compile(r"C:\\Users\\[A-Za-z0-9_.-]+", re.IGNORECASE)
+_EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+@dataclass(slots=True)
+class RedactionEntry:
+    path: str
+    category: str
+    sample_hash: str
+
+
+@dataclass(slots=True)
+class RedactionResult:
+    payload: Any
+    entries: list[RedactionEntry] = field(default_factory=list)
+
+
+def _stable_hash(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _placeholder(category: str, value: str) -> str:
+    return f"<REDACTED:{category}:{_stable_hash(value)}>"
+
+
+def _luhn_valid(digits: str) -> bool:
+    total = 0
+    parity = len(digits) % 2
+    for index, char in enumerate(digits):
+        digit = int(char)
+        if index % 2 == parity:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def _redact_string(value: str, path: str, entries: list[RedactionEntry]) -> str:
+    def record(category: str, matched: str) -> str:
+        entries.append(
+            RedactionEntry(path=path, category=category, sample_hash=_stable_hash(matched))
+        )
+        return _placeholder(category, matched)
+
+    def _sub_card(match: re.Match[str]) -> str:
+        raw = match.group(0)
+        if _luhn_valid(raw):
+            return record("credit_card", raw)
+        return raw
+
+    value = _AWS_ACCESS_KEY.sub(lambda m: record("aws_access_key", m.group(0)), value)
+    value = _GITHUB_PAT.sub(lambda m: record("github_pat", m.group(0)), value)
+    value = _OPENAI_KEY.sub(lambda m: record("openai_key", m.group(0)), value)
+    value = _JWT.sub(lambda m: record("jwt", m.group(0)), value)
+    value = _SSN.sub(lambda m: record("ssn", m.group(0)), value)
+    value = _CARD_CANDIDATE.sub(_sub_card, value)
+    value = _HOME_PATH_UNIX.sub(lambda m: record("home_path", m.group(0)), value)
+    value = _HOME_PATH_WIN.sub(lambda m: record("home_path", m.group(0)), value)
+    value = _EMAIL.sub(lambda m: record("email", m.group(0)), value)
+    return value
+
+
+def _redact_value(value: Any, path: str, entries: list[RedactionEntry]) -> Any:
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            child_path = f"{path}.{key}" if path else key
+            if key in _DROPPED_KEYS:
+                entries.append(
+                    RedactionEntry(
+                        path=child_path,
+                        category="dropped_key",
+                        sample_hash=_stable_hash(repr(item)),
+                    )
+                )
+                continue
+            if key in _TOOL_IO_KEYS:
+                serialised = repr(item)
+                entries.append(
+                    RedactionEntry(
+                        path=child_path,
+                        category="tool_io",
+                        sample_hash=_stable_hash(serialised),
+                    )
+                )
+                result[key] = _placeholder("tool_io", serialised)
+                continue
+            result[key] = _redact_value(item, child_path, entries)
+        return result
+    if isinstance(value, list):
+        return [
+            _redact_value(item, f"{path}[{index}]", entries)
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, str):
+        return _redact_string(value, path, entries)
+    return value
+
+
+def redact(payload: dict[str, Any]) -> RedactionResult:
+    """Recursively redact ``payload`` and return the rewritten copy plus entries.
+
+    The public manifest claim (REQUIRED_REDACTION_FIELDS) stays accurate: the
+    top-level redacted field set always advertises those three. The detailed
+    entries list captures every match the recursive ruleset made and is
+    intended for ``--show-manifest`` / ``--dry-run-redaction`` output and for
+    audit-trail consumers.
+    """
+    entries: list[RedactionEntry] = []
+    redacted_payload = _redact_value(payload, "", entries)
+    return RedactionResult(payload=redacted_payload, entries=entries)

--- a/driftshield/src/driftshield/recursive_redactor.py
+++ b/driftshield/src/driftshield/recursive_redactor.py
@@ -17,8 +17,8 @@ What v2 adds:
 The public envelope contract continues to advertise the v1 manifest claim
 (``REQUIRED_REDACTION_FIELDS``). The internal rule set is implementation-only
 and intentionally not surfaced on the manifest. A future contract bump
-(driftshield-intel#132) will add ``redactor_version`` and
-``redaction_ruleset_version`` provenance fields.
+will add ``redactor_version`` and ``redaction_ruleset_version`` provenance
+fields; this module pins both values as constants in anticipation.
 
 Tool-IO values are replaced (not deleted) with a stable hash placeholder so
 downstream analysers can keep their structural assumptions about tool-call

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -4,6 +4,12 @@ Per Phase 3h D19 (operator decision 2026-05-16): OSS submissions go on a
 dedicated unauthenticated lane. No installation_id, no api_key header, no
 consent_state echo. The server binds the persisted row to the in-stack OSS
 fallback installation + consent.
+
+Phase 3i (driftshield#109) replaces the v1 field-name-only redactor with a
+recursive ruleset implemented in :mod:`driftshield.recursive_redactor`. The
+public manifest contract still advertises ``REQUIRED_REDACTION_FIELDS``; the
+internal v2 ruleset (tool-IO keys, regex secrets, path-shape, email) is
+implementation-only.
 """
 
 from __future__ import annotations
@@ -22,16 +28,35 @@ from driftshield.intake_contract import (
     RedactionManifest,
     SubmissionEnvelope,
 )
+from driftshield.recursive_redactor import (
+    REDACTION_RULESET_VERSION,
+    REDACTOR_VERSION,
+    RedactionResult,
+    redact,
+)
 
 
 _DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
 
-# Nested keys that carry prompt/response text inside real session transcripts
-# (Claude Code events[].content, message.content, etc.). Stripped at every
-# depth alongside REQUIRED_REDACTION_FIELDS. Implementation-only: the public
-# redaction_manifest contract still advertises REQUIRED_REDACTION_FIELDS.
-_NESTED_SENSITIVE_KEYS: frozenset[str] = frozenset({"content", "text"})
-_REDACTED_KEYS: frozenset[str] = REQUIRED_REDACTION_FIELDS | _NESTED_SENSITIVE_KEYS
+
+_KNOWN_SHAPE_HINTS: dict[str, frozenset[str]] = {
+    "claude_code": frozenset({"events"}),
+    "claude_desktop": frozenset({"conversation", "messages"}),
+    "codex": frozenset({"session", "turns"}),
+    "openai_chat": frozenset({"choices", "model"}),
+    "langchain": frozenset({"runs", "trace"}),
+    "crewai": frozenset({"crew", "tasks"}),
+    "generic_session": frozenset({"session_id"}),
+}
+
+
+class UnknownTranscriptShapeError(ValueError):
+    """Raised when the input transcript does not match a known shape.
+
+    Silent under-redaction on unrecognised shapes is the failure mode
+    driftshield#109 exists to close. The caller must either map the payload
+    into a known shape or pass ``force_unknown_shape=True`` to override.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,30 +70,46 @@ class RemoteSubmissionError(RuntimeError):
     """Raised when the remote submission cannot be assembled or accepted."""
 
 
-def _redact_value(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {k: _redact_value(v) for k, v in value.items() if k not in _REDACTED_KEYS}
-    if isinstance(value, list):
-        return [_redact_value(item) for item in value]
-    return value
+def detect_shape(payload: dict[str, Any]) -> str | None:
+    """Return the matching known-shape name or ``None`` if unrecognised.
+
+    Detection is best-effort and heuristic. It exists so the CLI can refuse
+    to submit payloads the recursive redactor was not designed against,
+    rather than silently under-redacting them.
+    """
+    if not isinstance(payload, dict):
+        return None
+    keys = set(payload.keys())
+    for shape, required in _KNOWN_SHAPE_HINTS.items():
+        if required.issubset(keys):
+            return shape
+    return None
+
+
+def redact_payload_with_manifest(payload: dict[str, Any]) -> RedactionResult:
+    """Recursive redaction returning the rewritten payload + redaction entries.
+
+    Consumed by ``--show-manifest`` and ``--dry-run-redaction`` in the CLI so
+    callers can inspect what the redactor stripped without submitting.
+    """
+    return redact(payload)
 
 
 def redact_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
-    """Recursively strip sensitive keys from the payload.
+    """Recursively strip sensitive content from the payload.
 
-    Drops REQUIRED_REDACTION_FIELDS plus nested prompt/response-bearing keys
-    (`content`, `text`) at every depth. Real Claude Code session JSON keeps
-    prompts and responses inside events[].content, message.content and similar
-    nested structures, which top-level-only redaction missed (driftshield#107).
-
-    Returns (redacted_payload, redacted_fields). The manifest always advertises
-    the full REQUIRED_REDACTION_FIELDS superset so the intake validator
-    (incomplete_redaction_manifest) is satisfied without lying about it. The
-    nested key set is implementation-only and intentionally not advertised
-    on the public contract.
+    Returns ``(redacted_payload, redacted_fields)``. The advertised
+    ``redacted_fields`` list is the public ``REQUIRED_REDACTION_FIELDS``
+    superset so the intel-side validator (``incomplete_redaction_manifest``)
+    stays satisfied. The deeper v2 ruleset is implementation-only.
     """
-    redacted = _redact_value(payload)
-    return redacted, sorted(REQUIRED_REDACTION_FIELDS)
+    result = redact_payload_with_manifest(payload)
+    redacted_payload = result.payload
+    if not isinstance(redacted_payload, dict):
+        raise RemoteSubmissionError(
+            "redacted payload must remain a JSON object at top level"
+        )
+    return redacted_payload, sorted(REQUIRED_REDACTION_FIELDS)
 
 
 def _encode_payload(payload: dict[str, Any]) -> tuple[bytes, int]:
@@ -89,13 +130,28 @@ def build_oss_submission_request(
     workflow_reference: str | None = None,
     project_reference: str | None = None,
     source_report_id: str | None = None,
+    force_unknown_shape: bool = False,
 ) -> OssSubmissionRequest:
     """Build an unauthenticated OSS submission request.
+
+    ``force_unknown_shape`` defaults to False. The recursive redactor was
+    designed against the six known transcript shapes listed in
+    :data:`_KNOWN_SHAPE_HINTS`; an unrecognised top-level shape raises
+    :class:`UnknownTranscriptShapeError` unless the caller passes
+    ``force_unknown_shape=True``.
 
     No installation_id, no consent_state. The envelope still carries
     redaction_manifest + payload_size_bytes + schema_version, all enforced
     server-side by OssSubmissionService.
     """
+    shape = detect_shape(payload)
+    if shape is None and not force_unknown_shape:
+        raise UnknownTranscriptShapeError(
+            "Unrecognised transcript shape. Map the payload into a known "
+            "shape or pass force_unknown_shape=True (CLI: "
+            "--force-unknown-shape) to override."
+        )
+
     redacted_payload, redacted_fields = redact_payload(payload)
     _, payload_size = _encode_payload(redacted_payload)
 
@@ -156,3 +212,17 @@ def post_oss_submission(
     except json.JSONDecodeError as exc:
         raise RemoteSubmissionError(f"intake returned non-JSON body: {raw!r}") from exc
     return IntakeSubmissionResponse.model_validate(decoded)
+
+
+__all__ = [
+    "REDACTION_RULESET_VERSION",
+    "REDACTOR_VERSION",
+    "OssRemoteSubmissionConfig",
+    "RemoteSubmissionError",
+    "UnknownTranscriptShapeError",
+    "build_oss_submission_request",
+    "detect_shape",
+    "post_oss_submission",
+    "redact_payload",
+    "redact_payload_with_manifest",
+]

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -384,6 +384,114 @@ def test_submit_session_fails_on_non_object_json(tmp_path, monkeypatch):
     assert "json object" in result.stdout.lower()
 
 
+def test_submit_session_dry_run_redaction_prints_entries_and_does_not_submit(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path,
+        {
+            "session_id": "sess-1",
+            "events": [{"type": "user", "note": "ssn 123-45-6789"}],
+        },
+    )
+    called = {"posted": False}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        called["posted"] = True
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--dry-run-redaction"],
+    )
+
+    assert result.exit_code == 0
+    assert called["posted"] is False
+    body = json.loads(result.stdout)
+    assert body["detected_shape"] == "claude_code"
+    assert any(entry["category"] == "ssn" for entry in body["entries"])
+
+
+def test_submit_session_show_manifest_prints_manifest_and_does_not_submit(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path,
+        {"session_id": "sess-1", "events": []},
+    )
+    called = {"posted": False}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        called["posted"] = True
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--show-manifest"],
+    )
+
+    assert result.exit_code == 0
+    assert called["posted"] is False
+    manifest = json.loads(result.stdout)
+    assert manifest["manifest_version"] == "redaction-manifest.v1"
+    assert manifest["redaction_applied"] is True
+    assert sorted(manifest["redacted_fields"]) == sorted(
+        ["prompts", "responses", "user_identifiers"]
+    )
+
+
+def test_submit_session_refuses_unknown_shape_without_force(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"unrelated_top_key": True})
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 1
+    assert "shape" in result.stdout.lower()
+
+
+def test_submit_session_accepts_unknown_shape_when_forced(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"unrelated_top_key": True})
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        from driftshield.intake_contract import IntakeSubmissionResponse
+
+        return IntakeSubmissionResponse(submission_id="sub_forced", processing_status="received")
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--force-unknown-shape",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "sub_forced" in result.stdout
+
+
 def test_submit_session_surfaces_remote_error(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     runner.invoke(app, _remote_enable_argv())

--- a/driftshield/tests/fixtures/redactor_corpus/__init__.py
+++ b/driftshield/tests/fixtures/redactor_corpus/__init__.py
@@ -1,0 +1,14 @@
+"""Corpus of synthetic transcript fixtures used by the recursive-redactor tests.
+
+Each JSON file seeds ``DRIFTSHIELD_REDACTION_CANARY_<token>`` markers at every
+nesting depth the shape allows: prompt text, response text, tool input, tool
+output, file path, secret-style strings, and user identifier positions.
+
+Synthetic neutral names only. Never include real customer, employer, prospect,
+or partner names. Placeholder vocabulary:
+
+* ``ExampleCorp``, ``Acme Workspace``
+* ``user@example.test``, ``alice@example.test``
+* ``/home/example-user/``
+* ``DRIFTSHIELD_REDACTION_CANARY_*``
+"""

--- a/driftshield/tests/fixtures/redactor_corpus/claude_code.json
+++ b/driftshield/tests/fixtures/redactor_corpus/claude_code.json
@@ -1,0 +1,49 @@
+{
+  "session_id": "claude-code-sess-001",
+  "events": [
+    {
+      "type": "user",
+      "ts": 1700000000,
+      "content": "DRIFTSHIELD_REDACTION_CANARY_PROMPT_TOP read /home/example-user/secrets.txt"
+    },
+    {
+      "type": "assistant",
+      "ts": 1700000001,
+      "text": "DRIFTSHIELD_REDACTION_CANARY_RESPONSE_TOP I will read /home/example-user/secrets.txt for ExampleCorp.",
+      "tool_use": [
+        {
+          "name": "read_file",
+          "arguments": {
+            "path": "/home/example-user/repo/file.txt",
+            "note": "DRIFTSHIELD_REDACTION_CANARY_TOOL_INPUT_NESTED"
+          }
+        }
+      ]
+    },
+    {
+      "type": "tool_result",
+      "ts": 1700000002,
+      "tool_output": {
+        "stdout": "DRIFTSHIELD_REDACTION_CANARY_TOOL_OUTPUT contents include AKIAEXAMPLE12345CANARY",
+        "stderr": ""
+      }
+    },
+    {
+      "type": "assistant",
+      "ts": 1700000003,
+      "content": "DRIFTSHIELD_REDACTION_CANARY_NESTED_ASSISTANT email me at alice@example.test"
+    }
+  ],
+  "user_identifiers": ["DRIFTSHIELD_REDACTION_CANARY_USER_IDS user@example.test"],
+  "metadata": {
+    "workspace": "Acme Workspace",
+    "session_note": "ssn 123-45-6789",
+    "deep": {
+      "deeper": {
+        "deepest": {
+          "content": "DRIFTSHIELD_REDACTION_CANARY_DEEP_CONTENT very deep prompt"
+        }
+      }
+    }
+  }
+}

--- a/driftshield/tests/fixtures/redactor_corpus/claude_desktop.json
+++ b/driftshield/tests/fixtures/redactor_corpus/claude_desktop.json
@@ -1,0 +1,30 @@
+{
+  "conversation": {
+    "id": "cdsktp-conv-001",
+    "title": "Acme Workspace deploy chat"
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "DRIFTSHIELD_REDACTION_CANARY_DESKTOP_USER ping support at user@example.test"
+    },
+    {
+      "role": "assistant",
+      "content": "DRIFTSHIELD_REDACTION_CANARY_DESKTOP_ASSIST here is a token ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "attachments": [
+        {
+          "type": "code",
+          "file_content": "DRIFTSHIELD_REDACTION_CANARY_FILE_CONTENT print('hi')",
+          "path": "/Users/example-user/project/main.py"
+        }
+      ]
+    },
+    {
+      "role": "system",
+      "text": "DRIFTSHIELD_REDACTION_CANARY_SYSTEM_TEXT JWT eyJhbGciOiJIUzI1NiJ9.payload.signature"
+    }
+  ],
+  "user_identifiers": [
+    "DRIFTSHIELD_REDACTION_CANARY_UI alice@example.test"
+  ]
+}

--- a/driftshield/tests/fixtures/redactor_corpus/codex.json
+++ b/driftshield/tests/fixtures/redactor_corpus/codex.json
@@ -1,0 +1,29 @@
+{
+  "session": {
+    "session_id": "codex-sess-001",
+    "host_path": "/home/example-user/work/repo"
+  },
+  "turns": [
+    {
+      "turn_id": 1,
+      "user": {
+        "content": "DRIFTSHIELD_REDACTION_CANARY_CODEX_USER refactor /home/example-user/work/repo/lib.py"
+      },
+      "assistant": {
+        "text": "DRIFTSHIELD_REDACTION_CANARY_CODEX_ASSIST openai key sk-AAAAAAAAAAAAAAAAAAAAAA"
+      },
+      "tool_calls": [
+        {
+          "name": "apply_patch",
+          "input": {
+            "diff": "DRIFTSHIELD_REDACTION_CANARY_CODEX_TOOL_INPUT"
+          },
+          "result": {
+            "stdout": "DRIFTSHIELD_REDACTION_CANARY_CODEX_TOOL_RESULT applied to /home/example-user/work/repo/lib.py"
+          }
+        }
+      ]
+    }
+  ],
+  "prompts": ["DRIFTSHIELD_REDACTION_CANARY_CODEX_PROMPTS_TOP"]
+}

--- a/driftshield/tests/fixtures/redactor_corpus/crewai.json
+++ b/driftshield/tests/fixtures/redactor_corpus/crewai.json
@@ -1,0 +1,31 @@
+{
+  "crew": {
+    "crew_id": "crew-canary-001",
+    "name": "Acme Workspace research crew"
+  },
+  "tasks": [
+    {
+      "task_id": "task-1",
+      "agent": "researcher",
+      "description": "research /home/example-user/notes",
+      "content": "DRIFTSHIELD_REDACTION_CANARY_CREWAI_DESC research goals",
+      "output": {
+        "content": "DRIFTSHIELD_REDACTION_CANARY_CREWAI_OUTPUT_CONTENT findings drafted",
+        "tool_output": {
+          "result": "DRIFTSHIELD_REDACTION_CANARY_CREWAI_TOOL_RESULT contents AKIA0EXAMPLE0CANARY00"
+        }
+      }
+    },
+    {
+      "task_id": "task-2",
+      "agent": "writer",
+      "description": "write summary",
+      "text": "DRIFTSHIELD_REDACTION_CANARY_CREWAI_DESC2 user-provided draft hint",
+      "tool_input": {
+        "draft": "DRIFTSHIELD_REDACTION_CANARY_CREWAI_TOOL_INPUT"
+      }
+    }
+  ],
+  "session_id": "crewai-sess-001",
+  "user_identifiers": ["DRIFTSHIELD_REDACTION_CANARY_CREWAI_UI bob@example.test"]
+}

--- a/driftshield/tests/fixtures/redactor_corpus/langchain.json
+++ b/driftshield/tests/fixtures/redactor_corpus/langchain.json
@@ -1,0 +1,45 @@
+{
+  "trace": {
+    "trace_id": "lc-trace-001",
+    "owner": "ExampleCorp"
+  },
+  "runs": [
+    {
+      "run_id": "lc-run-1",
+      "name": "agent_executor",
+      "inputs": {
+        "input": "DRIFTSHIELD_REDACTION_CANARY_LC_RUN_INPUT pay 4111111111111111 to alice@example.test",
+        "messages": [
+          {
+            "role": "user",
+            "content": "DRIFTSHIELD_REDACTION_CANARY_LC_NESTED_PROMPT"
+          }
+        ]
+      },
+      "outputs": {
+        "output": "DRIFTSHIELD_REDACTION_CANARY_LC_RUN_OUTPUT done"
+      },
+      "child_runs": [
+        {
+          "run_id": "lc-run-2",
+          "name": "tool",
+          "input": {
+            "query": "DRIFTSHIELD_REDACTION_CANARY_LC_CHILD_TOOL_INPUT"
+          },
+          "output": {
+            "result": "DRIFTSHIELD_REDACTION_CANARY_LC_CHILD_TOOL_OUTPUT contents from /home/example-user/data.csv"
+          },
+          "child_runs": [
+            {
+              "run_id": "lc-run-3",
+              "input": {
+                "prompt": "DRIFTSHIELD_REDACTION_CANARY_LC_LEAF_PROMPT"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "session_id": "lc-sess-001"
+}

--- a/driftshield/tests/fixtures/redactor_corpus/openai_chat.json
+++ b/driftshield/tests/fixtures/redactor_corpus/openai_chat.json
@@ -1,0 +1,26 @@
+{
+  "id": "chatcmpl-canary-001",
+  "object": "chat.completion",
+  "model": "gpt-canary",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "DRIFTSHIELD_REDACTION_CANARY_OPENAI_ASSIST ping alice@example.test",
+        "tool_calls": [
+          {
+            "id": "call_canary_1",
+            "type": "function",
+            "function": {
+              "name": "get_file",
+              "arguments": "{\"path\": \"/Users/example-user/notes.txt\", \"canary\": \"DRIFTSHIELD_REDACTION_CANARY_OPENAI_FN_ARGS\"}"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "session_id": "openai-canary-sess",
+  "responses": ["DRIFTSHIELD_REDACTION_CANARY_OPENAI_RESPONSES_TOP"]
+}

--- a/driftshield/tests/test_recursive_redactor.py
+++ b/driftshield/tests/test_recursive_redactor.py
@@ -1,0 +1,222 @@
+"""Tests for the v2 recursive redactor (driftshield#109).
+
+Two test families:
+
+* per-rule unit tests covering each redaction category
+* corpus canary tests asserting zero ``DRIFTSHIELD_REDACTION_CANARY`` survival
+  across the six known transcript shapes
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from driftshield.intake_contract import REQUIRED_REDACTION_FIELDS
+from driftshield.recursive_redactor import (
+    REDACTION_RULESET_VERSION,
+    REDACTOR_VERSION,
+    redact,
+)
+from driftshield.remote_submission import (
+    UnknownTranscriptShapeError,
+    build_oss_submission_request,
+    detect_shape,
+    redact_payload,
+    redact_payload_with_manifest,
+)
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "redactor_corpus"
+_CORPUS_NAMES = (
+    "claude_code",
+    "claude_desktop",
+    "codex",
+    "openai_chat",
+    "langchain",
+    "crewai",
+)
+_CANARY_RE = re.compile(r"DRIFTSHIELD_REDACTION_CANARY_[A-Z0-9_]+")
+
+
+def _load(name: str) -> dict[str, object]:
+    return json.loads((_FIXTURE_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def test_module_pins_redactor_and_ruleset_versions():
+    assert REDACTOR_VERSION.startswith("recursive-redactor.v2")
+    assert REDACTION_RULESET_VERSION == "ruleset.v1"
+
+
+def test_aws_access_key_redacted_anywhere():
+    payload = {"events": [{"note": "key=AKIAEXAMPLE12345CANARY"}]}
+    result = redact(payload)
+    assert "AKIAEXAMPLE12345CANARY" not in json.dumps(result.payload)
+    assert any(entry.category == "aws_access_key" for entry in result.entries)
+
+
+def test_github_pat_redacted_anywhere():
+    pat = "ghp_" + "A" * 36
+    payload = {"events": [{"note": f"token {pat}"}]}
+    result = redact(payload)
+    assert pat not in json.dumps(result.payload)
+    assert any(entry.category == "github_pat" for entry in result.entries)
+
+
+def test_openai_key_redacted_anywhere():
+    key = "sk-" + "A" * 24
+    payload = {"events": [{"note": f"key {key}"}]}
+    result = redact(payload)
+    assert key not in json.dumps(result.payload)
+    assert any(entry.category == "openai_key" for entry in result.entries)
+
+
+def test_jwt_redacted_anywhere():
+    jwt = "eyJhbGciOiJIUzI1NiJ9.payload.signature"
+    payload = {"events": [{"note": f"jwt {jwt}"}]}
+    result = redact(payload)
+    assert jwt not in json.dumps(result.payload)
+    assert any(entry.category == "jwt" for entry in result.entries)
+
+
+def test_ssn_redacted_anywhere():
+    payload = {"events": [{"note": "ssn 123-45-6789"}]}
+    result = redact(payload)
+    assert "123-45-6789" not in json.dumps(result.payload)
+    assert any(entry.category == "ssn" for entry in result.entries)
+
+
+def test_credit_card_only_luhn_valid_is_redacted():
+    valid = "4111111111111111"
+    invalid = "4111111111111112"
+    payload = {"events": [{"note": f"v={valid} iv={invalid}"}]}
+    result = redact(payload)
+    serialised = json.dumps(result.payload)
+    assert valid not in serialised
+    assert invalid in serialised
+    assert any(entry.category == "credit_card" for entry in result.entries)
+
+
+def test_home_paths_unix_and_windows_redacted():
+    payload = {
+        "events": [
+            {"note": "open /home/example-user/file.txt"},
+            {"note": "open /Users/example-user/file.txt"},
+            {"note": "open C:\\Users\\example-user\\file.txt"},
+        ]
+    }
+    result = redact(payload)
+    serialised = json.dumps(result.payload)
+    assert "/home/example-user" not in serialised
+    assert "/Users/example-user" not in serialised
+    assert "C:\\\\Users\\\\example-user" not in serialised
+    categories = {entry.category for entry in result.entries}
+    assert "home_path" in categories
+
+
+def test_email_redacted_in_free_text():
+    payload = {"events": [{"note": "ping alice@example.test"}]}
+    result = redact(payload)
+    assert "alice@example.test" not in json.dumps(result.payload)
+    assert any(entry.category == "email" for entry in result.entries)
+
+
+def test_tool_io_keys_replaced_with_placeholder_not_dropped():
+    payload = {
+        "events": [
+            {
+                "type": "assistant",
+                "tool_use": [
+                    {
+                        "name": "read_file",
+                        "arguments": {"path": "/home/example-user/x", "marker": "INNER"},
+                    }
+                ],
+            }
+        ]
+    }
+    result = redact(payload)
+    assert "INNER" not in json.dumps(result.payload)
+    assert "/home/example-user/x" not in json.dumps(result.payload)
+    event = result.payload["events"][0]
+    tool = event["tool_use"][0]
+    assert tool["name"] == "read_file"
+    assert isinstance(tool["arguments"], str)
+    assert tool["arguments"].startswith("<REDACTED:tool_io:")
+
+
+def test_required_redaction_fields_still_dropped_at_top():
+    payload = {
+        "prompts": ["x"],
+        "responses": ["y"],
+        "user_identifiers": ["z"],
+        "session_id": "s",
+    }
+    redacted, fields = redact_payload(payload)
+    assert "prompts" not in redacted
+    assert "responses" not in redacted
+    assert "user_identifiers" not in redacted
+    assert redacted["session_id"] == "s"
+    assert set(fields) == REQUIRED_REDACTION_FIELDS
+
+
+def test_nested_content_and_text_still_dropped():
+    payload = {
+        "events": [
+            {"type": "user", "content": "SECRET_CONTENT"},
+            {"type": "assistant", "text": "SECRET_TEXT"},
+        ]
+    }
+    redacted, _ = redact_payload(payload)
+    serialised = json.dumps(redacted)
+    assert "SECRET_CONTENT" not in serialised
+    assert "SECRET_TEXT" not in serialised
+
+
+def test_redact_payload_with_manifest_exposes_entries():
+    payload = {"events": [{"note": "ssn 123-45-6789"}]}
+    result = redact_payload_with_manifest(payload)
+    assert any(entry.category == "ssn" for entry in result.entries)
+    assert any(entry.path.startswith("events[0].note") for entry in result.entries)
+
+
+@pytest.mark.parametrize("name", _CORPUS_NAMES)
+def test_corpus_fixture_has_no_canary_survival(name: str):
+    payload = _load(name)
+    redacted, _ = redact_payload(payload)
+    serialised = json.dumps(redacted)
+    leaks = _CANARY_RE.findall(serialised)
+    assert leaks == [], (
+        f"canary markers survived redaction in {name} fixture: {leaks}"
+    )
+
+
+@pytest.mark.parametrize("name", _CORPUS_NAMES)
+def test_corpus_fixture_detects_known_shape(name: str):
+    payload = _load(name)
+    shape = detect_shape(payload)
+    assert shape is not None, f"shape detection failed for {name}"
+
+
+def test_detect_shape_returns_none_for_unknown_shape():
+    payload = {"some_random_top_level_key": True}
+    assert detect_shape(payload) is None
+
+
+def test_build_request_refuses_unknown_shape_by_default():
+    payload = {"some_random_top_level_key": True}
+    with pytest.raises(UnknownTranscriptShapeError):
+        build_oss_submission_request(source_session_id="s", payload=payload)
+
+
+def test_build_request_accepts_unknown_shape_when_forced():
+    payload = {"some_random_top_level_key": True}
+    submission = build_oss_submission_request(
+        source_session_id="s",
+        payload=payload,
+        force_unknown_shape=True,
+    )
+    assert submission.envelope.source_session_id == "s"


### PR DESCRIPTION
## Summary

Replaces the v1 field-name-only redactor with a recursive depth-walking ruleset that covers tool-call shapes, embedded secrets, identifying paths, and free-text emails. Adds three new CLI inspection flags and a six-shape corpus of synthetic fixtures with canary tests proving zero marker survival.

Closes #109.

Linked hard gate: tborys/driftshield-meta#215.

## What changed

- `src/driftshield/recursive_redactor.py` (new): depth-walking redactor module. Pins `REDACTOR_VERSION` and `REDACTION_RULESET_VERSION` as module constants so the cross-repo manifest-v2 work (driftshield-intel#132) can read them.
- `src/driftshield/remote_submission.py`: routes through the new redactor, adds `detect_shape` heuristic and `UnknownTranscriptShapeError` gate, exposes `redact_payload_with_manifest` for inspection.
- `src/driftshield/cli/commands/telemetry.py`: adds `--dry-run-redaction`, `--show-manifest`, `--force-unknown-shape` flags.
- `tests/test_recursive_redactor.py` (new): 18 per-rule + 6 corpus canary tests.
- `tests/fixtures/redactor_corpus/`: six synthetic transcript shapes (Claude Code, Claude Desktop, Codex, OpenAI Chat Completions, LangChain, CrewAI), each seeding `DRIFTSHIELD_REDACTION_CANARY_*` markers at every nesting depth and every redaction category.
- `tests/cli/test_telemetry.py`: 4 new tests covering the new flags.
- `docs/redactor-v2.md` (new): coverage table, manifest semantics, CLI inspection, unknown-shape handling, rule-extension guidance.

## What stays unchanged

- Public manifest contract still advertises only the v1 superset (`prompts`, `responses`, `user_identifiers`). The v2 ruleset is implementation-only.
- `SUPPORTED_CONTRACT_VERSION` and `REDACTION_MANIFEST_VERSION` unchanged. The provenance fields (`redactor_version`, `redaction_ruleset_version`) land via driftshield-intel#132.
- The intel-side validator at `intake_api.py:340-344` stays satisfied.

## Hard-gate scope

Redactor v2 closes the part of meta#215 that lives on the OSS client. It does not address:

- Server-side backstop for payloads that escape client redaction (driftshield-intel#131).
- Manifest provenance fields (driftshield-intel#132).

The free-text-content category that v2 cannot catch (arbitrary user prose containing leaked secrets in non-redactable key positions) is intentionally left to the server backstop. Documented in `docs/redactor-v2.md`.

## Test plan

- [x] `uv run --extra dev pytest` — 507 passed, 3 skipped
- [x] `uv run --extra dev ruff check` on all changed files — clean
- [x] `uv run --extra dev mypy` on all changed source files — clean
- [x] Six-shape corpus canary tests pass (zero marker survival)
- [x] CLI `--dry-run-redaction`, `--show-manifest`, `--force-unknown-shape` covered by new tests
- [x] Existing top-level + nested-content redaction tests still pass

## OSS hygiene

All fixtures, tests, docs, and CLI examples use synthetic neutral names only (`ExampleCorp`, `Acme Workspace`, `user@example.test`, `/home/example-user/`). No real customer, partner, vendor, or employer names anywhere in this patch.

## Followups

- driftshield-intel#131 (server backstop) — picks up next once this lands
- driftshield-intel#132 (manifest provenance) — picks up after #131; will consume the pinned `REDACTOR_VERSION` and `REDACTION_RULESET_VERSION` constants from this PR
