### PR TITLE
feat(intake-contract): add signature_summary block to OSS submission envelope

### DIFF
--- a/driftshield/src/driftshield/cli/_signature_summary.py
+++ b/driftshield/src/driftshield/cli/_signature_summary.py
@@ -1,0 +1,214 @@
+"""Build a signature summary from a finished session file.
+
+Shared helper between the ``telemetry submit-session`` and ``ingest``
+commands. Given a session file path, parse it through the local
+deterministic matcher and project the result into the public envelope
+shape (:class:`driftshield.intake_contract.SignatureSummary`).
+
+Both ``community_pack_id``/``community_pack_version`` (the bundled
+community pack) and ``matcher_id``/``matcher_version`` (the deterministic
+ruleset) are stamped on every entry so the receiving endpoint can keep a
+public-safe audit trail of which pack and which ruleset produced the
+locally derived match.
+
+Only the six identification + provenance fields plus ``match_status``,
+``confidence`` and ``confidence_band`` are emitted. Recurrence, ranking
+and any private-pack identifiers stay local by construction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from driftshield.cli.parsers import (
+    ParserNotFoundError,
+    detect_parser,
+    get_parser,
+)
+from driftshield.core.analysis.session import analyze_session
+from driftshield.core.canonical_analysis import build_canonical_analysis
+from driftshield.core.deterministic_matching import (
+    MATCHING_SCHEMA_VERSION,
+    RULESET_VERSION,
+    build_deterministic_match,
+    build_signature_match_summary,
+)
+from driftshield.core.models import Session as DomainSession, SessionStatus
+from driftshield.core.normalization import normalize_events
+from driftshield.db.persistence import IngestProvenance
+from driftshield.intake_contract import (
+    MAX_SIGNATURE_SUMMARY_ENTRIES,
+    SIGNATURE_SUMMARY_VERSION,
+    SignatureSummary,
+    SignatureSummaryEntry,
+)
+from driftshield.signatures.community import load_builtin_community_pack
+
+
+_MATCHER_ID = MATCHING_SCHEMA_VERSION
+
+
+def _confidence_band(confidence: float | None) -> str | None:
+    """Coarse band the receiving endpoint can group on without storing the raw float."""
+    if confidence is None:
+        return None
+    if confidence >= 0.75:
+        return "high"
+    if confidence >= 0.5:
+        return "medium"
+    if confidence >= 0.25:
+        return "low"
+    return "very_low"
+
+
+def _coerce_confidence(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return None
+    if as_float < 0.0:
+        return 0.0
+    if as_float > 1.0:
+        return 1.0
+    return as_float
+
+
+def _coerce_str(value: Any, *, max_length: int) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    return trimmed[:max_length]
+
+
+def build_signature_summary_from_match(
+    *,
+    signature_match: dict[str, Any],
+    community_pack_id: str,
+    community_pack_version: str,
+    matcher_id: str = _MATCHER_ID,
+    matcher_version: str = RULESET_VERSION,
+) -> SignatureSummary:
+    """Project a ``build_signature_match_summary`` payload to the public envelope shape.
+
+    Pure function over a known dict. Callers wire in the pack identifiers
+    so the bundled-pack default can be overridden by tests.
+    """
+    raw_matches = signature_match.get("matches") or []
+    entries: list[SignatureSummaryEntry] = []
+    dropped = 0
+    for raw in raw_matches:
+        if not isinstance(raw, dict):
+            continue
+        if len(entries) >= MAX_SIGNATURE_SUMMARY_ENTRIES:
+            dropped += 1
+            continue
+
+        signature_id = _coerce_str(raw.get("signature_id"), max_length=64)
+        if signature_id is None:
+            continue
+
+        confidence = _coerce_confidence(raw.get("confidence"))
+        entry = SignatureSummaryEntry(
+            signature_id=signature_id,
+            signature_version=None,
+            mechanism_id=_coerce_str(raw.get("mechanism_id"), max_length=48),
+            match_status="matched",
+            confidence=confidence,
+            confidence_band=_confidence_band(confidence),
+            community_pack_id=community_pack_id,
+            community_pack_version=community_pack_version,
+            matcher_id=matcher_id,
+            matcher_version=matcher_version,
+        )
+        entries.append(entry)
+
+    if dropped:
+        print(
+            f"warning: signature summary truncated to "
+            f"{MAX_SIGNATURE_SUMMARY_ENTRIES} entries; "
+            f"{dropped} additional match(es) dropped",
+            file=sys.stderr,
+        )
+
+    return SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=entries,
+    )
+
+
+def build_signature_summary_from_session(session_path: Path) -> SignatureSummary | None:
+    """Parse a session file, run the local matcher, and project to SignatureSummary.
+
+    Returns ``None`` when no parser can be detected for the path. Any other
+    parse or analysis failure raises through to the caller so the CLI can
+    surface it.
+    """
+    parser_name = detect_parser(session_path)
+    if parser_name is None:
+        return None
+
+    try:
+        parser = get_parser(parser_name)
+    except ParserNotFoundError:
+        return None
+
+    events = parser.parse_file(str(session_path))
+    if not events:
+        return None
+
+    session_id = uuid.uuid4()
+    normalize_events(events, source_type=getattr(parser, "source_type", None), source_path=str(session_path))
+    result = analyze_session(events, session_id=str(session_id))
+
+    domain_session = DomainSession(
+        id=session_id,
+        agent_id=events[0].agent_id or "unknown",
+        started_at=events[0].timestamp,
+        external_id=events[0].session_id or None,
+        status=SessionStatus.COMPLETED,
+    )
+    transcript_hash = hashlib.sha256(session_path.read_bytes()).hexdigest()
+    provenance = IngestProvenance(
+        transcript_hash=transcript_hash,
+        source_session_id=events[0].session_id or None,
+        source_path=str(session_path),
+        parser_version=f"{parser_name}@1",
+        ingested_at=datetime.now(timezone.utc),
+    )
+
+    canonical_analysis = build_canonical_analysis(
+        session=domain_session,
+        result=result,
+        provenance=provenance,
+    )
+    deterministic_match = build_deterministic_match(
+        canonical_analysis=canonical_analysis,
+        result=result,
+    )
+    signature_match = build_signature_match_summary(deterministic_match)
+
+    pack = load_builtin_community_pack()
+    return build_signature_summary_from_match(
+        signature_match=signature_match,
+        community_pack_id=pack.metadata.name,
+        community_pack_version=pack.metadata.version,
+        matcher_id=_MATCHER_ID,
+        matcher_version=RULESET_VERSION,
+    )
+
+
+__all__ = [
+    "build_signature_summary_from_match",
+    "build_signature_summary_from_session",
+]

--- a/driftshield/src/driftshield/cli/commands/ingest.py
+++ b/driftshield/src/driftshield/cli/commands/ingest.py
@@ -51,6 +51,7 @@ class SubmissionContext:
     workflow_reference: str | None = None
     project_reference: str | None = None
     source_connector: SourceConnectorMetadata | None = None
+    signature_summary_json: str | None = None
 
 
 def ingest(
@@ -129,6 +130,15 @@ def ingest(
         help="Optional source connector parser name.",
         envvar="DRIFTSHIELD_SOURCE_CONNECTOR_PARSER",
     ),
+    include_analysis: bool = typer.Option(
+        False,
+        "--include-analysis",
+        help=(
+            "Run the local deterministic matcher and attach a signature_summary "
+            "form field to the multipart upload. Off by default; no behavioural "
+            "change vs the default ingest path when omitted."
+        ),
+    ),
 ) -> None:
     """Upload a transcript to the DriftShield ingest API."""
     selected = [bool(path), project, latest]
@@ -180,6 +190,30 @@ def ingest(
     except error.URLError as exc:
         console.print(f"[red]Error:[/red] Could not reach Teams auth-check endpoint: {exc.reason}")
         raise typer.Exit(1) from exc
+
+    if include_analysis:
+        try:
+            from driftshield.cli._signature_summary import (
+                build_signature_summary_from_session,
+            )
+
+            summary = build_signature_summary_from_session(file_path)
+        except Exception as exc:  # noqa: BLE001
+            console.print(
+                f"[yellow]Warning:[/yellow] Could not derive signature_summary "
+                f"({exc}). Ingest will proceed without it."
+            )
+            summary = None
+        if summary is not None:
+            submission_context = SubmissionContext(
+                submission_tier=submission_context.submission_tier,
+                tenant_id=submission_context.tenant_id,
+                workspace_id=submission_context.workspace_id,
+                workflow_reference=submission_context.workflow_reference,
+                project_reference=submission_context.project_reference,
+                source_connector=submission_context.source_connector,
+                signature_summary_json=summary.model_dump_json(),
+            )
 
     target_url = api_url.rstrip("/") + "/api/ingest"
 
@@ -390,6 +424,12 @@ def _build_multipart_body(
         boundary=boundary,
         name="project_reference",
         value=submission_context.project_reference,
+    )
+    _append_optional_text_form_field(
+        segments,
+        boundary=boundary,
+        name="signature_summary",
+        value=submission_context.signature_summary_json,
     )
     if submission_context.source_connector is not None:
         source_connector_payload = submission_context.source_connector.as_payload()

--- a/driftshield/src/driftshield/cli/commands/ingest.py
+++ b/driftshield/src/driftshield/cli/commands/ingest.py
@@ -192,28 +192,37 @@ def ingest(
         raise typer.Exit(1) from exc
 
     if include_analysis:
-        try:
-            from driftshield.cli._signature_summary import (
-                build_signature_summary_from_session,
-            )
+        from driftshield.cli._signature_summary import (
+            build_signature_summary_from_session,
+        )
 
+        try:
             summary = build_signature_summary_from_session(file_path)
         except Exception as exc:  # noqa: BLE001
-            console.print(
-                f"[yellow]Warning:[/yellow] Could not derive signature_summary "
-                f"({exc}). Ingest will proceed without it."
+            typer.echo(
+                "error: --include-analysis specified but "
+                f"build_signature_summary_from_session(...) failed: {exc}",
+                err=True,
             )
-            summary = None
-        if summary is not None:
-            submission_context = SubmissionContext(
-                submission_tier=submission_context.submission_tier,
-                tenant_id=submission_context.tenant_id,
-                workspace_id=submission_context.workspace_id,
-                workflow_reference=submission_context.workflow_reference,
-                project_reference=submission_context.project_reference,
-                source_connector=submission_context.source_connector,
-                signature_summary_json=summary.model_dump_json(),
+            raise typer.Exit(code=2) from exc
+        if summary is None:
+            typer.echo(
+                "error: --include-analysis specified but "
+                "build_signature_summary_from_session(...) could not produce "
+                "a summary (no parser detected or session yielded no events). "
+                "Re-run without --include-analysis or supply a parseable session.",
+                err=True,
             )
+            raise typer.Exit(code=2)
+        submission_context = SubmissionContext(
+            submission_tier=submission_context.submission_tier,
+            tenant_id=submission_context.tenant_id,
+            workspace_id=submission_context.workspace_id,
+            workflow_reference=submission_context.workflow_reference,
+            project_reference=submission_context.project_reference,
+            source_connector=submission_context.source_connector,
+            signature_summary_json=summary.model_dump_json(),
+        )
 
     target_url = api_url.rstrip("/") + "/api/ingest"
 

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -19,6 +19,7 @@ from driftshield.recursive_redactor import (
     REDACTION_RULESET_VERSION,
     REDACTOR_VERSION,
 )
+from driftshield.cli._signature_summary import build_signature_summary_from_session
 from driftshield.remote_submission import (
     OssRemoteSubmissionConfig,
     RemoteSubmissionError,
@@ -143,6 +144,15 @@ def telemetry_submit_session(
         "--force-unknown-shape",
         help="Submit even if the transcript top-level shape is not recognised by the redactor.",
     ),
+    include_analysis: bool = typer.Option(
+        False,
+        "--include-analysis",
+        help=(
+            "Run the local deterministic matcher and attach a signature_summary "
+            "block to the envelope. Off by default; no behavioural change vs the "
+            "default submission path when omitted."
+        ),
+    ),
 ) -> None:
     """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
 
