### PR TITLE
feat(contract): mirror phase3g.v1 envelope on OSS contract + submit-session (intel#122)

### DIFF
--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -10,7 +10,14 @@ from rich.console import Console
 
 from driftshield.intake_contract import (
     DEFAULT_WORKFLOW_REFERENCE,
+    REDACTION_MANIFEST_VERSION,
+    REQUIRED_REDACTION_FIELDS,
     SUPPORTED_CONTRACT_VERSION,
+    RedactionManifest,
+)
+from driftshield.recursive_redactor import (
+    REDACTION_RULESET_VERSION,
+    REDACTOR_VERSION,
 )
 from driftshield.remote_submission import (
     OssRemoteSubmissionConfig,
@@ -182,18 +189,17 @@ def telemetry_submit_session(
                 )
             )
         if show_manifest:
-            typer.echo(
-                json.dumps(
-                    {
-                        "manifest_version": "redaction-manifest.v1",
-                        "redaction_applied": True,
-                        "redacted_fields": sorted(["prompts", "responses", "user_identifiers"]),
-                        "detected_shape": shape,
-                        "ruleset_entry_count": len(result.entries),
-                    },
-                    indent=2,
-                )
+            manifest = RedactionManifest(
+                manifest_version=REDACTION_MANIFEST_VERSION,
+                redaction_applied=True,
+                redacted_fields=sorted(REQUIRED_REDACTION_FIELDS),
+                redactor_version=REDACTOR_VERSION,
+                redaction_ruleset_version=REDACTION_RULESET_VERSION,
             )
+            manifest_payload = manifest.model_dump(mode="json")
+            manifest_payload["detected_shape"] = shape
+            manifest_payload["ruleset_entry_count"] = len(result.entries)
+            typer.echo(json.dumps(manifest_payload, indent=2))
         return
 
     config = TelemetryService().load_config()
@@ -245,9 +251,9 @@ def telemetry_submit_session(
         console.print(
             f"[yellow]Deprecation:[/yellow] intake server advertises "
             f"{result.server_contract_version}; this client is on "
-            f"{SUPPORTED_CONTRACT_VERSION}. Coordinate the server upgrade "
-            "before the 90-day sunset documented at "
-            "driftshield-meta/docs/operations/phase-3i-envelope-deprecation.md."
+            f"{SUPPORTED_CONTRACT_VERSION}. The server is in its post-bump "
+            "deprecation window: submissions are still accepted, but the "
+            "server operator should upgrade before the window closes."
         )
 
     response = result.response

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -8,6 +8,10 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from driftshield.intake_contract import (
+    DEFAULT_WORKFLOW_REFERENCE,
+    SUPPORTED_CONTRACT_VERSION,
+)
 from driftshield.remote_submission import (
     OssRemoteSubmissionConfig,
     RemoteSubmissionError,
@@ -94,13 +98,28 @@ def telemetry_submit_session(
         help="Override the source_session_id field. Defaults to the JSON file stem.",
     ),
     workflow_reference: str | None = typer.Option(
-        None, "--workflow-reference", help="Optional workflow identifier."
+        None,
+        "--workflow-reference",
+        help=(
+            "Workflow identifier stamped on the envelope. Defaults to the "
+            "value in the session JSON's 'workflow_reference' field, or "
+            "'default' if neither is supplied."
+        ),
     ),
     project_reference: str | None = typer.Option(
         None, "--project-reference", help="Optional project identifier."
     ),
     source_report_id: str | None = typer.Option(
         None, "--source-report-id", help="Optional source report identifier."
+    ),
+    agent_id: str | None = typer.Option(
+        None, "--agent-id", help="Optional agent identifier (phase3g.v1 provenance)."
+    ),
+    model_name: str | None = typer.Option(
+        None, "--model-name", help="Optional model name (phase3g.v1 provenance)."
+    ),
+    model_version: str | None = typer.Option(
+        None, "--model-version", help="Optional model version (phase3g.v1 provenance)."
     ),
     dry_run_redaction: bool = typer.Option(
         False,
@@ -118,11 +137,17 @@ def telemetry_submit_session(
         help="Submit even if the transcript top-level shape is not recognised by the redactor.",
     ),
 ) -> None:
-    """Build a phase3f.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
+    """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
 
     The OSS lane is unauthenticated. No X-API-Key header is sent, no installation_id
     or consent_state is included in the request. The server binds the persisted row
     to the in-stack OSS fallback installation + consent.
+
+    ``workflow_reference`` precedence: --workflow-reference flag, then
+    session JSON's ``workflow_reference`` field, then ``"default"``. The
+    Phase 3i recurrence matcher requires distinct workflow references to
+    light up the Emerging signal; leaving every submission on ``"default"``
+    masks recurrence.
     """
     try:
         raw = path.read_text(encoding="utf-8")
@@ -179,14 +204,25 @@ def telemetry_submit_session(
         )
         raise typer.Exit(1)
 
+    resolved_workflow_reference = workflow_reference
+    if resolved_workflow_reference is None:
+        payload_workflow = payload.get("workflow_reference")
+        if isinstance(payload_workflow, str) and payload_workflow.strip():
+            resolved_workflow_reference = payload_workflow
+    if resolved_workflow_reference is None:
+        resolved_workflow_reference = DEFAULT_WORKFLOW_REFERENCE
+
     try:
         submission = build_oss_submission_request(
             source_session_id=source_session_id or path.stem,
             payload=payload,
-            workflow_reference=workflow_reference,
+            workflow_reference=resolved_workflow_reference,
             project_reference=project_reference,
             source_report_id=source_report_id,
             force_unknown_shape=force_unknown_shape,
+            agent_id=agent_id,
+            model_name=model_name,
+            model_version=model_version,
         )
     except UnknownTranscriptShapeError as exc:
         console.print(
@@ -197,11 +233,24 @@ def telemetry_submit_session(
 
     submission_config = OssRemoteSubmissionConfig(intake_url=config.remote_intake_url)
     try:
-        response = post_oss_submission(config=submission_config, submission=submission)
+        result = post_oss_submission(config=submission_config, submission=submission)
     except RemoteSubmissionError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
 
+    if (
+        result.server_contract_version is not None
+        and result.server_contract_version != SUPPORTED_CONTRACT_VERSION
+    ):
+        console.print(
+            f"[yellow]Deprecation:[/yellow] intake server advertises "
+            f"{result.server_contract_version}; this client is on "
+            f"{SUPPORTED_CONTRACT_VERSION}. Coordinate the server upgrade "
+            "before the 90-day sunset documented at "
+            "driftshield-meta/docs/operations/phase-3i-envelope-deprecation.md."
+        )
+
+    response = result.response
     console.print(
         f"Submitted. submission_id={response.submission_id} status={response.processing_status}"
     )

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -1,10 +1,12 @@
-"""Phase 3h intake submission contract (OSS side).
+"""Intake submission contract (OSS side).
 
-Duplicate-with-version-pin of the canonical models at
-driftshield-intel/src/driftshield_intel/intake_api.py:57-149.
-Promote to a shared package post Phase 3i. Until then, any change here
-must be mirrored on the intel side and vice versa, and both ends must
-continue to advertise the same SUPPORTED_CONTRACT_VERSION.
+Pydantic models for the request body that ``driftshield submit-session``
+sends to the configured intake server. The server validates the same
+shape and rejects with HTTP 422 when ``envelope_contract_version`` or
+``schema_version`` are not in ``ACCEPTED_CONTRACT_VERSIONS``. Keep
+``SUPPORTED_CONTRACT_VERSION`` and the model field sets in lockstep with
+the server-side contract; both ends must continue to advertise the same
+``SUPPORTED_CONTRACT_VERSION`` outside the post-bump deprecation window.
 """
 
 from __future__ import annotations
@@ -16,10 +18,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 SUPPORTED_CONTRACT_VERSION = "phase3g.v1"
-# Server-side validators on the intel side accept either pin during the
-# 90-day deprecation window (see
-# driftshield-meta/docs/operations/phase-3i-envelope-deprecation.md). The
-# OSS-side declaration is here for contract-pin parity; this module has no
+# Intake servers accept submissions on either pin during a 90-day
+# deprecation window after a contract bump, so older clients can still
+# submit while operators upgrade. The OSS-side declaration is here for
+# contract-pin parity with the server validator; this module has no
 # accept-logic of its own.
 ACCEPTED_CONTRACT_VERSIONS: frozenset[str] = frozenset({"phase3f.v1", "phase3g.v1"})
 MAX_ENVELOPE_BYTES = 256_000

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -1,10 +1,10 @@
 """Phase 3h intake submission contract (OSS side).
 
 Duplicate-with-version-pin of the canonical models at
-driftshield-intel/src/driftshield_intel/intake_api.py:35-80.
-Promote to a shared package in Phase 3i. Until then, any change here must be
-mirrored on the intel side and vice versa, and both ends must continue to
-advertise the same SUPPORTED_CONTRACT_VERSION.
+driftshield-intel/src/driftshield_intel/intake_api.py:57-149.
+Promote to a shared package post Phase 3i. Until then, any change here
+must be mirrored on the intel side and vice versa, and both ends must
+continue to advertise the same SUPPORTED_CONTRACT_VERSION.
 """
 
 from __future__ import annotations
@@ -15,7 +15,13 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
-SUPPORTED_CONTRACT_VERSION = "phase3f.v1"
+SUPPORTED_CONTRACT_VERSION = "phase3g.v1"
+# Server-side validators on the intel side accept either pin during the
+# 90-day deprecation window (see
+# driftshield-meta/docs/operations/phase-3i-envelope-deprecation.md). The
+# OSS-side declaration is here for contract-pin parity; this module has no
+# accept-logic of its own.
+ACCEPTED_CONTRACT_VERSIONS: frozenset[str] = frozenset({"phase3f.v1", "phase3g.v1"})
 MAX_ENVELOPE_BYTES = 256_000
 REDACTION_MANIFEST_VERSION_V1 = "redaction-manifest.v1"
 REDACTION_MANIFEST_VERSION_V2 = "redaction-manifest.v2"
@@ -50,18 +56,24 @@ class ConsentState(BaseModel):
     revoked_at: datetime | None = None
 
 
+DEFAULT_WORKFLOW_REFERENCE = "default"
+
+
 class SubmissionEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     source_system: str = Field(min_length=1)
     source_session_id: str = Field(min_length=1)
     source_report_id: str | None = None
-    workflow_reference: str | None = Field(default=None, min_length=1)
+    workflow_reference: str = Field(default=DEFAULT_WORKFLOW_REFERENCE, min_length=1)
     project_reference: str | None = Field(default=None, min_length=1)
     schema_version: str = Field(min_length=1)
     payload: dict[str, Any]
     payload_size_bytes: int = Field(ge=1, le=MAX_ENVELOPE_BYTES)
     redaction_manifest: RedactionManifest
+    agent_id: str | None = Field(default=None, min_length=1)
+    model_name: str | None = Field(default=None, min_length=1)
+    model_version: str | None = Field(default=None, min_length=1)
 
 
 class IntakeSubmissionRequest(BaseModel):

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -20,6 +20,7 @@ from typing import Any
 from urllib import error, request
 
 from driftshield.intake_contract import (
+    DEFAULT_WORKFLOW_REFERENCE,
     REDACTION_MANIFEST_VERSION,
     REQUIRED_REDACTION_FIELDS,
     SUPPORTED_CONTRACT_VERSION,
@@ -34,6 +35,9 @@ from driftshield.recursive_redactor import (
     RedactionResult,
     redact,
 )
+
+
+SERVER_CONTRACT_VERSION_HEADER = "X-DriftShield-Contract-Version"
 
 
 _DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
@@ -131,6 +135,9 @@ def build_oss_submission_request(
     project_reference: str | None = None,
     source_report_id: str | None = None,
     force_unknown_shape: bool = False,
+    agent_id: str | None = None,
+    model_name: str | None = None,
+    model_version: str | None = None,
 ) -> OssSubmissionRequest:
     """Build an unauthenticated OSS submission request.
 
@@ -155,11 +162,14 @@ def build_oss_submission_request(
     redacted_payload, redacted_fields = redact_payload(payload)
     _, payload_size = _encode_payload(redacted_payload)
 
+    envelope_workflow_reference = (
+        workflow_reference if workflow_reference is not None else DEFAULT_WORKFLOW_REFERENCE
+    )
     envelope = SubmissionEnvelope(
         source_system=source_system,
         source_session_id=source_session_id,
         source_report_id=source_report_id,
-        workflow_reference=workflow_reference,
+        workflow_reference=envelope_workflow_reference,
         project_reference=project_reference,
         schema_version=SUPPORTED_CONTRACT_VERSION,
         payload=redacted_payload,
@@ -171,6 +181,9 @@ def build_oss_submission_request(
             redactor_version=REDACTOR_VERSION,
             redaction_ruleset_version=REDACTION_RULESET_VERSION,
         ),
+        agent_id=agent_id,
+        model_name=model_name,
+        model_version=model_version,
     )
     return OssSubmissionRequest(
         envelope_contract_version=SUPPORTED_CONTRACT_VERSION,
@@ -178,12 +191,27 @@ def build_oss_submission_request(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class OssSubmissionResult:
+    """Response + transport-level metadata for one OSS submission.
+
+    ``server_contract_version`` is the value of the
+    ``X-DriftShield-Contract-Version`` response header, or ``None`` if the
+    server did not advertise one. Callers compare it against
+    :data:`driftshield.intake_contract.SUPPORTED_CONTRACT_VERSION` to detect
+    a deprecated server.
+    """
+
+    response: IntakeSubmissionResponse
+    server_contract_version: str | None
+
+
 def post_oss_submission(
     *,
     config: OssRemoteSubmissionConfig,
     submission: OssSubmissionRequest,
     opener: Any = None,
-) -> IntakeSubmissionResponse:
+) -> OssSubmissionResult:
     """Single unauthenticated POST to /v1/oss/submissions. No retry on failure.
 
     No X-API-Key header. No Authorization header. The intake URL is taken
@@ -203,6 +231,7 @@ def post_oss_submission(
     try:
         with urlopen(req) as resp:
             raw = resp.read().decode("utf-8")
+            server_contract_version = resp.headers.get(SERVER_CONTRACT_VERSION_HEADER)
     except error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else str(exc)
         raise RemoteSubmissionError(f"intake HTTP {exc.code}: {detail}") from exc
@@ -213,13 +242,19 @@ def post_oss_submission(
         decoded = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise RemoteSubmissionError(f"intake returned non-JSON body: {raw!r}") from exc
-    return IntakeSubmissionResponse.model_validate(decoded)
+    response = IntakeSubmissionResponse.model_validate(decoded)
+    return OssSubmissionResult(
+        response=response,
+        server_contract_version=server_contract_version,
+    )
 
 
 __all__ = [
     "REDACTION_RULESET_VERSION",
     "REDACTOR_VERSION",
+    "SERVER_CONTRACT_VERSION_HEADER",
     "OssRemoteSubmissionConfig",
+    "OssSubmissionResult",
     "RemoteSubmissionError",
     "UnknownTranscriptShapeError",
     "build_oss_submission_request",

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -562,6 +562,17 @@ def test_submit_session_dry_run_redaction_prints_entries_and_does_not_submit(
 def test_submit_session_show_manifest_prints_manifest_and_does_not_submit(
     tmp_path, monkeypatch
 ):
+    """--show-manifest must print the exact manifest shape the real
+    submission path emits, so operators can preview without surprises."""
+    from driftshield.intake_contract import (
+        REDACTION_MANIFEST_VERSION,
+        REQUIRED_REDACTION_FIELDS,
+    )
+    from driftshield.recursive_redactor import (
+        REDACTION_RULESET_VERSION,
+        REDACTOR_VERSION,
+    )
+
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     runner.invoke(app, _remote_enable_argv())
     session_path = _write_session(
@@ -585,11 +596,47 @@ def test_submit_session_show_manifest_prints_manifest_and_does_not_submit(
     assert result.exit_code == 0
     assert called["posted"] is False
     manifest = json.loads(result.stdout)
-    assert manifest["manifest_version"] == "redaction-manifest.v1"
+    assert manifest["manifest_version"] == REDACTION_MANIFEST_VERSION == "redaction-manifest.v2"
     assert manifest["redaction_applied"] is True
-    assert sorted(manifest["redacted_fields"]) == sorted(
-        ["prompts", "responses", "user_identifiers"]
+    assert sorted(manifest["redacted_fields"]) == sorted(REQUIRED_REDACTION_FIELDS)
+    assert manifest["redactor_version"] == REDACTOR_VERSION
+    assert manifest["redaction_ruleset_version"] == REDACTION_RULESET_VERSION
+
+
+def test_submit_session_show_manifest_matches_real_submission_manifest(
+    tmp_path, monkeypatch
+):
+    """The --show-manifest output must equal the redaction_manifest the
+    real builder embeds in the OSS submission request, modulo the two
+    preview-only fields (detected_shape, ruleset_entry_count). Locks the
+    preview against silent drift from the submission path."""
+    from driftshield.remote_submission import build_oss_submission_request
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    payload = {"session_id": "sess-1", "events": []}
+    session_path = _write_session(tmp_path, payload)
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission",
+        lambda **_: (_ for _ in ()).throw(AssertionError("must not submit")),
     )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--show-manifest"],
+    )
+
+    assert result.exit_code == 0
+    preview = json.loads(result.stdout)
+    # Strip preview-only fields before equality.
+    preview.pop("detected_shape", None)
+    preview.pop("ruleset_entry_count", None)
+
+    real_request = build_oss_submission_request(
+        source_session_id="sess-1", payload=payload
+    )
+    real_manifest = real_request.envelope.redaction_manifest.model_dump(mode="json")
+    assert preview == real_manifest
 
 
 def test_submit_session_refuses_unknown_shape_without_force(tmp_path, monkeypatch):

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -299,6 +299,18 @@ def _write_session(tmp_path, contents):
     return session_path
 
 
+def _ok_result(*, submission_id="sub_xyz", server_contract_version="phase3g.v1"):
+    from driftshield.intake_contract import IntakeSubmissionResponse
+    from driftshield.remote_submission import OssSubmissionResult
+
+    return OssSubmissionResult(
+        response=IntakeSubmissionResponse(
+            submission_id=submission_id, processing_status="received"
+        ),
+        server_contract_version=server_contract_version,
+    )
+
+
 def test_submit_session_happy_path(tmp_path, monkeypatch):
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     runner.invoke(app, _remote_enable_argv())
@@ -319,9 +331,8 @@ def test_submit_session_happy_path(tmp_path, monkeypatch):
         captured["intake_url"] = config.intake_url
         captured["payload_keys"] = sorted(submission.envelope.payload.keys())
         captured["request_keys"] = set(json.loads(submission.model_dump_json()).keys())
-        from driftshield.intake_contract import IntakeSubmissionResponse
-
-        return IntakeSubmissionResponse(submission_id="sub_xyz", processing_status="received")
+        captured["workflow_reference"] = submission.envelope.workflow_reference
+        return _ok_result()
 
     monkeypatch.setattr(
         "driftshield.cli.commands.telemetry.post_oss_submission",
@@ -336,12 +347,143 @@ def test_submit_session_happy_path(tmp_path, monkeypatch):
     assert "sub_xyz" in result.stdout
     assert "received" in result.stdout
     assert captured["intake_url"] == _OSS_TEST_INTAKE_URL
+    assert captured["workflow_reference"] == "default"
     assert "prompts" not in captured["payload_keys"]
     assert "responses" not in captured["payload_keys"]
     assert "user_identifiers" not in captured["payload_keys"]
     assert "metadata" in captured["payload_keys"]
     # D19 contract: request body has no installation_id, no consent_state.
     assert captured["request_keys"] == {"envelope_contract_version", "envelope"}
+
+
+def test_submit_session_defaults_workflow_reference_to_default(tmp_path, monkeypatch):
+    """Neither --workflow-reference nor session JSON supplies one -> 'default'."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["workflow_reference"] = submission.envelope.workflow_reference
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert captured["workflow_reference"] == "default"
+
+
+def test_submit_session_prefers_session_json_workflow_reference(tmp_path, monkeypatch):
+    """Session JSON's workflow_reference wins over the default when --flag absent."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path,
+        {"session_id": "sess-1", "workflow_reference": "checkout-flow"},
+    )
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["workflow_reference"] = submission.envelope.workflow_reference
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert captured["workflow_reference"] == "checkout-flow"
+
+
+def test_submit_session_flag_overrides_session_json_workflow_reference(tmp_path, monkeypatch):
+    """--workflow-reference takes precedence over session JSON's value."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path,
+        {"session_id": "sess-1", "workflow_reference": "from-json"},
+    )
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["workflow_reference"] = submission.envelope.workflow_reference
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--workflow-reference",
+            "from-flag",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["workflow_reference"] == "from-flag"
+
+
+def test_submit_session_logs_deprecation_warning_when_server_on_phase3f_v1(
+    tmp_path, monkeypatch
+):
+    """If the server's X-DriftShield-Contract-Version header is phase3f.v1,
+    the CLI emits a deprecation note. AC5 second half."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        return _ok_result(server_contract_version="phase3f.v1")
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert "deprecation" in result.stdout.lower()
+    assert "phase3f.v1" in result.stdout
+
+
+def test_submit_session_no_deprecation_warning_when_server_on_phase3g_v1(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        return _ok_result(server_contract_version="phase3g.v1")
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert "deprecation" not in result.stdout.lower()
 
 
 def test_submit_session_fails_when_remote_not_configured(tmp_path, monkeypatch):
@@ -469,9 +611,7 @@ def test_submit_session_accepts_unknown_shape_when_forced(tmp_path, monkeypatch)
     session_path = _write_session(tmp_path, {"unrelated_top_key": True})
 
     def fake_post(*, config, submission, opener=None):  # noqa: ARG001
-        from driftshield.intake_contract import IntakeSubmissionResponse
-
-        return IntakeSubmissionResponse(submission_id="sub_forced", processing_status="received")
+        return _ok_result(submission_id="sub_forced")
 
     monkeypatch.setattr(
         "driftshield.cli.commands.telemetry.post_oss_submission", fake_post

--- a/driftshield/tests/test_intake_contract.py
+++ b/driftshield/tests/test_intake_contract.py
@@ -1,13 +1,11 @@
-"""Structural pin for the duplicated phase3g.v1 intake contract.
+"""Structural pin for the phase3g.v1 intake contract.
 
-Until the contract is promoted to a shared package (Phase 3i+), this test
-locks the OSS-side models against a hardcoded reference snapshot copied
-from `driftshield-intel/src/driftshield_intel/intake_api.py:57-149`.
-
-If the canonical intel models change, update both the reference snapshot
-below AND `src/driftshield/intake_contract.py`, in lockstep. Otherwise the
-intake validator will reject submissions silently or with a misleading
-error code.
+Locks the OSS-side Pydantic models against a hardcoded reference
+snapshot that mirrors the server-side validator. If either side moves
+without the other, the intake validator will reject submissions silently
+or with a misleading error code. Update both the reference snapshot
+below AND ``src/driftshield/intake_contract.py`` in lockstep, and keep
+the server-side validator in sync.
 """
 
 from __future__ import annotations

--- a/driftshield/tests/test_intake_contract.py
+++ b/driftshield/tests/test_intake_contract.py
@@ -1,8 +1,8 @@
-"""Structural pin for the duplicated phase3f.v1 intake contract.
+"""Structural pin for the duplicated phase3g.v1 intake contract.
 
-Until the contract is promoted to a shared package (Phase 3i), this test
+Until the contract is promoted to a shared package (Phase 3i+), this test
 locks the OSS-side models against a hardcoded reference snapshot copied
-from `driftshield-intel/src/driftshield_intel/intake_api.py:35-80`.
+from `driftshield-intel/src/driftshield_intel/intake_api.py:57-149`.
 
 If the canonical intel models change, update both the reference snapshot
 below AND `src/driftshield/intake_contract.py`, in lockstep. Otherwise the
@@ -18,6 +18,8 @@ import pytest
 from pydantic import ValidationError
 
 from driftshield.intake_contract import (
+    ACCEPTED_CONTRACT_VERSIONS,
+    DEFAULT_WORKFLOW_REFERENCE,
     MAX_ENVELOPE_BYTES,
     REDACTION_MANIFEST_VERSION,
     REQUIRED_REDACTION_FIELDS,
@@ -30,9 +32,11 @@ from driftshield.intake_contract import (
 )
 
 
-# Reference snapshot — keep in sync with intake_api.py:35-80.
+# Reference snapshot — keep in sync with intake_api.py:57-149.
 _REFERENCE_CONSTANTS = {
-    "SUPPORTED_CONTRACT_VERSION": "phase3f.v1",
+    "SUPPORTED_CONTRACT_VERSION": "phase3g.v1",
+    "ACCEPTED_CONTRACT_VERSIONS": frozenset({"phase3f.v1", "phase3g.v1"}),
+    "DEFAULT_WORKFLOW_REFERENCE": "default",
     "MAX_ENVELOPE_BYTES": 256_000,
     "REDACTION_MANIFEST_VERSION": "redaction-manifest.v2",
     "REQUIRED_REDACTION_FIELDS": frozenset({"prompts", "responses", "user_identifiers"}),
@@ -62,6 +66,9 @@ _REFERENCE_FIELDS = {
         "payload",
         "payload_size_bytes",
         "redaction_manifest",
+        "agent_id",
+        "model_name",
+        "model_version",
     },
     "IntakeSubmissionRequest": {
         "installation_id",
@@ -79,9 +86,16 @@ _REFERENCE_FIELDS = {
 
 def test_contract_constants_match_canonical_snapshot():
     assert SUPPORTED_CONTRACT_VERSION == _REFERENCE_CONSTANTS["SUPPORTED_CONTRACT_VERSION"]
+    assert ACCEPTED_CONTRACT_VERSIONS == _REFERENCE_CONSTANTS["ACCEPTED_CONTRACT_VERSIONS"]
+    assert DEFAULT_WORKFLOW_REFERENCE == _REFERENCE_CONSTANTS["DEFAULT_WORKFLOW_REFERENCE"]
     assert MAX_ENVELOPE_BYTES == _REFERENCE_CONSTANTS["MAX_ENVELOPE_BYTES"]
     assert REDACTION_MANIFEST_VERSION == _REFERENCE_CONSTANTS["REDACTION_MANIFEST_VERSION"]
     assert REQUIRED_REDACTION_FIELDS == _REFERENCE_CONSTANTS["REQUIRED_REDACTION_FIELDS"]
+
+
+def test_accepted_contract_versions_includes_supported_and_predecessor():
+    assert SUPPORTED_CONTRACT_VERSION in ACCEPTED_CONTRACT_VERSIONS
+    assert "phase3f.v1" in ACCEPTED_CONTRACT_VERSIONS
 
 
 @pytest.mark.parametrize(
@@ -131,6 +145,67 @@ def test_oss_submission_request_rejects_legacy_authenticated_fields():
         })
 
 
+def test_envelope_workflow_reference_defaults_to_constant_when_omitted():
+    """phase3g.v1 envelope tightens workflow_reference to required-with-default 'default'."""
+    envelope = SubmissionEnvelope.model_validate(
+        {
+            "source_system": "oss",
+            "source_session_id": "sess-1",
+            "schema_version": SUPPORTED_CONTRACT_VERSION,
+            "payload": {"foo": "bar"},
+            "payload_size_bytes": 13,
+            "redaction_manifest": {
+                "manifest_version": REDACTION_MANIFEST_VERSION,
+                "redaction_applied": True,
+                "redacted_fields": ["prompts", "responses", "user_identifiers"],
+            },
+        }
+    )
+    assert envelope.workflow_reference == DEFAULT_WORKFLOW_REFERENCE
+
+
+def test_envelope_accepts_new_optional_provenance_fields():
+    """agent_id / model_name / model_version are optional on the envelope."""
+    envelope = SubmissionEnvelope.model_validate(
+        {
+            "source_system": "oss",
+            "source_session_id": "sess-1",
+            "schema_version": SUPPORTED_CONTRACT_VERSION,
+            "payload": {"foo": "bar"},
+            "payload_size_bytes": 13,
+            "redaction_manifest": {
+                "manifest_version": REDACTION_MANIFEST_VERSION,
+                "redaction_applied": True,
+                "redacted_fields": ["prompts", "responses", "user_identifiers"],
+            },
+            "agent_id": "agent-42",
+            "model_name": "claude-opus-4-7",
+            "model_version": "2026-05",
+        }
+    )
+    assert envelope.agent_id == "agent-42"
+    assert envelope.model_name == "claude-opus-4-7"
+    assert envelope.model_version == "2026-05"
+
+
+def test_envelope_rejects_unknown_sibling_field_alongside_new_optional_fields():
+    """extra='forbid' must still reject unknown fields after the phase3g.v1 widening."""
+    base = {
+        "source_system": "oss",
+        "source_session_id": "sess-1",
+        "schema_version": SUPPORTED_CONTRACT_VERSION,
+        "payload": {"foo": "bar"},
+        "payload_size_bytes": 13,
+        "redaction_manifest": {
+            "manifest_version": REDACTION_MANIFEST_VERSION,
+            "redaction_applied": True,
+            "redacted_fields": ["prompts", "responses", "user_identifiers"],
+        },
+    }
+    with pytest.raises(ValidationError):
+        SubmissionEnvelope.model_validate({**base, "rogue_sibling": "x"})
+
+
 def test_contract_rejects_extra_fields():
     base_manifest = {
         "manifest_version": REDACTION_MANIFEST_VERSION,
@@ -138,21 +213,21 @@ def test_contract_rejects_extra_fields():
         "redacted_fields": ["prompts", "responses", "user_identifiers"],
     }
     base_consent = {
-        "consent_version": "phase3f.v1",
+        "consent_version": SUPPORTED_CONTRACT_VERSION,
         "consent_granted": True,
         "captured_at": datetime.now(UTC).isoformat(),
     }
     base_envelope = {
         "source_system": "oss",
         "source_session_id": "sess-1",
-        "schema_version": "phase3f.v1",
+        "schema_version": SUPPORTED_CONTRACT_VERSION,
         "payload": {"foo": "bar"},
         "payload_size_bytes": 13,
         "redaction_manifest": base_manifest,
     }
     base_request = {
         "installation_id": "oss-fallback-installation",
-        "envelope_contract_version": "phase3f.v1",
+        "envelope_contract_version": SUPPORTED_CONTRACT_VERSION,
         "consent_state": base_consent,
         "envelope": base_envelope,
     }
@@ -182,7 +257,7 @@ def test_payload_size_bytes_bounds_match_canonical():
     base = {
         "source_system": "oss",
         "source_session_id": "sess-1",
-        "schema_version": "phase3f.v1",
+        "schema_version": SUPPORTED_CONTRACT_VERSION,
         "payload": {"foo": "bar"},
         "redaction_manifest": {
             "manifest_version": REDACTION_MANIFEST_VERSION,

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -10,12 +10,14 @@ from urllib import error
 import pytest
 
 from driftshield.intake_contract import (
+    DEFAULT_WORKFLOW_REFERENCE,
     REDACTION_MANIFEST_VERSION,
     REQUIRED_REDACTION_FIELDS,
     SUPPORTED_CONTRACT_VERSION,
     OssSubmissionRequest,
 )
 from driftshield.remote_submission import (
+    SERVER_CONTRACT_VERSION_HEADER,
     OssRemoteSubmissionConfig,
     RemoteSubmissionError,
     build_oss_submission_request,
@@ -178,7 +180,8 @@ def test_redact_payload_manifest_advertises_superset_even_if_missing():
     assert set(redacted_fields) == REQUIRED_REDACTION_FIELDS
 
 
-def test_build_oss_submission_request_phase3f_v1_shape():
+def test_build_oss_submission_request_phase3g_v1_shape():
+    """Builder produces a phase3g.v1 envelope with the default workflow ref."""
     payload = {
         "session_id": "sess-1",
         "prompts": ["should be stripped"],
@@ -193,11 +196,15 @@ def test_build_oss_submission_request_phase3f_v1_shape():
     )
 
     assert isinstance(request, OssSubmissionRequest)
-    assert request.envelope_contract_version == SUPPORTED_CONTRACT_VERSION
+    assert request.envelope_contract_version == SUPPORTED_CONTRACT_VERSION == "phase3g.v1"
 
     envelope = request.envelope
     assert envelope.schema_version == SUPPORTED_CONTRACT_VERSION
     assert envelope.source_session_id == "sess-1"
+    assert envelope.workflow_reference == DEFAULT_WORKFLOW_REFERENCE
+    assert envelope.agent_id is None
+    assert envelope.model_name is None
+    assert envelope.model_version is None
     assert "prompts" not in envelope.payload
     assert "responses" not in envelope.payload
     assert "user_identifiers" not in envelope.payload
@@ -207,6 +214,32 @@ def test_build_oss_submission_request_phase3f_v1_shape():
     assert envelope.redaction_manifest.manifest_version == REDACTION_MANIFEST_VERSION
     assert envelope.redaction_manifest.redaction_applied is True
     assert set(envelope.redaction_manifest.redacted_fields) == REQUIRED_REDACTION_FIELDS
+
+
+def test_build_oss_submission_request_threads_provenance_fields():
+    """agent_id / model_name / model_version are surfaced on the envelope when supplied."""
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+        agent_id="agent-42",
+        model_name="claude-opus-4-7",
+        model_version="2026-05",
+    )
+
+    envelope = request.envelope
+    assert envelope.agent_id == "agent-42"
+    assert envelope.model_name == "claude-opus-4-7"
+    assert envelope.model_version == "2026-05"
+
+
+def test_build_oss_submission_request_workflow_reference_override():
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+        workflow_reference="checkout-flow",
+    )
+
+    assert request.envelope.workflow_reference == "checkout-flow"
 
 
 def test_build_oss_submission_request_emits_manifest_v2_with_provenance():
@@ -259,8 +292,9 @@ def test_build_oss_submission_request_payload_size_bytes_is_exact():
 
 
 class _FakeHttpResponse:
-    def __init__(self, body: bytes) -> None:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None) -> None:
         self._body = body
+        self.headers = headers or {}
 
     def __enter__(self) -> "_FakeHttpResponse":
         return self
@@ -281,7 +315,8 @@ def test_post_oss_submission_happy_path():
         captured["headers"] = dict(req.headers)
         captured["body"] = req.data
         return _FakeHttpResponse(
-            json.dumps({"submission_id": "sub_abc", "processing_status": "received"}).encode("utf-8")
+            json.dumps({"submission_id": "sub_abc", "processing_status": "received"}).encode("utf-8"),
+            headers={SERVER_CONTRACT_VERSION_HEADER: SUPPORTED_CONTRACT_VERSION},
         )
 
     request = build_oss_submission_request(
@@ -289,10 +324,11 @@ def test_post_oss_submission_happy_path():
         payload={"session_id": "sess-1"},
     )
 
-    response = post_oss_submission(config=_config(), submission=request, opener=fake_opener)
+    result = post_oss_submission(config=_config(), submission=request, opener=fake_opener)
 
-    assert response.submission_id == "sub_abc"
-    assert response.processing_status == "received"
+    assert result.response.submission_id == "sub_abc"
+    assert result.response.processing_status == "received"
+    assert result.server_contract_version == SUPPORTED_CONTRACT_VERSION
     assert captured["url"] == _OSS_INTAKE_URL
     assert captured["method"] == "POST"
     # urllib.request lowercases header keys when stored on the Request object.
@@ -304,6 +340,42 @@ def test_post_oss_submission_happy_path():
     assert "installation_id" not in decoded
     assert "consent_state" not in decoded
     assert decoded["envelope_contract_version"] == SUPPORTED_CONTRACT_VERSION
+
+
+def test_post_oss_submission_surfaces_deprecated_server_header():
+    """OSS client surfaces a server-side phase3f.v1 advertisement so the CLI
+    can log a deprecation warning. AC5."""
+
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        return _FakeHttpResponse(
+            json.dumps({"submission_id": "sub_abc", "processing_status": "received"}).encode("utf-8"),
+            headers={SERVER_CONTRACT_VERSION_HEADER: "phase3f.v1"},
+        )
+
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    result = post_oss_submission(config=_config(), submission=request, opener=fake_opener)
+
+    assert result.server_contract_version == "phase3f.v1"
+
+
+def test_post_oss_submission_server_contract_version_absent_when_header_missing():
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        return _FakeHttpResponse(
+            json.dumps({"submission_id": "sub_abc", "processing_status": "received"}).encode("utf-8"),
+        )
+
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+
+    result = post_oss_submission(config=_config(), submission=request, opener=fake_opener)
+
+    assert result.server_contract_version is None
 
 
 def test_post_oss_submission_http_error_raises_remote_submission_error():


### PR DESCRIPTION
## Summary

Mirrors the intel-side phase3f.v1 → phase3g.v1 envelope bump (intel#122) on the OSS-side contract pin so the two duplicated copies stay in lockstep:

- `SUPPORTED_CONTRACT_VERSION = "phase3g.v1"` and new `ACCEPTED_CONTRACT_VERSIONS = frozenset({"phase3f.v1", "phase3g.v1"})` for contract-pin parity. The OSS module has no validator of its own; declaration is purely for the test-pin invariant.
- `SubmissionEnvelope` tightens `workflow_reference` to required-with-default `"default"` and adds three optional provenance fields `agent_id`, `model_name`, `model_version`. `extra="forbid"` preserved.
- `driftshield submit-session` CLI gains `--agent-id`, `--model-name`, `--model-version` flags. `workflow_reference` precedence is now: flag → session JSON's `workflow_reference` field → `"default"`.
- `submit-session` logs a single-line deprecation warning when the server's `X-DriftShield-Contract-Version` header is `phase3f.v1`. AC5.
- `post_oss_submission()` return type changes from `IntakeSubmissionResponse` to a new `OssSubmissionResult` wrapper that surfaces the server's advertised contract version alongside the response. Breaking change to the function signature; in-tree callers (CLI + test mocks) updated in the same PR.

Spec: https://github.com/tborys/driftshield-intel/issues/122#issuecomment-3251050557

Paired PR (intel server + audit log + migration): https://github.com/tborys/driftshield-intel/pull/138

Parent: https://github.com/tborys/driftshield-meta/issues/133

Deprecation playbook PR (meta): https://github.com/tborys/driftshield-meta/pull/231

Refs intel#122

## Test files

- `driftshield/tests/test_intake_contract.py` — extended; pins `SUPPORTED_CONTRACT_VERSION`, `ACCEPTED_CONTRACT_VERSIONS`, `DEFAULT_WORKFLOW_REFERENCE`, envelope optional fields, default workflow_reference stamping, `extra="forbid"` rejection alongside new fields.
- `driftshield/tests/test_remote_submission.py` — extended; renamed `phase3f_v1_shape` to `phase3g_v1_shape`; new tests cover provenance fields threading, workflow_reference override, deprecated server header surfacing, absent header.
- `driftshield/tests/cli/test_telemetry.py` — extended; new tests cover default workflow_reference (`"default"` when neither flag nor JSON), JSON precedence, flag precedence, deprecation log when server header is `phase3f.v1`, absence of warning on `phase3g.v1`.

## Test plan

- [x] `uv sync --extra dev && uv run --extra dev pytest`: 522 passed, 3 skipped, 0 failed locally (incl. the new --show-manifest regression test added in bf20cc1).
- [x] `uv run --extra dev ruff check src/driftshield/`: clean.
- [ ] Coordinated intel PR + meta deprecation-doc PR both green.

## Out of scope (flagged for follow-up)

- Rendering provenance fields in any OSS-side dashboard or CLI list view. Phase 4.
- Renaming `workflow_reference` to `workflow_id`. Operator chose Path A (intel#122 comment 4487034834).
- Removing `phase3f.v1` from `ACCEPTED_CONTRACT_VERSIONS` after sunset. Follow-up sub-issue.

