### PR TITLE
fix(telemetry): submit-session --path now accepts native JSONL transcripts

### DIFF
--- a/driftshield/src/driftshield/cli/_session_payload.py
+++ b/driftshield/src/driftshield/cli/_session_payload.py
@@ -1,0 +1,97 @@
+"""Load a session file as the envelope payload dict.
+
+Both ``telemetry submit-session`` and ``ingest`` accept a ``--path``
+pointing at the user's local session. Historically the file had to be a
+single JSON object (the envelope payload). Native Claude Code sessions
+ship as JSONL: a line-delimited transcript. This helper accepts either
+shape transparently so users can point ``--path`` at the same JSONL the
+matcher reads from when ``--include-analysis`` is set.
+
+For JSONL inputs, each line is parsed as a JSON object and the whole
+collection becomes ``payload['events']``. If any line contains a
+``sessionId`` field, the first such value is also stamped on
+``payload['session_id']`` so the downstream shape detector recognises
+the transcript as ``claude_code``.
+
+Lines that fail to parse are dropped silently to mirror the parser's
+own tolerance for partial transcripts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_session_payload(path: Path) -> dict[str, Any]:
+    """Read ``path`` and return the envelope payload dict.
+
+    Raises:
+        OSError: cannot read the file.
+        ValueError: file is neither a JSON object nor parseable JSONL.
+    """
+
+    raw = path.read_text(encoding="utf-8")
+    stripped = raw.strip()
+    if not stripped:
+        raise ValueError("session file is empty")
+
+    # Try parsing the whole file as a single JSON value first. If it
+    # succeeds the file is the legacy "pre-built envelope payload"
+    # shape (e.g. produced by bin/claude_code_jsonl_to_envelope.py).
+    # A successful parse to a non-dict is a hard error (arrays, scalars).
+    try:
+        whole = json.loads(stripped)
+    except json.JSONDecodeError:
+        whole = None
+
+    if whole is not None:
+        if isinstance(whole, dict):
+            return whole
+        raise ValueError(
+            "session file must contain a JSON object at top level, not "
+            f"a {type(whole).__name__}"
+        )
+
+    # Reject top-level JSON arrays detected by quick syntax check too,
+    # in case a multi-line array slipped past json.loads (e.g. the file
+    # opens with `[` and contains line-broken records but isn't valid
+    # JSON). This keeps the operator error message clear.
+    if stripped[0] == "[":
+        raise ValueError(
+            "session file must contain a JSON object at top level, not an array"
+        )
+
+    # JSONL branch. Treat the file as line-delimited JSON, project each
+    # line into payload['events']. Drop unparseable lines to match the
+    # native claude_code parser's behaviour at parsers/claude_code.py.
+    events: list[Any] = []
+    session_id: str | None = None
+    for line in stripped.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        events.append(entry)
+        if (
+            session_id is None
+            and isinstance(entry, dict)
+            and isinstance(entry.get("sessionId"), str)
+        ):
+            session_id = entry["sessionId"]
+    if not events:
+        raise ValueError(
+            "session file is not a JSON object and contains no parseable "
+            "JSONL records"
+        )
+    payload: dict[str, Any] = {"events": events}
+    if session_id is not None:
+        payload["session_id"] = session_id
+    return payload
+
+
+__all__ = ["load_session_payload"]

--- a/driftshield/src/driftshield/cli/_session_payload.py
+++ b/driftshield/src/driftshield/cli/_session_payload.py
@@ -37,8 +37,19 @@ def load_session_payload(path: Path) -> dict[str, Any]:
     if not stripped:
         raise ValueError("session file is empty")
 
-    # Try parsing the whole file as a single JSON value first. If it
-    # succeeds the file is the legacy "pre-built envelope payload"
+    # Path-based routing first: any ``.jsonl`` file is treated as a
+    # native transcript regardless of whether its content happens to
+    # parse as a single JSON object. A one-line ``.jsonl`` is still
+    # JSONL: collapsing it through the JSON-object branch would emit a
+    # bare transcript event in place of an envelope payload, and
+    # downstream shape detection at ``remote_submission.detect_shape``
+    # would fail (UnknownTranscriptShapeError). Reviewer-flagged edge
+    # case on PR-118; the path-suffix gate is the load-bearing fix.
+    if path.suffix.lower() == ".jsonl":
+        return _load_jsonl(stripped)
+
+    # Otherwise try parsing the whole file as a single JSON value. If
+    # it succeeds the file is the legacy "pre-built envelope payload"
     # shape (e.g. produced by bin/claude_code_jsonl_to_envelope.py).
     # A successful parse to a non-dict is a hard error (arrays, scalars).
     try:
@@ -63,9 +74,15 @@ def load_session_payload(path: Path) -> dict[str, Any]:
             "session file must contain a JSON object at top level, not an array"
         )
 
-    # JSONL branch. Treat the file as line-delimited JSON, project each
-    # line into payload['events']. Drop unparseable lines to match the
-    # native claude_code parser's behaviour at parsers/claude_code.py.
+    return _load_jsonl(stripped)
+
+
+def _load_jsonl(stripped: str) -> dict[str, Any]:
+    """Treat the file as line-delimited JSON, project each line into
+    ``payload['events']``. Drop unparseable lines to match the native
+    claude_code parser's behaviour at ``parsers/claude_code.py``.
+    """
+
     events: list[Any] = []
     session_id: str | None = None
     for line in stripped.split("\n"):

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -19,6 +19,7 @@ from driftshield.recursive_redactor import (
     REDACTION_RULESET_VERSION,
     REDACTOR_VERSION,
 )
+from driftshield.cli._session_payload import load_session_payload
 from driftshield.cli._signature_summary import build_signature_summary_from_session
 from driftshield.remote_submission import (
     OssRemoteSubmissionConfig,
@@ -167,18 +168,13 @@ def telemetry_submit_session(
     masks recurrence.
     """
     try:
-        raw = path.read_text(encoding="utf-8")
+        payload = load_session_payload(path)
     except OSError as exc:
         console.print(f"[red]Error:[/red] Could not read session file: {exc}")
         raise typer.Exit(1) from exc
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        console.print(f"[red]Error:[/red] Session file is not valid JSON: {exc}")
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}.")
         raise typer.Exit(1) from exc
-    if not isinstance(payload, dict):
-        console.print("[red]Error:[/red] Session file must contain a JSON object at top level.")
-        raise typer.Exit(1)
 
     if dry_run_redaction or show_manifest:
         result = redact_payload_with_manifest(payload)

--- a/driftshield/tests/cli/test_session_payload.py
+++ b/driftshield/tests/cli/test_session_payload.py
@@ -1,0 +1,114 @@
+"""Unit tests for driftshield.cli._session_payload.load_session_payload."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from driftshield.cli._session_payload import load_session_payload
+
+
+def test_loads_single_json_object(tmp_path: Path) -> None:
+    path = tmp_path / "session.json"
+    payload = {"events": [{"a": 1}], "session_id": "sess-1"}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_session_payload(path)
+
+    assert loaded == payload
+
+
+def test_loads_jsonl_collects_events_and_session_id(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    lines = [
+        json.dumps({"type": "assistant", "sessionId": "sess-2", "x": 1}),
+        json.dumps({"type": "user", "y": 2}),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    loaded = load_session_payload(path)
+
+    assert loaded["session_id"] == "sess-2"
+    assert isinstance(loaded["events"], list)
+    assert len(loaded["events"]) == 2
+    assert loaded["events"][0]["type"] == "assistant"
+    assert loaded["events"][1]["type"] == "user"
+
+
+def test_jsonl_without_session_id_omits_field(tmp_path: Path) -> None:
+    """Multi-line JSONL whose lines lack ``sessionId`` produces a payload
+    with ``events`` but no ``session_id``. A single-line JSONL parses as
+    a JSON object and takes the object branch (see
+    ``test_loads_single_json_object``); two lines forces the JSONL branch.
+    """
+    path = tmp_path / "session.jsonl"
+    path.write_text(
+        json.dumps({"type": "user", "x": 1})
+        + "\n"
+        + json.dumps({"type": "assistant", "y": 2})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    loaded = load_session_payload(path)
+
+    assert "session_id" not in loaded
+    assert loaded["events"][0]["type"] == "user"
+    assert loaded["events"][1]["type"] == "assistant"
+
+
+def test_jsonl_drops_unparseable_lines(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "assistant", "sessionId": "sess-3"}),
+                "{not parseable",
+                json.dumps({"type": "user"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    loaded = load_session_payload(path)
+
+    assert loaded["session_id"] == "sess-3"
+    assert len(loaded["events"]) == 2
+
+
+def test_empty_file_raises(tmp_path: Path) -> None:
+    path = tmp_path / "empty.json"
+    path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="empty"):
+        load_session_payload(path)
+
+
+def test_top_level_array_raises(tmp_path: Path) -> None:
+    path = tmp_path / "array.json"
+    path.write_text(json.dumps([{"events": []}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        load_session_payload(path)
+
+
+def test_non_json_garbage_raises(tmp_path: Path) -> None:
+    path = tmp_path / "garbage.txt"
+    path.write_text("not json at all", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no parseable JSONL records"):
+        load_session_payload(path)
+
+
+def test_malformed_json_object_falls_through_to_jsonl_and_raises(tmp_path: Path) -> None:
+    """A file that looks like a malformed JSON object falls through to the
+    JSONL branch (single unparseable line → no events → ValueError).
+    """
+    path = tmp_path / "broken.json"
+    path.write_text('{"events": [}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no parseable JSONL records"):
+        load_session_payload(path)

--- a/driftshield/tests/cli/test_session_payload.py
+++ b/driftshield/tests/cli/test_session_payload.py
@@ -39,9 +39,7 @@ def test_loads_jsonl_collects_events_and_session_id(tmp_path: Path) -> None:
 
 def test_jsonl_without_session_id_omits_field(tmp_path: Path) -> None:
     """Multi-line JSONL whose lines lack ``sessionId`` produces a payload