@@ -218,6 +228,16 @@ def telemetry_submit_session(
     if resolved_workflow_reference is None:
         resolved_workflow_reference = DEFAULT_WORKFLOW_REFERENCE
 
+    summary = None
+    if include_analysis:
+        try:
+            summary = build_signature_summary_from_session(path)
+        except Exception as exc:  # noqa: BLE001
+            console.print(
+                f"[yellow]Warning:[/yellow] Could not derive signature_summary "
+                f"({exc}). Submission will proceed without it."
+            )
+
     try:
         submission = build_oss_submission_request(
             source_session_id=source_session_id or path.stem,
@@ -229,6 +249,7 @@ def telemetry_submit_session(
             agent_id=agent_id,
             model_name=model_name,
             model_version=model_version,
+            signature_summary=summary,
         )
     except UnknownTranscriptShapeError as exc:
         console.print(

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -233,10 +233,21 @@ def telemetry_submit_session(
         try:
             summary = build_signature_summary_from_session(path)
         except Exception as exc:  # noqa: BLE001
-            console.print(
-                f"[yellow]Warning:[/yellow] Could not derive signature_summary "
-                f"({exc}). Submission will proceed without it."
+            typer.echo(
+                "error: --include-analysis specified but "
+                f"build_signature_summary_from_session(...) failed: {exc}",
+                err=True,
             )
+            raise typer.Exit(code=2) from exc
+        if summary is None:
+            typer.echo(
+                "error: --include-analysis specified but "
+                "build_signature_summary_from_session(...) could not produce "
+                "a summary (no parser detected or session yielded no events). "
+                "Re-run without --include-analysis or supply a parseable session.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
 
     try:
         submission = build_oss_submission_request(

--- a/driftshield/src/driftshield/db/hosted_schema_sql.py
+++ b/driftshield/src/driftshield/db/hosted_schema_sql.py
@@ -106,6 +106,8 @@ def build_hosted_base_sql() -> tuple[str, ...]:
             review_needed boolean not null default false,
             visibility_class text not null default 'internal_only',
             recurrence_group_key text,
+            source_trust text not null default 'client_supplied_oss'
+                check (source_trust in ('client_supplied_oss', 'server_derived')),
             created_at timestamptz not null default timezone('utc', now())
         )
         """,

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -38,6 +38,42 @@ REQUIRED_REDACTION_FIELDS: frozenset[str] = frozenset(
     {"prompts", "responses", "user_identifiers"}
 )
 
+# Signature summary block (envelope-level sibling of ``payload``).
+#
+# Locally derived deterministic-matcher output for a single submission so a
+# remote endpoint can record what the OSS-side analyser already produced.
+# Sits at envelope level, not inside ``payload``, the recursive redactor
+# only walks ``payload``, so the summary is untouched by construction.
+SIGNATURE_SUMMARY_VERSION = "signature-summary.v1"
+ACCEPTED_SIGNATURE_SUMMARY_VERSIONS: frozenset[str] = frozenset(
+    {SIGNATURE_SUMMARY_VERSION}
+)
+MAX_SIGNATURE_SUMMARY_ENTRIES = 50
+
+
+class SignatureSummaryEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    signature_id: str = Field(min_length=1, max_length=64)
+    signature_version: str | None = Field(default=None, max_length=24)
+    mechanism_id: str | None = Field(default=None, max_length=48)
+    match_status: str = Field(min_length=1, max_length=24)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    confidence_band: str | None = Field(default=None, max_length=24)
+    community_pack_id: str = Field(min_length=1, max_length=48)
+    community_pack_version: str = Field(min_length=1, max_length=32)
+    matcher_id: str = Field(min_length=1, max_length=48)
+    matcher_version: str = Field(min_length=1, max_length=40)
+
+
+class SignatureSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(min_length=1)
+    matches: list[SignatureSummaryEntry] = Field(
+        default_factory=list, max_length=MAX_SIGNATURE_SUMMARY_ENTRIES
+    )
+
 
 class RedactionManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -76,6 +112,9 @@ class SubmissionEnvelope(BaseModel):
     agent_id: str | None = Field(default=None, min_length=1)
     model_name: str | None = Field(default=None, min_length=1)
     model_version: str | None = Field(default=None, min_length=1)
+    # Envelope-level sibling of ``payload``. The recursive redactor only
+    # walks ``payload``; this block stays byte-identical end-to-end.
+    signature_summary: SignatureSummary | None = None
 
 
 class IntakeSubmissionRequest(BaseModel):

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -27,6 +27,7 @@ from driftshield.intake_contract import (
     IntakeSubmissionResponse,
     OssSubmissionRequest,
     RedactionManifest,
+    SignatureSummary,
     SubmissionEnvelope,
 )
 from driftshield.recursive_redactor import (
@@ -138,6 +139,7 @@ def build_oss_submission_request(
     agent_id: str | None = None,
     model_name: str | None = None,
     model_version: str | None = None,
+    signature_summary: SignatureSummary | None = None,
 ) -> OssSubmissionRequest:
     """Build an unauthenticated OSS submission request.
 
@@ -184,6 +186,7 @@ def build_oss_submission_request(
         agent_id=agent_id,
         model_name=model_name,
         model_version=model_version,
+        signature_summary=signature_summary,
     )
     return OssSubmissionRequest(
         envelope_contract_version=SUPPORTED_CONTRACT_VERSION,

--- a/driftshield/tests/cli/test_ingest.py
+++ b/driftshield/tests/cli/test_ingest.py
@@ -358,3 +358,147 @@ def test_ingest_teams_submission_uses_server_resolved_context(monkeypatch):
             workspace_id="workspace-resolved",
         ),
     }
+
+
+# ---------------------------------------------------------------------------
+# --include-analysis flag on ingest
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_default_no_signature_summary(monkeypatch):
+    """Default invocation does not attach a signature_summary form field."""
+    captured: dict[str, object] = {}
+
+    def fake_post_ingest(*, target_url, api_key, file_path, parser, submission_context):  # noqa: ARG001
+        captured["submission_context"] = submission_context
+        return DummyResponse()._payload
+
+    monkeypatch.setenv("DRIFTSHIELD_API_URL", "http://localhost:8000")
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "test-key")
+    monkeypatch.setattr("driftshield.cli.commands.ingest.post_ingest", fake_post_ingest)
+
+    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
+    result = runner.invoke(app, ["ingest", "--path", str(transcript)])
+
+    assert result.exit_code == 0
+    context = captured["submission_context"]
+    assert isinstance(context, SubmissionContext)
+    assert context.signature_summary_json is None
+
+
+def test_ingest_with_include_analysis_attaches_signature_summary(monkeypatch):
+    """--include-analysis populates SubmissionContext.signature_summary_json."""
+    from driftshield.intake_contract import (
+        SIGNATURE_SUMMARY_VERSION,
+        SignatureSummary,
+        SignatureSummaryEntry,
+    )
+
+    fake_summary = SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=[
+            SignatureSummaryEntry(
+                signature_id="sig-abc",
+                match_status="matched",
+                community_pack_id="community-general",
+                community_pack_version="1.0.0",
+                matcher_id="phase-3g-deterministic-v1",
+                matcher_version="phase-3g-deterministic-rules-v1",
+                confidence=0.9,
+                confidence_band="high",
+            )
+        ],
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_post_ingest(*, target_url, api_key, file_path, parser, submission_context):  # noqa: ARG001
+        captured["submission_context"] = submission_context
+        return DummyResponse()._payload
+
+    monkeypatch.setenv("DRIFTSHIELD_API_URL", "http://localhost:8000")
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "test-key")
+    monkeypatch.setattr("driftshield.cli.commands.ingest.post_ingest", fake_post_ingest)
+    monkeypatch.setattr(
+        "driftshield.cli._signature_summary.build_signature_summary_from_session",
+        lambda _path: fake_summary,
+    )
+
+    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
+    result = runner.invoke(
+        app, ["ingest", "--path", str(transcript), "--include-analysis"]
+    )
+
+    assert result.exit_code == 0
+    context = captured["submission_context"]
+    assert isinstance(context, SubmissionContext)
+    assert context.signature_summary_json is not None
+    decoded = json.loads(context.signature_summary_json)
+    assert decoded["schema_version"] == SIGNATURE_SUMMARY_VERSION
+    assert decoded["matches"][0]["signature_id"] == "sig-abc"
+
+
+def test_ingest_include_analysis_handles_builder_failure(monkeypatch):
+    """If the local matcher fails under --include-analysis, ingest still proceeds."""
+    captured: dict[str, object] = {}
+
+    def fake_post_ingest(*, target_url, api_key, file_path, parser, submission_context):  # noqa: ARG001
+        captured["submission_context"] = submission_context
+        return DummyResponse()._payload
+
+    def boom(_path):
+        raise RuntimeError("matcher exploded")
+
+    monkeypatch.setenv("DRIFTSHIELD_API_URL", "http://localhost:8000")
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "test-key")
+    monkeypatch.setattr("driftshield.cli.commands.ingest.post_ingest", fake_post_ingest)
+    monkeypatch.setattr(
+        "driftshield.cli._signature_summary.build_signature_summary_from_session",
+        boom,
+    )
+
+    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
+    result = runner.invoke(
+        app, ["ingest", "--path", str(transcript), "--include-analysis"]
+    )
+
+    assert result.exit_code == 0
+    context = captured["submission_context"]
+    assert isinstance(context, SubmissionContext)
+    assert context.signature_summary_json is None
+    assert "warning" in result.output.lower()
+
+
+def test_build_multipart_body_includes_signature_summary_field():
+    """signature_summary form field is written when SubmissionContext carries it."""
+    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
+
+    summary_json = '{"schema_version": "signature-summary.v1", "matches": []}'
+    body = _build_multipart_body(
+        boundary="test-boundary",
+        file_path=transcript,
+        parser="claude_code",
+        submission_context=SubmissionContext(
+            submission_tier="oss",
+            signature_summary_json=summary_json,
+        ),
+    )
+
+    decoded = body.decode("utf-8", errors="ignore")
+    assert 'name="signature_summary"' in decoded
+    assert "signature-summary.v1" in decoded
+
+
+def test_build_multipart_body_omits_signature_summary_when_absent():
+    """No signature_summary field appears when SubmissionContext.signature_summary_json is None."""
+    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
+
+    body = _build_multipart_body(
+        boundary="test-boundary",
+        file_path=transcript,
+        parser="claude_code",
+        submission_context=SubmissionContext(submission_tier="oss"),
+    )
+
+    decoded = body.decode("utf-8", errors="ignore")
+    assert 'name="signature_summary"' not in decoded

--- a/driftshield/tests/cli/test_ingest.py
+++ b/driftshield/tests/cli/test_ingest.py
@@ -438,12 +438,16 @@ def test_ingest_with_include_analysis_attaches_signature_summary(monkeypatch):
     assert decoded["matches"][0]["signature_id"] == "sig-abc"
 
 
-def test_ingest_include_analysis_handles_builder_failure(monkeypatch):
-    """If the local matcher fails under --include-analysis, ingest still proceeds."""
-    captured: dict[str, object] = {}
+def test_ingest_include_analysis_strict_fail_on_builder_error(monkeypatch):
+    """--include-analysis is strict: any builder exception fails the command.
+
+    The ingest POST MUST NOT happen and the exit code MUST be non-zero so the
+    operator notices that the explicit opt-in could not be honoured.
+    """
+    posted = {"called": False}
 
     def fake_post_ingest(*, target_url, api_key, file_path, parser, submission_context):  # noqa: ARG001
-        captured["submission_context"] = submission_context
+        posted["called"] = True
         return DummyResponse()._payload
 
     def boom(_path):
@@ -462,11 +466,54 @@ def test_ingest_include_analysis_handles_builder_failure(monkeypatch):
         app, ["ingest", "--path", str(transcript), "--include-analysis"]
     )
 
+    assert result.exit_code != 0
+    assert posted["called"] is False
+    assert "build_signature_summary_from_session" in result.stderr
+    assert "matcher exploded" in result.stderr
+
+
+def test_ingest_include_analysis_empty_matches_is_valid_success(monkeypatch):
+    """An empty matches list IS a valid success path under --include-analysis.
+
+    Zero matches is not a builder failure: the multipart upload proceeds with
+    the empty SignatureSummary attached as the signature_summary form field.
+    """
+    from driftshield.intake_contract import (
+        SIGNATURE_SUMMARY_VERSION,
+        SignatureSummary,
+    )
+
+    empty_summary = SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=[],
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_post_ingest(*, target_url, api_key, file_path, parser, submission_context):  # noqa: ARG001
+        captured["submission_context"] = submission_context
+        return DummyResponse()._payload
+
+    monkeypatch.setenv("DRIFTSHIELD_API_URL", "http://localhost:8000")
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "test-key")
+    monkeypatch.setattr("driftshield.cli.commands.ingest.post_ingest", fake_post_ingest)
+    monkeypatch.setattr(
+        "driftshield.cli._signature_summary.build_signature_summary_from_session",
+        lambda _path: empty_summary,
+    )
+
+    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
+    result = runner.invoke(
+        app, ["ingest", "--path", str(transcript), "--include-analysis"]
+    )
+
     assert result.exit_code == 0
     context = captured["submission_context"]
     assert isinstance(context, SubmissionContext)
