### PR TITLE
fix(redactor): drop free-text failure/diagnostic body keys at any depth

### DIFF
--- a/driftshield/src/driftshield/recursive_redactor.py
+++ b/driftshield/src/driftshield/recursive_redactor.py
@@ -56,7 +56,54 @@ _TOOL_IO_KEYS: frozenset[str] = frozenset(
 
 _PROMPT_RESPONSE_KEYS: frozenset[str] = frozenset({"content", "text"})
 
-_DROPPED_KEYS: frozenset[str] = REQUIRED_REDACTION_FIELDS | _PROMPT_RESPONSE_KEYS
+# Failure / diagnostic body keys.
+#
+# Native transcripts append failure and tool-result records verbatim into
+# ``payload['events']`` with no field mapping, so a key carrying a raw
+# failure body (an API-error message with bearer tokens and response
+# headers, a command's stdout/stderr, a traceback, a tool-argument blob)
+# survives unless dropped by name. None of these keys are read by the
+# deterministic matcher: failure mechanism is keyed off the locally derived
+# structured fields (``result_status``, ``failure_context.error``,
+# ``error_code``, the ``is_error`` flag), which are computed before
+# redaction from the parsed events, not from these verbatim keys. So
+# dropping them has zero matcher-quality cost.
+#
+# Scope is the named free-text keys only. Bare codes / enums / flags are
+# deliberately NOT dropped, so the matcher keeps its failure signal and
+# the retained non-sensitive HTTP status code stays available:
+#
+#  * ``status`` / ``error_code`` / ``result_status`` / ``is_error`` are
+#    matcher mechanism signals (enums / flags), retained.
+#  * ``api_error_status`` is a bare HTTP status code (401/429/500). It is
+#    non-sensitive and is retained on purpose; only the ``error`` body that
+#    accompanies it carries tokens/headers/tracebacks and must be dropped.
+#
+# Dropped keys:
+#  * ``error``          free-text failure body (Claude Code API-error
+#                       records; crewai ``outputs.error``; langchain
+#                       ``outputs.error`` + ``metadata.error``)
+#  * ``stdout`` /       native ``toolUseResult`` command-output streams
+#    ``stderr``         (tracebacks, hostnames, file dumps)
+#  * ``toolUseResult``  the native root-level key itself, which arrives as a
+#                       bare string ("Error: ...") or a dict wrapping
+#                       stdout/stderr
+#  * ``details``        openclaw ``outputs.details`` diagnostic dict
+#  * ``raw``            openclaw fallback for unparseable tool arguments
+_FAILURE_BODY_KEYS: frozenset[str] = frozenset(
+    {
+        "error",
+        "stdout",
+        "stderr",
+        "toolUseResult",
+        "details",
+        "raw",
+    }
+)
+
+_DROPPED_KEYS: frozenset[str] = (
+    REQUIRED_REDACTION_FIELDS | _PROMPT_RESPONSE_KEYS | _FAILURE_BODY_KEYS
+)
 
 
 _AWS_ACCESS_KEY = re.compile(r"AKIA[0-9A-Z]{16}")

--- a/driftshield/tests/fixtures/redactor_corpus/claude_code.json
+++ b/driftshield/tests/fixtures/redactor_corpus/claude_code.json
@@ -32,6 +32,23 @@
       "type": "assistant",
       "ts": 1700000003,
       "content": "DRIFTSHIELD_REDACTION_CANARY_NESTED_ASSISTANT email me at alice@example.test"
+    },
+    {
+      "type": "tool_result",
+      "ts": 1700000004,
+      "toolUseResult": {
+        "stdout": "DRIFTSHIELD_REDACTION_CANARY_STDOUT_VERBATIM contents of /home/example-user/secrets.txt",
+        "stderr": "DRIFTSHIELD_REDACTION_CANARY_STDERR_VERBATIM Traceback host internal.example",
+        "interrupted": false
+      }
+    },
+    {
+      "type": "api_error",
+      "ts": 1700000005,
+      "event": {
+        "error": "DRIFTSHIELD_REDACTION_CANARY_API_ERROR_BODY 401 Unauthorized: Bearer ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "api_error_status": 401
+      }
     }
   ],
   "user_identifiers": ["DRIFTSHIELD_REDACTION_CANARY_USER_IDS user@example.test"],

--- a/driftshield/tests/test_recursive_redactor.py
+++ b/driftshield/tests/test_recursive_redactor.py
@@ -183,6 +183,119 @@ def test_redact_payload_with_manifest_exposes_entries():
     assert any(entry.path.startswith("events[0].note") for entry in result.entries)
 
 