-    with ``events`` but no ``session_id``. A single-line JSONL parses as
-    a JSON object and takes the object branch (see
-    ``test_loads_single_json_object``); two lines forces the JSONL branch.
+    with ``events`` but no ``session_id``.
     """
     path = tmp_path / "session.jsonl"
     path.write_text(
@@ -57,6 +55,33 @@ def test_jsonl_without_session_id_omits_field(tmp_path: Path) -> None:
     assert "session_id" not in loaded
     assert loaded["events"][0]["type"] == "user"
     assert loaded["events"][1]["type"] == "assistant"
+
+
+def test_single_line_jsonl_is_still_jsonl(tmp_path: Path) -> None:
+    """A one-line ``.jsonl`` file MUST take the JSONL branch — the lone
+    line is wrapped as ``payload['events'][0]`` and ``sessionId`` is
+    promoted. Reviewer-flagged edge case on PR-118: previously a
+    single-line JSONL collapsed through the JSON-object branch and
+    returned the bare transcript event in place of an envelope payload,
+    breaking downstream shape detection.
+    """
+    path = tmp_path / "session.jsonl"
+    payload_line = {
+        "type": "assistant",
+        "sessionId": "sess-one-liner",
+        "message": {"content": [{"type": "text", "text": "hello"}]},
+    }
+    path.write_text(json.dumps(payload_line) + "\n", encoding="utf-8")
+
+    loaded = load_session_payload(path)
+
+    assert loaded["session_id"] == "sess-one-liner"
+    assert isinstance(loaded["events"], list)
+    assert len(loaded["events"]) == 1
+    assert loaded["events"][0]["type"] == "assistant"
+    # Critically: the loaded dict is the envelope payload (events,
+    # session_id) — NOT the raw transcript event itself.
+    assert "sessionId" not in loaded
 
 
 def test_jsonl_drops_unparseable_lines(tmp_path: Path) -> None:

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -509,7 +509,11 @@ def test_submit_session_fails_on_invalid_json(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 1
-    assert "not valid json" in result.stdout.lower()
+    # After the JSON-or-JSONL loader landed, the file is parsed as
+    # JSONL: every line fails json.loads silently, leaving zero events.
+    # Rich may wrap the error string on whitespace, so match the stable
+    # prefix only.
+    assert "no parseable jsonl" in result.stdout.lower()
 
 
 def test_submit_session_fails_on_non_object_json(tmp_path, monkeypatch):
@@ -523,7 +527,7 @@ def test_submit_session_fails_on_non_object_json(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 1
-    assert "json object" in result.stdout.lower()
+    assert "must contain a json object" in result.stdout.lower()
 
 
 def test_submit_session_dry_run_redaction_prints_entries_and_does_not_submit(
@@ -885,3 +889,57 @@ def test_submit_session_include_analysis_empty_matches_is_valid_success(
     assert captured["signature_summary"] is not None
     assert captured["signature_summary"].schema_version == SIGNATURE_SUMMARY_VERSION
     assert captured["signature_summary"].matches == []
+
+
+def test_submit_session_accepts_jsonl_input(tmp_path, monkeypatch):
+    """A native JSONL transcript at --path is accepted transparently.
+
+    The loader collects each parsed line into ``payload['events']`` and
+    threads ``sessionId`` into ``payload['session_id']``.
+    """
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    jsonl_path = tmp_path / "session.jsonl"
+    jsonl_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "sessionId": "sess-jsonl",
+                        "message": {"content": []},
+                    }
+                ),
+                json.dumps({"type": "user", "message": {"content": "hi"}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["payload"] = submission.envelope.payload
+        captured["session_id"] = submission.envelope.source_session_id
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(jsonl_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload.get("session_id") == "sess-jsonl"
+    assert isinstance(payload.get("events"), list)
+    assert len(payload["events"]) == 2


### PR DESCRIPTION
## Summary
- `submit-session --path` used to require a single JSON-object envelope payload. The matcher helper called by `--include-analysis` expected the *native parser input* (JSONL for `claude_code`). Same file could not satisfy both, so the flag was unusable on a real Claude Code transcript path.
- New helper `driftshield.cli._session_payload.load_session_payload(path)` accepts either shape transparently: parses as JSON if possible, otherwise treats the file as line-delimited JSON and collects each line into `payload['events']`. First `sessionId` field on any line is stamped on `payload['session_id']` so the redactor's shape detector recognises the transcript.
- Existing JSON-object inputs (e.g. files produced by `bin/claude_code_jsonl_to_envelope.py`) keep working unchanged.

## Behaviour matrix

| Input | Before | After |
|---|---|---|
| Single JSON object | OK | OK |
| Native `.jsonl` transcript | `Session file is not valid JSON` exit 1 | events collected, session_id resolved |
| Empty file | exit 1 | exit 1 |
| Top-level JSON array | exit 1 | exit 1 |
| Garbage | exit 1 | exit 1 |

## Tests
- `tests/cli/test_session_payload.py` (new): 9 unit tests for the loader covering JSON, JSONL multi-line, JSONL with/without `sessionId`, JSONL with unparseable lines, top-level array reject, empty reject, garbage reject, malformed JSON object falls through.
- `tests/cli/test_telemetry.py::test_submit_session_accepts_jsonl_input` (new): end-to-end test that points `--path` at a JSONL file and asserts the captured envelope payload carries `events` + `session_id`.
- Two existing error-path tests updated to reflect the new loader's error messages (`not valid json` → `no parseable jsonl`, `json object` → `must contain a json object`).

## Verification
- `uv run --extra dev pytest -q` → 554 passed, 3 skipped
- `uv run --extra dev ruff check .` → clean
- Live AC9 fired against the deployed sandbox with this fix: `submit-session --include-analysis --path <real-claude-code-session>.jsonl` accepted (`sub_b325397fe790929fae807daca2eb9d57`, state=received). Empty `signature_matches` rows on that submission because the small transcript yielded no matches — short-circuit is by design.

## Test plan
- [ ] Targeted CLI tests
- [ ] Full pytest
- [ ] ruff