-    assert context.signature_summary_json is None
-    assert "warning" in result.output.lower()
+    assert context.signature_summary_json is not None
+    decoded = json.loads(context.signature_summary_json)
+    assert decoded["schema_version"] == SIGNATURE_SUMMARY_VERSION
+    assert decoded["matches"] == []
 
 
 def test_build_multipart_body_includes_signature_summary_field():

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -791,15 +791,21 @@ def test_submit_session_with_include_analysis_populates_signature_summary(
     assert captured["signature_summary"].matches[0].signature_id == "sig-abc"
 
 
-def test_submit_session_include_analysis_handles_builder_failure(tmp_path, monkeypatch):
-    """If the local matcher fails, submission still proceeds with signature_summary=None."""
+def test_submit_session_include_analysis_strict_fail_on_builder_error(
+    tmp_path, monkeypatch
+):
+    """--include-analysis is strict: any builder exception fails the command.
+
+    The submission MUST NOT be sent and the exit code MUST be non-zero so the
+    operator notices that the explicit opt-in could not be honoured.
+    """
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     runner.invoke(app, _remote_enable_argv())
     session_path = _write_session(tmp_path, {"session_id": "sess-1"})
-    captured = {}
+    posted = {"called": False}
 
     def fake_post(*, config, submission, opener=None):  # noqa: ARG001
-        captured["signature_summary"] = submission.envelope.signature_summary
+        posted["called"] = True
         return _ok_result()
 
     def boom(_path):
@@ -823,6 +829,59 @@ def test_submit_session_include_analysis_handles_builder_failure(tmp_path, monke
         ],
     )
 
