### PR TITLE
feat(contract): bump redaction manifest to v2 with provenance fields

### DIFF
--- a/driftshield/docs/redactor-v2.md
+++ b/driftshield/docs/redactor-v2.md
@@ -67,19 +67,26 @@ not the client.
 
 ## Public manifest claim
 
-The redaction manifest accompanying every envelope advertises only the v1
-public superset (`prompts`, `responses`, `user_identifiers`). The v2 internal
-ruleset is implementation-only and intentionally not surfaced on the public
-contract. A future `redaction-manifest.v2` contract bump will add
-`redactor_version` and `redaction_ruleset_version` fields so server-side can
-identify which redactor produced a given payload.
+The redaction manifest accompanying every envelope advertises the public
+superset (`prompts`, `responses`, `user_identifiers`). The v2 internal ruleset
+is implementation-only and intentionally not surfaced on the public contract.
 
-The redactor pins both values as module-level constants:
+### Manifest provenance (`redaction-manifest.v2`)
+
+OSS builders now emit `redaction-manifest.v2` envelopes carrying two
+provenance fields:
 
 ```python
 REDACTOR_VERSION = "recursive-redactor.v2.0.0"
 REDACTION_RULESET_VERSION = "ruleset.v1"
 ```
+
+Both are module-level constants in `recursive_redactor.py` so callers and
+tests can import the same source of truth. The server side accepts both v1
+and v2 manifests during the deprecation window. v2 manifests must carry
+non-empty `redactor_version` and `redaction_ruleset_version`; v1 manifests
+continue to validate as before. Bump the version constants whenever the
+public detection surface or the rule-evaluation order changes.
 
 ## CLI inspection
 

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -17,7 +17,15 @@ from pydantic import BaseModel, ConfigDict, Field
 
 SUPPORTED_CONTRACT_VERSION = "phase3f.v1"
 MAX_ENVELOPE_BYTES = 256_000
-REDACTION_MANIFEST_VERSION = "redaction-manifest.v1"
+REDACTION_MANIFEST_VERSION_V1 = "redaction-manifest.v1"
+REDACTION_MANIFEST_VERSION_V2 = "redaction-manifest.v2"
+# Current OSS builders emit v2 manifests. Server side accepts both v1 and v2
+# during the deprecation window: ship manifest provenance fields without
+# waiting on an unrelated envelope-bump release.
+REDACTION_MANIFEST_VERSION = REDACTION_MANIFEST_VERSION_V2
+ACCEPTED_REDACTION_MANIFEST_VERSIONS: frozenset[str] = frozenset(
+    {REDACTION_MANIFEST_VERSION_V1, REDACTION_MANIFEST_VERSION_V2}
+)
 REQUIRED_REDACTION_FIELDS: frozenset[str] = frozenset(
     {"prompts", "responses", "user_identifiers"}
 )
@@ -29,6 +37,8 @@ class RedactionManifest(BaseModel):
     manifest_version: str = Field(default=REDACTION_MANIFEST_VERSION)
     redaction_applied: bool
     redacted_fields: list[str] = Field(min_length=1)