+def test_claude_code_error_body_dropped_api_error_status_retained():
+    """Confirmed live leak: a native Claude Code API-failure record nests a
+    free-text ``error`` body (bearer token + 401 headers) plus a bare
+    ``api_error_status`` HTTP code. The free-text body must be dropped; the
+    bare status code is a non-sensitive failure-mechanism code and is retained.
+    """
+    payload = {
+        "events": [
+            {
+                "event": {
+                    "error": "401 Unauthorized: Bearer sk-leakedtokenvalue\r\n"
+                    "www-authenticate: ... host internal.example",
+                    "api_error_status": 401,
+                }
+            }
+        ]
+    }
+    result = redact(payload)
+    serialised = json.dumps(result.payload)
+
+    assert "sk-leakedtokenvalue" not in serialised
+    assert "www-authenticate" not in serialised
+    assert any(
+        entry.category == "dropped_key" and entry.path.endswith(".error")
+        for entry in result.entries
+    )
+    event = result.payload["events"][0]["event"]
+    assert "error" not in event
+    # api_error_status is a bare HTTP status code, not free text -> retained.
+    assert event["api_error_status"] == 401
+
+
+def test_verbatim_failure_body_keys_dropped_at_any_depth():
+    """``stdout`` / ``stderr`` / ``toolUseResult`` / ``details`` / ``raw`` ride
+    verbatim into ``events[]`` via the native-JSONL passthrough and can carry
+    command output, tracebacks and tool-argument text. None are read by the
+    matcher by name, so all are dropped wherever they nest.
+    """
+    payload = {
+        "events": [
+            {
+                "toolUseResult": {
+                    "stdout": "leak STDOUT_CANARY /home/example-user/secrets.txt",
+                    "stderr": "leak STDERR_CANARY Traceback host internal.example",
+                    "interrupted": False,
+                },
+            },
+            {"toolUseResult": "Error: STRINGFORM_CANARY leaked body"},
+            {"outputs": {"details": {"diag": "DETAILS_CANARY leaked"}}},
+            {"inputs": {"raw": "RAW_CANARY unparseable tool arguments"}},
+        ]
+    }
+    result = redact(payload)
+    serialised = json.dumps(result.payload)
+
+    for canary in (
+        "STDOUT_CANARY",
+        "STDERR_CANARY",
+        "STRINGFORM_CANARY",
+        "DETAILS_CANARY",
+        "RAW_CANARY",
+    ):
+        assert canary not in serialised, f"{canary} survived redaction"
+
+    dropped_paths = {
+        entry.path for entry in result.entries if entry.category == "dropped_key"
+    }
+    assert any(p.endswith("toolUseResult") for p in dropped_paths)
+    assert any(p.endswith("details") for p in dropped_paths)
+    assert any(p.endswith("raw") for p in dropped_paths)
+
+
+def test_claude_code_corpus_api_error_status_retained():
+    """The claude_code corpus fixture carries a native API-failure record.
+    Its free-text ``error`` body is dropped by the canary-survival test; the
+    bare ``api_error_status`` HTTP code is retained.
+    """
+    redacted, _ = redact_payload(_load("claude_code"))
+    statuses = [
+        event["event"]["api_error_status"]
+        for event in redacted.get("events", [])
+        if isinstance(event, dict) and isinstance(event.get("event"), dict)
+        and "api_error_status" in event["event"]
+    ]
+    assert 401 in statuses
+
+
+def test_matcher_signal_keys_retained_not_blanket_dropped():
+    """Guard against over-broad drops. ``error_code`` / ``status`` / ``is_error``
+    are matcher mechanism signals (bare codes/enums/flags), not free-text
+    bodies, and must survive redaction.
+    """
+    payload = {
+        "events": [
+            {
+                "structured_payload": {
+                    "result_status": "error",
+                    "error_code": "tool_error",
+                },
+                "tool_activity": {"status": "error"},
+                "is_error": True,
+            }
+        ]
+    }
+    result = redact(payload)
+    event = result.payload["events"][0]
+
+    assert event["structured_payload"]["result_status"] == "error"
+    assert event["structured_payload"]["error_code"] == "tool_error"
+    assert event["tool_activity"]["status"] == "error"
+    assert event["is_error"] is True
+
+
 @pytest.mark.parametrize("name", _CORPUS_NAMES)
 def test_corpus_fixture_has_no_canary_survival(name: str):
     payload = _load(name)


### PR DESCRIPTION
## Summary