+    assert result.exit_code != 0
+    assert posted["called"] is False
+    assert "build_signature_summary_from_session" in result.stderr
+    assert "matcher exploded" in result.stderr
+
+
+def test_submit_session_include_analysis_empty_matches_is_valid_success(
+    tmp_path, monkeypatch
+):
+    """An empty matches list IS a valid success path under --include-analysis.
+
+    Zero matches is not a builder failure: the submission proceeds with the
+    empty SignatureSummary attached.
+    """
+    from driftshield.intake_contract import (
+        SIGNATURE_SUMMARY_VERSION,
+        SignatureSummary,
+    )
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["signature_summary"] = submission.envelope.signature_summary
+        return _ok_result()
+
+    empty_summary = SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=[],
+    )
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.build_signature_summary_from_session",
+        lambda _path: empty_summary,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--include-analysis",
+        ],
+    )
+
     assert result.exit_code == 0
-    assert captured["signature_summary"] is None
-    assert "warning" in result.stdout.lower()
+    assert captured["signature_summary"] is not None
+    assert captured["signature_summary"].schema_version == SIGNATURE_SUMMARY_VERSION
+    assert captured["signature_summary"].matches == []

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -701,3 +701,128 @@ def test_submit_session_surfaces_remote_error(tmp_path, monkeypatch):
     assert result.exit_code == 1
     assert "422" in result.stdout
     assert "invalid_redaction_manifest" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# --include-analysis flag on submit-session