+    redactor_version: str | None = Field(default=None, min_length=1)
+    redaction_ruleset_version: str | None = Field(default=None, min_length=1)
 
 
 class ConsentState(BaseModel):

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -168,6 +168,8 @@ def build_oss_submission_request(
             manifest_version=REDACTION_MANIFEST_VERSION,
             redaction_applied=True,
             redacted_fields=redacted_fields,
+            redactor_version=REDACTOR_VERSION,
+            redaction_ruleset_version=REDACTION_RULESET_VERSION,
         ),
     )
     return OssSubmissionRequest(

--- a/driftshield/tests/test_intake_contract.py
+++ b/driftshield/tests/test_intake_contract.py
@@ -34,7 +34,7 @@ from driftshield.intake_contract import (
 _REFERENCE_CONSTANTS = {
     "SUPPORTED_CONTRACT_VERSION": "phase3f.v1",
     "MAX_ENVELOPE_BYTES": 256_000,
-    "REDACTION_MANIFEST_VERSION": "redaction-manifest.v1",
+    "REDACTION_MANIFEST_VERSION": "redaction-manifest.v2",
     "REQUIRED_REDACTION_FIELDS": frozenset({"prompts", "responses", "user_identifiers"}),
 }
 
@@ -43,6 +43,8 @@ _REFERENCE_FIELDS = {
         "manifest_version",
         "redaction_applied",
         "redacted_fields",
+        "redactor_version",
+        "redaction_ruleset_version",
     },
     "ConsentState": {
         "consent_version",

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -209,6 +209,24 @@ def test_build_oss_submission_request_phase3f_v1_shape():
     assert set(envelope.redaction_manifest.redacted_fields) == REQUIRED_REDACTION_FIELDS
 
 
+def test_build_oss_submission_request_emits_manifest_v2_with_provenance():
+    """Manifest v2 carries redactor + ruleset versions for server-side provenance."""
+    from driftshield.recursive_redactor import (
+        REDACTION_RULESET_VERSION,
+        REDACTOR_VERSION,
+    )
+
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1", "metadata": {"foo": "bar"}},
+    )
+
+    manifest = request.envelope.redaction_manifest
+    assert manifest.manifest_version == "redaction-manifest.v2"
+    assert manifest.redactor_version == REDACTOR_VERSION
+    assert manifest.redaction_ruleset_version == REDACTION_RULESET_VERSION
+
+
 def test_build_oss_submission_request_has_no_installation_id_or_consent_state():
     """D19 contract: request must NOT carry installation_id or consent_state."""
     request = build_oss_submission_request(


### PR DESCRIPTION
## Summary

Bumps the OSS submission `RedactionManifest` to `redaction-manifest.v2` with two new provenance fields: `redactor_version` and `redaction_ruleset_version`. Both are populated by the OSS builder from constants pinned in `recursive_redactor.py`. Server-side intake accepts both v1 and v2 manifests during the deprecation window.

This is the OSS half of a paired cross-repo contract bump. The intel-side PR ships the receiving validator, persistence, and audit-log integration.

## What changed

- `src/driftshield/intake_contract.py`: new `REDACTION_MANIFEST_VERSION_V1` / `_V2` constants, new `ACCEPTED_REDACTION_MANIFEST_VERSIONS` set, default `REDACTION_MANIFEST_VERSION` now `redaction-manifest.v2`. `RedactionManifest` gains optional `redactor_version` and `redaction_ruleset_version` fields.
- `src/driftshield/remote_submission.py`: `build_oss_submission_request` populates both new fields from `REDACTOR_VERSION` and `REDACTION_RULESET_VERSION` pinned in `recursive_redactor.py`.
- `tests/test_remote_submission.py`: new focused test asserts builder emits manifest-v2 with both provenance fields set to the pinned constants.
- `tests/test_intake_contract.py`: snapshot pin bumped to include the two new fields.
- `docs/redactor-v2.md`: new section documenting manifest-v2 shape, provenance constants, deprecation-window semantics.

## What stays unchanged

- `SUPPORTED_CONTRACT_VERSION` stays `phase3f.v1`. Manifest v2 ships without waiting on any envelope-version bump.
- `REQUIRED_REDACTION_FIELDS` unchanged. The public claim still advertises the v1 superset.
- All existing redactor behaviour, CLI flags, corpus tests untouched.

## Test plan

- [x] `uv run --extra dev pytest` — 508 passed, 3 skipped
- [x] `uv run --extra dev ruff check` on changed files — clean
- [x] `uv run --extra dev mypy` on changed source — clean
- [x] `bash scripts/check-public-scope.sh` — OK
- [x] Existing snapshot pin (`tests/test_intake_contract.py`) updated and passing

## OSS hygiene

No private-repo references in tracked files. Docs and tests use only synthetic neutral identifiers.

## Paired landing

The intel-side PR adds the receiving validator, persistence columns, alembic migration, and backstop-audit metadata enrichment. Both PRs need to land together to keep the contract aligned across the boundary. Intel PR linked in the parent thread.
