### PR TITLE
chore(oss): scrub driftshield-infra reference from seed migration comment (driftshield#113)

### DIFF
--- a/driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py
+++ b/driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py
@@ -21,7 +21,7 @@ depends_on: Sequence[str] | None = None
 
 LOGGER = logging.getLogger("alembic.runtime.migration")
 
-# Keep the hard-coded row UUIDs aligned with driftshield-infra fallback env wiring/test fixtures.
+# Keep the hard-coded row UUIDs aligned with the matching server-side fallback env vars and the smoke test fixtures.
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary

Replaces the comment on line 24 of ``driftshield/src/driftshield/db/migrations/versions/20260512_02_seed_oss_fallback_installation.py`` so the public tree no longer references a private sibling repo by name. Self-contained explanation of the row-UUID invariant, no behaviour change.

The leak was caught by a grep gate run during review of #112 (intel#122 OSS PR). It predates #112 and was filed here as a small standalone cleanup so it didn't get rolled into the larger contract-bump diff.

## Acceptance

- ``grep -rn "driftshield-meta|driftshield-intel|driftshield-infra" driftshield/src driftshield/tests`` returns zero hits (verified locally).
- No behaviour change; comment-only edit on a migration file that won't re-run.

Closes #113

## Test plan

- [x] ``uv sync --extra dev && uv run --extra dev pytest``: 522 passed, 3 skipped locally.
- [x] ``uv run --extra dev ruff check src/driftshield/``: clean.
- [x] Grep gate against the full public tree confirms zero remaining ``driftshield-{meta,intel,infra}`` substring hits.