+# ---------------------------------------------------------------------------
+
+
+def test_submit_session_default_no_signature_summary(tmp_path, monkeypatch):
+    """Default invocation (no --include-analysis) keeps signature_summary=None."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["signature_summary"] = submission.envelope.signature_summary
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert captured["signature_summary"] is None
+
+
+def test_submit_session_with_include_analysis_populates_signature_summary(
+    tmp_path, monkeypatch
+):
+    """--include-analysis triggers the local matcher and attaches the block."""
+    from driftshield.intake_contract import (
+        SIGNATURE_SUMMARY_VERSION,
+        SignatureSummary,
+        SignatureSummaryEntry,
+    )
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["signature_summary"] = submission.envelope.signature_summary
+        return _ok_result()
+
+    fake_summary = SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=[
+            SignatureSummaryEntry(
+                signature_id="sig-abc",
+                match_status="matched",
+                community_pack_id="community-general",
+                community_pack_version="1.0.0",
+                matcher_id="phase-3g-deterministic-v1",
+                matcher_version="phase-3g-deterministic-rules-v1",
+                confidence=0.9,
+                confidence_band="high",
+            )
+        ],
+    )
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.build_signature_summary_from_session",
+        lambda _path: fake_summary,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--include-analysis",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["signature_summary"] is not None
+    assert captured["signature_summary"].schema_version == SIGNATURE_SUMMARY_VERSION
+    assert captured["signature_summary"].matches[0].signature_id == "sig-abc"
+
+
+def test_submit_session_include_analysis_handles_builder_failure(tmp_path, monkeypatch):
+    """If the local matcher fails, submission still proceeds with signature_summary=None."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["signature_summary"] = submission.envelope.signature_summary
+        return _ok_result()
+
+    def boom(_path):
+        raise RuntimeError("matcher exploded")
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.build_signature_summary_from_session", boom
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--include-analysis",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["signature_summary"] is None
+    assert "warning" in result.stdout.lower()