**What changed.** The recursive redactor now drops free-text failure and diagnostic body keys at any nesting depth.

Native transcripts append failure and tool-result records verbatim into `payload['events']` with no field mapping (see `cli/_session_payload.py` `_load_jsonl`). A key carrying a raw failure body therefore survives the redactor unless it is dropped by name. Before this change `_DROPPED_KEYS` covered `prompts` / `responses` / `user_identifiers` / `content` / `text` but none of the failure-body shapes, so an API-error record's free-text `error` body, which can carry bearer tokens, HTTP response headers, hostnames and tracebacks, rode through into the submitted envelope. Command `stdout` / `stderr` and openclaw diagnostic dicts had the same gap.

**Why.** Opt-in cloud submissions must be redacted before they leave the client. Failure and response bodies are exactly the class of content that must not persist. This is a redaction-hardening fix to close that class.

### Leak-surface enumeration (drop / keep decision per key)

The bug class is "failure/response/diagnostic bodies ride in verbatim via the capture path", so every known-shape adapter (`claude_code`, `openai`/`codex`, `langchain`, `crewai`, `claude_desktop`, `local_chat`, `openclaw`) and the raw JSONL passthrough were swept. Decision per candidate key, grounded in (a) can it carry free text, (b) does the deterministic matcher read it by name:

| Key | Decision | Rationale |
|---|---|---|
| `error` | **DROP** | Free-text body. Covers Claude Code API-error records, `crewai` `outputs.error`, `langchain` `outputs.error` + `metadata.error`. Matcher reads the locally derived `failure_context.error` / `error_code`, not this verbatim key. |
| `stdout` | **DROP** | Native `toolUseResult` command-output stream (tracebacks, hostnames, file dumps). Not matcher-read. |
| `stderr` | **DROP** | Same, command error stream. |
| `toolUseResult` | **DROP** | Native root-level key; arrives as a bare string (`"Error: ..."`) or a dict wrapping stdout/stderr. Dropping the key strips both forms. |
| `details` | **DROP** | `openclaw` `outputs.details` arbitrary diagnostic dict. Not matcher-read. |
| `raw` | **DROP** | `openclaw` fallback for unparseable tool arguments. Not matcher-read. |
| `content`, `text` | already handled | in `_DROPPED_KEYS` (`_PROMPT_RESPONSE_KEYS`). |
| `result`, `output`, `arguments`, `input` | already handled | in `_TOOL_IO_KEYS` (placeholder-replaced, not dropped). |
| `api_error_status` | **KEEP** | Bare HTTP status code (401/429/500); non-sensitive failure-mechanism code, not a free-text body. |
| `status`, `error_code`, `result_status`, `is_error`, `isError`, `raw_action` | **KEEP** | Bare enums/flags / matcher mechanism signals, not free text. Deliberately NOT blanket-dropped. |

Scope is the named free-text keys only. A guard test (`test_matcher_signal_keys_retained_not_blanket_dropped`) asserts the keep set survives, so a future over-broad drop is caught.

**Redaction runs on every submission path (no cached/replayed bypass).** `submit-session` redacts once via `build_redacted_payload()` before the inline-vs-presigned lane decision (`cli/commands/telemetry.py`); the Teams and large-OSS presigned lanes ship that already-redacted payload, and the inline OSS lane redacts inside `build_oss_submission_request`. `_load_jsonl`'s verbatim capture only feeds the in-memory dict that is the *input* to `redact()`; nothing submits a pre-redactor payload.

`REQUIRED_REDACTION_FIELDS` and the public manifest claim are unchanged: this drops message bodies, it does not add a new sensitive-field category.

## Verification

- [x] Automated tests run — `uv run --extra dev pytest tests` → **568 passed, 3 skipped**; `ruff` + `mypy` clean on changed files
- [ ] Browser flow exercised if UI changed — n/a (no UI change)
- [x] CLI flow exercised if command behavior changed — redactor unit + corpus-canary tests cover the submit-session redaction path; new tests assert each dropped key is absent and reported as `dropped_key`, and `api_error_status` is retained

New tests: `test_claude_code_error_body_dropped_api_error_status_retained`, `test_verbatim_failure_body_keys_dropped_at_any_depth`, `test_claude_code_corpus_api_error_status_retained`, `test_matcher_signal_keys_retained_not_blanket_dropped`. The `claude_code` corpus fixture gains a native API-failure record so the canary-survival family permanently guards this class.

## Links

Closes #

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- A server-side defence-in-depth net (key-aware backstop) is tracked separately so a future client regression on these keys is caught at intake rather than silently persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)