--- a/driftshield/tests/test_intake_contract.py
+++ b/driftshield/tests/test_intake_contract.py
@@ -67,6 +67,7 @@ _REFERENCE_FIELDS = {
         "agent_id",
         "model_name",
         "model_version",
+        "signature_summary",
     },
     "IntakeSubmissionRequest": {
         "installation_id",
@@ -270,3 +271,152 @@ def test_payload_size_bytes_bounds_match_canonical():
 
     accepted = SubmissionEnvelope.model_validate({**base, "payload_size_bytes": 1})
     assert accepted.payload_size_bytes == 1
+
+
+# ---------------------------------------------------------------------------
+# signature_summary block (envelope-level sibling of payload)
+# ---------------------------------------------------------------------------
+
+
+from driftshield.intake_contract import (  # noqa: E402
+    ACCEPTED_SIGNATURE_SUMMARY_VERSIONS,
+    MAX_SIGNATURE_SUMMARY_ENTRIES,
+    SIGNATURE_SUMMARY_VERSION,
+    SignatureSummary,
+    SignatureSummaryEntry,
+)
+
+
+_BASE_ENTRY = {
+    "signature_id": "sig-abc",
+    "match_status": "matched",
+    "community_pack_id": "community-general",
+    "community_pack_version": "1.0.0",
+    "matcher_id": "phase-3g-deterministic-v1",
+    "matcher_version": "phase-3g-deterministic-rules-v1",
+}
+
+
+def _envelope_body(*, signature_summary: dict | None = None) -> dict:
+    body = {
+        "source_system": "oss",
+        "source_session_id": "sess-1",
+        "schema_version": SUPPORTED_CONTRACT_VERSION,
+        "payload": {"foo": "bar"},
+        "payload_size_bytes": 13,
+        "redaction_manifest": {
+            "manifest_version": REDACTION_MANIFEST_VERSION,
+            "redaction_applied": True,
+            "redacted_fields": ["prompts", "responses", "user_identifiers"],
+        },
+    }
+    if signature_summary is not None:
+        body["signature_summary"] = signature_summary
+    return body
+
+
+def test_signature_summary_constants_match_canonical_snapshot():
+    assert SIGNATURE_SUMMARY_VERSION == "signature-summary.v1"
+    assert ACCEPTED_SIGNATURE_SUMMARY_VERSIONS == frozenset({SIGNATURE_SUMMARY_VERSION})
+    assert MAX_SIGNATURE_SUMMARY_ENTRIES == 50
+
+
+def test_envelope_signature_summary_optional():
+    envelope = SubmissionEnvelope.model_validate(_envelope_body())
+    assert envelope.signature_summary is None
+
+
+def test_envelope_accepts_signature_summary():
+    summary = {
+        "schema_version": SIGNATURE_SUMMARY_VERSION,
+        "matches": [
+            {**_BASE_ENTRY, "confidence": 0.85, "confidence_band": "high"},
+        ],
+    }
+    envelope = SubmissionEnvelope.model_validate(
+        _envelope_body(signature_summary=summary)
+    )
+    assert envelope.signature_summary is not None
+    assert envelope.signature_summary.schema_version == SIGNATURE_SUMMARY_VERSION
+    assert len(envelope.signature_summary.matches) == 1
+    entry = envelope.signature_summary.matches[0]
+    assert entry.signature_id == "sig-abc"
+    assert entry.confidence == 0.85
+    assert entry.confidence_band == "high"
+
+    # OssSubmissionRequest carries the block through to the request body.
+    request = OssSubmissionRequest.model_validate(
+        {
+            "envelope_contract_version": SUPPORTED_CONTRACT_VERSION,
+            "envelope": _envelope_body(signature_summary=summary),
+        }
+    )
+    assert request.envelope.signature_summary is not None
+    assert request.envelope.signature_summary.matches[0].signature_id == "sig-abc"
+
+
+def test_envelope_rejects_unknown_signature_summary_fields():
+    summary = {
+        "schema_version": SIGNATURE_SUMMARY_VERSION,
+        "matches": [{**_BASE_ENTRY, "rogue": "value"}],
+    }
+    with pytest.raises(ValidationError):
+        SubmissionEnvelope.model_validate(_envelope_body(signature_summary=summary))
+
+    summary_with_extra_top = {
+        "schema_version": SIGNATURE_SUMMARY_VERSION,
+        "matches": [],
+        "rogue_top": "x",
+    }
+    with pytest.raises(ValidationError):
+        SubmissionEnvelope.model_validate(
+            _envelope_body(signature_summary=summary_with_extra_top)
+        )
+
+
+@pytest.mark.parametrize(
+    "field_name, max_length",
+    [
+        ("signature_id", 64),
+        ("community_pack_version", 32),
+        ("matcher_version", 40),
+    ],
+)
+def test_signature_summary_per_field_caps_enforced(field_name, max_length):
+    at_cap = {**_BASE_ENTRY, field_name: "a" * max_length}
+    accepted = SignatureSummaryEntry.model_validate(at_cap)
+    assert getattr(accepted, field_name) == "a" * max_length
+
+    over_cap = {**_BASE_ENTRY, field_name: "a" * (max_length + 1)}
+    with pytest.raises(ValidationError):
+        SignatureSummaryEntry.model_validate(over_cap)
+
+
+def test_signature_summary_50_entry_cap():
+    base_matches = [dict(_BASE_ENTRY) for _ in range(MAX_SIGNATURE_SUMMARY_ENTRIES)]
+    accepted = SignatureSummary.model_validate(
+        {
+            "schema_version": SIGNATURE_SUMMARY_VERSION,
+            "matches": base_matches,
+        }
+    )
+    assert len(accepted.matches) == MAX_SIGNATURE_SUMMARY_ENTRIES
+
+    over_cap_matches = [dict(_BASE_ENTRY) for _ in range(MAX_SIGNATURE_SUMMARY_ENTRIES + 1)]
+    with pytest.raises(ValidationError):
+        SignatureSummary.model_validate(
+            {
+                "schema_version": SIGNATURE_SUMMARY_VERSION,
+                "matches": over_cap_matches,
+            }
+        )
+
+
+def test_signature_summary_confidence_bounds():
+    with pytest.raises(ValidationError):
+        SignatureSummaryEntry.model_validate({**_BASE_ENTRY, "confidence": 1.5})
+    with pytest.raises(ValidationError):
+        SignatureSummaryEntry.model_validate({**_BASE_ENTRY, "confidence": -0.1})
+
+    accepted = SignatureSummaryEntry.model_validate({**_BASE_ENTRY, "confidence": 0.0})
+    assert accepted.confidence == 0.0

--- a/driftshield/tests/test_recursive_redactor.py
+++ b/driftshield/tests/test_recursive_redactor.py
@@ -220,3 +220,69 @@ def test_build_request_accepts_unknown_shape_when_forced():
         force_unknown_shape=True,
     )
     assert submission.envelope.source_session_id == "s"
+
+
+# ---------------------------------------------------------------------------
+# signature_summary stays byte-identical at envelope level
+# ---------------------------------------------------------------------------
+
+
+def test_signature_summary_at_envelope_level_is_untouched():
+    """The redactor only walks ``payload``. A sibling ``signature_summary``
+    block must come out the other side byte-for-byte identical.
+    """
+    import copy
+    from driftshield.intake_contract import (
+        REDACTION_MANIFEST_VERSION,
+        REQUIRED_REDACTION_FIELDS,
+        SIGNATURE_SUMMARY_VERSION,
+        SUPPORTED_CONTRACT_VERSION,
+        RedactionManifest,
+        SignatureSummary,
+        SignatureSummaryEntry,
+        SubmissionEnvelope,
+    )
+
+    summary = SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=[
+            SignatureSummaryEntry(
+                signature_id="sig-abc",
+                match_status="matched",
+                community_pack_id="community-general",
+                community_pack_version="1.0.0",
+                matcher_id="phase-3g-deterministic-v1",
+                matcher_version="phase-3g-deterministic-rules-v1",
+                confidence=0.9,
+                confidence_band="high",
+            )
+        ],
+    )
+
+    envelope = SubmissionEnvelope(
+        source_system="oss",
+        source_session_id="sess-1",
+        schema_version=SUPPORTED_CONTRACT_VERSION,
+        payload={
+            "session_id": "sess-1",
+            "events": [{"type": "user", "content": "LEAK_CANARY_PROMPT"}],
+        },
+        payload_size_bytes=64,
+        redaction_manifest=RedactionManifest(
+            manifest_version=REDACTION_MANIFEST_VERSION,
+            redaction_applied=True,
+            redacted_fields=sorted(REQUIRED_REDACTION_FIELDS),
+        ),
+        signature_summary=summary,
+    )
+
+    before = copy.deepcopy(envelope.signature_summary)
+    before_json = envelope.signature_summary.model_dump_json()
+
+    # Run the redactor against ONLY the payload, mirroring the build-time call site.
+    result = redact(envelope.payload)
+    assert "LEAK_CANARY_PROMPT" not in json.dumps(result.payload)
+
+    after_json = envelope.signature_summary.model_dump_json()
+    assert envelope.signature_summary == before
+    assert after_json == before_json

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -425,3 +425,90 @@ def test_post_oss_submission_non_json_response_raises():
     with pytest.raises(RemoteSubmissionError) as exc_info:
         post_oss_submission(config=_config(), submission=request, opener=fake_opener)
     assert "non-JSON" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# signature_summary plumbing
+# ---------------------------------------------------------------------------
+
+
+from unittest.mock import patch  # noqa: E402
+
+from driftshield.intake_contract import (  # noqa: E402
+    SIGNATURE_SUMMARY_VERSION,
+    SignatureSummary,
+    SignatureSummaryEntry,
+)
+
+
+def _summary_with_one_entry() -> SignatureSummary:
+    return SignatureSummary(
+        schema_version=SIGNATURE_SUMMARY_VERSION,
+        matches=[
+            SignatureSummaryEntry(
+                signature_id="sig-abc",
+                match_status="matched",
+                community_pack_id="community-general",
+                community_pack_version="1.0.0",
+                matcher_id="phase-3g-deterministic-v1",
+                matcher_version="phase-3g-deterministic-rules-v1",
+                confidence=0.9,
+                confidence_band="high",
+            )
+        ],
+    )
+
+
+def test_build_oss_submission_request_no_signature_summary():
+    """Default invocation produces an envelope with signature_summary=None."""
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+    assert request.envelope.signature_summary is None
+
+
+def test_build_oss_submission_request_populates_signature_summary():
+    summary = _summary_with_one_entry()
+    request = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+        signature_summary=summary,
+    )
+    assert request.envelope.signature_summary is not None
+    assert request.envelope.signature_summary.schema_version == SIGNATURE_SUMMARY_VERSION
+    assert request.envelope.signature_summary.matches[0].signature_id == "sig-abc"
+
+    # Serialised payload carries the block alongside ``payload``.
+    encoded = json.loads(request.model_dump_json())
+    assert "signature_summary" in encoded["envelope"]
+    assert encoded["envelope"]["signature_summary"]["matches"][0]["signature_id"] == "sig-abc"
+
+
+def test_redact_call_site_passes_only_payload():
+    """The redactor is invoked only with the inner payload dict, never the envelope."""
+    summary = _summary_with_one_entry()
+    captured: dict[str, Any] = {}
+
+    real_redact = __import__(
+        "driftshield.remote_submission", fromlist=["redact_payload"]
+    ).redact_payload
+
+    def spy(payload):
+        captured["payload"] = payload
+        return real_redact(payload)
+
+    with patch("driftshield.remote_submission.redact_payload", side_effect=spy) as spied:
+        build_oss_submission_request(
+            source_session_id="sess-1",
+            payload={"session_id": "sess-1", "metadata": {"foo": "bar"}},
+            signature_summary=summary,
+        )
+
+    # Redactor saw exactly the inner payload dict; signature_summary was not
+    # in the input, by construction (it is a sibling of payload, not nested).
+    assert spied.call_count == 1
+    inner_payload = captured["payload"]
+    assert "signature_summary" not in inner_payload
+    assert inner_payload["session_id"] == "sess-1"
+    assert inner_payload["metadata"] == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- Extend `SubmissionEnvelope` with an optional `signature_summary` block carrying ten fields (six match plus four provenance) and a `schema_version`.
- Add `--include-analysis` flag (default off) to `telemetry submit-session` and `ingest` so locally derived matches can ship to a remote endpoint as an opt-in.
- Redactor placement is structural: the new block sits at envelope level alongside `payload`; the redactor only walks `payload`, so the block is untouched by construction. Two tests pin that contract.

## What's NOT in this PR
- Server-side accept-as-optional change for this field (separate change in the receiving service).
- Auto-derivation inside `build_oss_submission_request` (kept pure, CLI is the populator).

## Per-field caps
`signature_id` <= 64, `signature_version` <= 24, `mechanism_id` <= 48, `match_status` <= 24, `confidence_band` <= 24, `community_pack_id` <= 48, `community_pack_version` <= 32, `matcher_id` <= 48, `matcher_version` <= 40. 50-entry list cap.

## Test plan
- [ ] `uv run --extra dev pytest -q`
- [ ] `uv run --extra dev ruff check .`
- [ ] `uv run --extra dev mypy .`
- [ ] Manual: `driftshield telemetry submit-session --include-analysis --path ...` against a known good session ships a populated block; default invocation ships `signature_summary=None`.