### PR TITLE
feat(core): canonical failed-run qualification, provenance, and delta records

### DIFF
--- a/driftshield/src/driftshield/api/routes/sessions.py
+++ b/driftshield/src/driftshield/api/routes/sessions.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session as DBSession
 from driftshield.api.auth import require_api_key
 from driftshield.api.dependencies import get_db
 from driftshield.api.schemas import (
+    ClassifiabilityInputsResponse,
+    DeltaRecordResponse,
     ExplanationPayloadResponse,
     ForensicFeedbackCreateRequest,
     ForensicFeedbackResponse,
@@ -16,6 +18,8 @@ from driftshield.api.schemas import (
     GraphResponse,
     IntegrityStatusResponse,
     PaginatedResponse,
+    ProvenanceResponse,
+    QualificationResponse,
     SessionDetail,
     SessionExplanationItemResponse,
     SessionExplanationsResponse,
@@ -26,6 +30,7 @@ from driftshield.api.schemas import (
     ValidationResponse,
 )
 from driftshield.core.models import RiskClassification
+from driftshield.core.visibility import apply_visibility
 from driftshield.db.models import (
     AnalystValidationModel,
     DecisionNodeModel,
@@ -214,7 +219,51 @@ def _extract_canonical_analysis(session: SessionModel) -> dict[str, Any] | None:
     payload = metadata.get("canonical_analysis")
     if not isinstance(payload, dict):
         return None
-    return payload
+    # The OSS API serves a single public tier. Apply visibility here so the raw
+    # stored dict can never bypass the boundary on its way out.
+    return apply_visibility(payload, tier="oss")
+
+
+def _qualification_response(canonical: dict[str, Any] | None) -> QualificationResponse | None:
+    if not canonical:
+        return None
+    block = canonical.get("qualification")
+    if not isinstance(block, dict):
+        return None
+    inputs = block.get("classifiability_inputs")
+    return QualificationResponse(
+        qualification_state=block.get("qualification_state"),
+        qualification_reasons=[
+            str(reason) for reason in block.get("qualification_reasons", []) if isinstance(reason, str)
+        ],
+        qualified_at=block.get("qualified_at"),
+        classifiability_inputs=(
+            ClassifiabilityInputsResponse(**inputs) if isinstance(inputs, dict) else None
+        ),
+        qualification_schema_version=block.get("qualification_schema_version"),
+    )
+
+
+def _provenance_environment_response(canonical: dict[str, Any] | None) -> ProvenanceResponse | None:
+    if not canonical:
+        return None
+    block = canonical.get("provenance_environment")
+    if not isinstance(block, dict):
+        return None
+    return ProvenanceResponse(
+        provenance_confidence=block.get("provenance_confidence"),
+        environment_class=block.get("environment_class"),
+        environment_source=block.get("environment_source"),
+    )
+
+
+def _delta_record_responses(canonical: dict[str, Any] | None) -> list[DeltaRecordResponse]:
+    if not canonical:
+        return []
+    records = canonical.get("delta_records")
+    if not isinstance(records, list):
+        return []
+    return [DeltaRecordResponse(**record) for record in records if isinstance(record, dict)]
 
 
 def _feedback_response(
@@ -424,7 +473,10 @@ def get_session(
         risk_summary=_risk_summary(nodes),
         explanations=_session_explanations(nodes),
         signature_match=_extract_signature_match(session),
-        canonical_analysis=_extract_canonical_analysis(session),
+        canonical_analysis=(canonical := _extract_canonical_analysis(session)),
+        qualification=_qualification_response(canonical),
+        provenance_environment=_provenance_environment_response(canonical),
+        delta_records=_delta_record_responses(canonical),
     )
 
 

--- a/driftshield/src/driftshield/api/schemas.py
+++ b/driftshield/src/driftshield/api/schemas.py
@@ -72,6 +72,39 @@ class SignatureMatchSummaryResponse(BaseModel):
     raw: dict[str, Any] | None = None
 
 
+class ClassifiabilityInputsResponse(BaseModel):
+    extraction_quality_band: str | None = None
+    coverage_ratio: float | None = None
+    event_count: int | None = None
+    has_expected_actual_delta: bool | None = None
+    ambiguity_count: int | None = None
+
+
+class QualificationResponse(BaseModel):
+    qualification_state: str | None = None
+    qualification_reasons: list[str] = Field(default_factory=list)
+    qualified_at: datetime | None = None
+    classifiability_inputs: ClassifiabilityInputsResponse | None = None
+    qualification_schema_version: str | None = None
+    # qualification_policy_version is internal_only; the visibility serializer
+    # strips it before this model is ever populated for a public response.
+
+
+class ProvenanceResponse(BaseModel):
+    provenance_confidence: str | None = None
+    environment_class: str | None = None
+    environment_source: str | None = None
+
+
+class DeltaRecordResponse(BaseModel):
+    delta_type: str | None = None
+    delta_severity: str | None = None
+    expected_ref: str | None = None
+    actual_ref: str | None = None
+    delta_summary: str | None = None
+    delta_confidence: float | None = None
+
+
 class SessionDetail(SessionSummary):
     total_events: int = 0
     flagged_events: int = 0
@@ -79,6 +112,9 @@ class SessionDetail(SessionSummary):
     explanations: SessionExplanationsResponse | None = None
     signature_match: SignatureMatchSummaryResponse | None = None
     canonical_analysis: dict[str, Any] | None = None
+    qualification: QualificationResponse | None = None
+    provenance_environment: ProvenanceResponse | None = None
+    delta_records: list[DeltaRecordResponse] = Field(default_factory=list)
 
 
 class GraphNodeResponse(BaseModel):

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -6,12 +6,40 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from driftshield.core.analysis.session import AnalysisResult
-from driftshield.core.models import CanonicalEvent, EventType, Session as DomainSession
+from driftshield.core.models import (
+    CanonicalEvent,
+    DeltaSeverity,
+    DeltaType,
+    EnvironmentClass,
+    EnvironmentSource,
+    EventType,
+    ProvenanceConfidence,
+    QualificationState,
+    Session as DomainSession,
+)
 
 if TYPE_CHECKING:
     from driftshield.db.persistence import IngestProvenance
 
 ANALYSIS_SCHEMA_VERSION = "phase-3g-canonical-v1"
+QUALIFICATION_SCHEMA_VERSION = "qualification-v1"
+QUALIFICATION_POLICY_VERSION = "qualification-policy-v1"
+
+# Extraction bands that fail the classifiable bar. A run in either band can never
+# reach qualified_failure, regardless of any candidate confidence.
+_DEGRADED_QUALITY_BANDS = {"degraded", "insufficient_for_matching"}
+
+# Integrity statuses that are too damaged to qualify a failure.
+_NON_QUALIFYING_INTEGRITY = {"corrupted_but_usable"}
+
+# Declared environment values trusted verbatim. Anything outside this set falls to
+# inference; absence falls to unknown. Never silently defaults to production.
+_DECLARED_ENVIRONMENTS = {
+    EnvironmentClass.PRODUCTION.value,
+    EnvironmentClass.STAGING.value,
+    EnvironmentClass.TEST.value,
+    EnvironmentClass.DEMO.value,
+}
 
 _DIRECT_RECOVERY_MODE = "direct"
 _NORMALISED_RECOVERY_MODE = "normalised"
@@ -49,6 +77,7 @@ def build_canonical_analysis(
     )
 
     integrity_reasons = _integrity_reasons(result.events)
+    integrity_status = _integrity_status(result.events)
     overall_quality_band = _overall_quality_band(result.events, ambiguity_count=ambiguity_count)
     delta_types = _delta_types(result)
     parser_name = _parser_name(provenance)
@@ -56,6 +85,13 @@ def build_canonical_analysis(
     ordering_confidence = _ordering_confidence(result.events)
     critical_gaps = _critical_gaps(result.events)
     quality_warnings = _quality_warnings(result.events)
+
+    qualification_state, qualification_reasons = _compute_qualification_state(
+        overall_quality_band=overall_quality_band,
+        integrity_status=integrity_status,
+        delta_types=delta_types,
+        normalized_events=normalized_events,
+    )
 
     return {
         "analysis_session": {
@@ -73,7 +109,7 @@ def build_canonical_analysis(
             "source_fingerprint": provenance.transcript_hash if provenance else None,
             "time_bounds": _time_bounds(result.events),
             "event_count": len(normalized_events),
-            "integrity_status": _integrity_status(result.events),
+            "integrity_status": integrity_status,
             "integrity_reasons": integrity_reasons,
         },
         "normalized_events": normalized_events,
@@ -133,7 +169,302 @@ def build_canonical_analysis(
                 overall_quality_band=overall_quality_band,
             ),
         },
+        "qualification": {
+            "qualification_state": qualification_state,
+            "qualification_reasons": qualification_reasons,
+            "qualified_at": _qualified_at(provenance, session),
+            "classifiability_inputs": _classifiability_inputs(
+                overall_quality_band=overall_quality_band,
+                coverage_ratio=coverage_ratio,
+                event_count=len(normalized_events),
+                ambiguity_count=ambiguity_count,
+                delta_types=delta_types,
+            ),
+            "qualification_schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "qualification_policy_version": QUALIFICATION_POLICY_VERSION,
+        },
+        "provenance_environment": _compute_provenance_and_environment(session, provenance),
+        "delta_records": _refine_delta_records(
+            result,
+            normalized_events=normalized_events,
+            delta_types=delta_types,
+            overall_quality_band=overall_quality_band,
+            coverage_ratio=coverage_ratio,
+        ),
     }
+
+
+def _compute_qualification_state(
+    *,
+    overall_quality_band: str,
+    integrity_status: str,
+    delta_types: list[str],
+    normalized_events: list[dict[str, Any]],
+) -> tuple[str, list[str]]:
+    """Resolve the structural qualification state for an analysed run.
+
+    The bars are deliberately structural. ``qualified_failure`` requires usable
+    extraction AND a material delta AND acceptable integrity. A degraded run can
+    never be upgraded to ``qualified_failure`` by a high-confidence candidate;
+    degraded extraction is a hard ``unclassified`` bar.
+    """
+
+    if not normalized_events:
+        return QualificationState.NOT_CLASSIFIABLE.value, ["no_events"]
+
+    # HARD bar: degraded / insufficient extraction is never classifiable.
+    if overall_quality_band in _DEGRADED_QUALITY_BANDS:
+        return QualificationState.UNCLASSIFIED.value, ["extraction_quality_degraded"]
+
+    # A run too damaged to read leaves no usable structure to classify.
+    if integrity_status in _NON_QUALIFYING_INTEGRITY and _all_events_inferred_and_incomplete(
+        normalized_events
+    ):
+        return QualificationState.NOT_CLASSIFIABLE.value, ["corrupted_run_no_usable_events"]
+
+    has_material_delta = _has_material_delta(delta_types)
+
+    if not has_material_delta:
+        return QualificationState.UNCLASSIFIED.value, ["no_material_delta_detected"]
+
+    if integrity_status in _NON_QUALIFYING_INTEGRITY:
+        return QualificationState.UNCLASSIFIED.value, ["extraction_integrity_insufficient"]
+
+    return QualificationState.QUALIFIED_FAILURE.value, []
+
+
+def _has_material_delta(delta_types: list[str]) -> bool:
+    return bool(delta_types) and any(
+        delta_type != DeltaType.NO_MATERIAL_DELTA_DETECTED.value for delta_type in delta_types
+    )
+
+
+def _all_events_inferred_and_incomplete(normalized_events: list[dict[str, Any]]) -> bool:
+    return all(
+        event.get("recovery_mode") == _INFERRED_RECOVERY_MODE and event.get("missing_fields")
+        for event in normalized_events
+    )
+
+
+def _classifiability_inputs(
+    *,
+    overall_quality_band: str,
+    coverage_ratio: float,
+    event_count: int,
+    ambiguity_count: int,
+    delta_types: list[str],
+) -> dict[str, Any]:
+    return {
+        "extraction_quality_band": overall_quality_band,
+        "coverage_ratio": coverage_ratio,
+        "event_count": event_count,
+        "has_expected_actual_delta": _has_material_delta(delta_types),
+        "ambiguity_count": ambiguity_count,
+    }
+
+
+def _qualified_at(provenance: IngestProvenance | None, session: DomainSession) -> str | None:
+    """Stamp when qualification was computed.
+
+    Anchored to a deterministic clock so re-analysis produces a stable, auditable
+    timestamp rather than a wall-clock value that varies per call.
+    """
+
+    if provenance is not None:
+        return provenance.ingested_at.isoformat()
+    if session.ended_at is not None:
+        return session.ended_at.isoformat()
+    if session.started_at is not None:
+        return session.started_at.isoformat()
+    return None
+
+
+def _compute_provenance_and_environment(
+    session: DomainSession,
+    provenance: IngestProvenance | None,
+) -> dict[str, Any]:
+    """Classify origin attestation and run environment.
+
+    Environment is never silently defaulted to production: a declared value is
+    trusted only if it is in the closed set, otherwise the path is inspected, and
+    absence resolves to ``unknown``.
+    """
+
+    provenance_confidence = _provenance_confidence(session, provenance)
+    environment_class, environment_source = _environment_classification(session, provenance)
+
+    return {
+        "provenance_confidence": provenance_confidence.value,
+        "environment_class": environment_class.value,
+        "environment_source": environment_source.value,
+    }
+
+
+def _provenance_confidence(
+    session: DomainSession,
+    provenance: IngestProvenance | None,
+) -> ProvenanceConfidence:
+    # NOTE: IngestProvenance carries no connector signal today, so an attested
+    # provenance is user_claimed. connector_verified becomes reachable once a
+    # source-kind marker is threaded onto the provenance record.
+    if provenance is not None:
+        return ProvenanceConfidence.USER_CLAIMED
+    if session.external_id:
+        return ProvenanceConfidence.INFERRED
+    return ProvenanceConfidence.UNKNOWN
+
+
+def _environment_classification(
+    session: DomainSession,
+    provenance: IngestProvenance | None,
+) -> tuple[EnvironmentClass, EnvironmentSource]:
+    declared = session.metadata.get("environment") if isinstance(session.metadata, dict) else None
+    if isinstance(declared, str) and declared in _DECLARED_ENVIRONMENTS:
+        return EnvironmentClass(declared), EnvironmentSource.SUBMITTER_DECLARED
+
+    source_path = provenance.source_path if provenance else None
+    if source_path:
+        inferred = _infer_environment_from_path(source_path)
+        return inferred, EnvironmentSource.INFERRED
+
+    return EnvironmentClass.UNKNOWN, EnvironmentSource.ABSENT
+
+
+def _infer_environment_from_path(source_path: str) -> EnvironmentClass:
+    lowered = source_path.lower()
+    if "demo" in lowered:
+        return EnvironmentClass.DEMO
+    if "staging" in lowered or "/stg" in lowered:
+        return EnvironmentClass.STAGING
+    if "test" in lowered:
+        return EnvironmentClass.TEST
+    return EnvironmentClass.UNKNOWN
+
+
+def _refine_delta_records(
+    result: AnalysisResult,
+    *,
+    normalized_events: list[dict[str, Any]],
+    delta_types: list[str],
+    overall_quality_band: str,
+    coverage_ratio: float,
+) -> list[dict[str, Any]]:
+    """Build structured delta records from existing risk signals.
+
+    Each record carries a closed DeltaType, a severity band, and event_id refs
+    that resolve against ``normalized_events``. A ref that does not resolve (for
+    example, lost to redaction) is nulled rather than left dangling.
+    """
+
+    known_ids = {str(event.get("event_id")) for event in normalized_events}
+    delta_confidence = _delta_confidence(overall_quality_band, coverage_ratio)
+
+    if not _has_material_delta(delta_types):
+        return [
+            {
+                "delta_type": DeltaType.NO_MATERIAL_DELTA_DETECTED.value,
+                "delta_severity": DeltaSeverity.NONE.value,
+                "expected_ref": None,
+                "actual_ref": None,
+                "delta_summary": "No material deviation from expected behaviour was detected.",
+                "delta_confidence": delta_confidence,
+            }
+        ]
+
+    flag_events = _events_by_flag(result)
+    supporting = [str(event.id) for event in result.events if event.has_risk_flags()]
+    default_expected = next((ref for ref in supporting if ref in known_ids), None)
+
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for flag, (delta_type, severity, summary) in _DELTA_FLAG_MAP.items():
+        flagged = flag_events.get(flag, [])
+        if not flagged:
+            continue
+        if delta_type.value in seen:
+            continue
+        seen.add(delta_type.value)
+        expected_ref = next((str(eid) for eid in flagged if str(eid) in known_ids), default_expected)
+        records.append(
+            {
+                "delta_type": delta_type.value,
+                "delta_severity": severity.value,
+                "expected_ref": _resolve_ref(expected_ref, known_ids),
+                "actual_ref": None,
+                "delta_summary": summary,
+                "delta_confidence": delta_confidence,
+            }
+        )
+
+    if not records:
+        # A material delta_type was present but did not map to a per-event flag
+        # (for example, an unresolved ambiguity). Emit one honest record.
+        records.append(
+            {
+                "delta_type": DeltaType.CONTRADICTORY_OUTPUT.value,
+                "delta_severity": DeltaSeverity.MINOR.value,
+                "expected_ref": _resolve_ref(default_expected, known_ids),
+                "actual_ref": None,
+                "delta_summary": "An expected-vs-actual deviation was observed without a single owning event.",
+                "delta_confidence": delta_confidence,
+            }
+        )
+
+    return records
+
+
+# Risk flag -> (DeltaType, DeltaSeverity, human summary). Closed mapping.
+_DELTA_FLAG_MAP: dict[str, tuple[DeltaType, DeltaSeverity, str]] = {
+    "coverage_gap": (
+        DeltaType.MISSING_OUTPUT,
+        DeltaSeverity.MATERIAL,
+        "A required action or output was missing from the run.",
+    ),
+    "policy_divergence": (
+        DeltaType.INCORRECT_OUTPUT,
+        DeltaSeverity.MATERIAL,
+        "The run diverged from the expected action.",
+    ),
+    "assumption_mutation": (
+        DeltaType.INCORRECT_OUTPUT,
+        DeltaSeverity.MATERIAL,
+        "An implicit assumption changed and drove a divergent action.",
+    ),
+    "constraint_violation": (
+        DeltaType.INVALID_SCHEMA,
+        DeltaSeverity.SEVERE,
+        "A declared constraint or contract was violated.",
+    ),
+    "context_contamination": (
+        DeltaType.INCOMPLETE_EXECUTION,
+        DeltaSeverity.MINOR,
+        "Retrieved context was missing or contaminated.",
+    ),
+}
+
+
+def _events_by_flag(result: AnalysisResult) -> dict[str, list[Any]]:
+    by_flag: dict[str, list[Any]] = {}
+    for event in result.events:
+        classification = event.risk_classification
+        if classification is None:
+            continue
+        for flag in classification.active_flags():
+            by_flag.setdefault(flag, []).append(event.id)
+    return by_flag
+
+
+def _resolve_ref(candidate: str | None, known_ids: set[str]) -> str | None:
+    if candidate is None:
+        return None
+    return candidate if candidate in known_ids else None
+
+
+def _delta_confidence(overall_quality_band: str, coverage_ratio: float) -> float:
+    confidence = min(coverage_ratio, 0.95)
+    if overall_quality_band == "usable":
+        confidence = min(confidence, 0.75)
+    return round(max(confidence, 0.0), 4)
 
 
 def _canonical_event_payloads(events: list[CanonicalEvent]) -> list[dict[str, Any]]:

--- a/driftshield/src/driftshield/core/models.py
+++ b/driftshield/src/driftshield/core/models.py
@@ -299,6 +299,88 @@ class Session:
             self.metadata = {}
 
 
+class QualificationState(str, Enum):
+    """Structural qualification state for an analysed run.
+
+    The state machine entry node is ``analysed``. It is never emitted as a final
+    state: every analysed run resolves to one of the terminal states below.
+
+        analysed
+          -> classifiable      (high/usable extraction)
+              -> qualified_failure   (material delta + integrity ok)
+              -> unclassified        (no material delta)
+          -> unclassified      (degraded extraction; HARD bar, never upgraded)
+          -> not_classifiable  (no usable events)
+
+    ``qualified_failure`` is the only state eligible to contribute to downstream
+    recurrence aggregation. Eligibility is structural, not a trust score: a
+    high-confidence candidate never upgrades a degraded run.
+    """
+
+    ANALYSED = "analysed"
+    CLASSIFIABLE = "classifiable"
+    UNCLASSIFIED = "unclassified"
+    NOT_CLASSIFIABLE = "not_classifiable"
+    QUALIFIED_FAILURE = "qualified_failure"
+
+
+class ProvenanceConfidence(str, Enum):
+    """How strongly the origin of a run is attested."""
+
+    CONNECTOR_VERIFIED = "connector_verified"
+    USER_CLAIMED = "user_claimed"
+    INFERRED = "inferred"
+    UNKNOWN = "unknown"
+
+
+class EnvironmentClass(str, Enum):
+    """Declared or inferred environment of a run.
+
+    Absence of any signal resolves to ``unknown``. It is never silently
+    defaulted to ``production``.
+    """
+
+    PRODUCTION = "production"
+    STAGING = "staging"
+    TEST = "test"
+    DEMO = "demo"
+    UNKNOWN = "unknown"
+
+
+class EnvironmentSource(str, Enum):
+    """How the environment class was determined."""
+
+    CONNECTOR = "connector"
+    SUBMITTER_DECLARED = "submitter_declared"
+    INFERRED = "inferred"
+    ABSENT = "absent"
+
+
+class DeltaType(str, Enum):
+    """Closed vocabulary of expected-vs-actual failure manifestations.
+
+    New values require a contract amendment, not a code-only addition.
+    """
+
+    MISSING_OUTPUT = "missing_output"
+    INCORRECT_OUTPUT = "incorrect_output"
+    CONTRADICTORY_OUTPUT = "contradictory_output"
+    INVALID_SCHEMA = "invalid_schema"
+    UNSAFE_ACTION = "unsafe_action"
+    INCOMPLETE_EXECUTION = "incomplete_execution"
+    UNINTENDED_STATE_CHANGE = "unintended_state_change"
+    NO_MATERIAL_DELTA_DETECTED = "no_material_delta_detected"
+
+
+class DeltaSeverity(str, Enum):
+    """Severity band for a single delta record."""
+
+    NONE = "none"
+    MINOR = "minor"
+    MATERIAL = "material"
+    SEVERE = "severe"
+
+
 class ForensicCaseState(str, Enum):
     """User-visible lifecycle state for a persisted single-run forensic case."""
 

--- a/driftshield/src/driftshield/core/visibility.py
+++ b/driftshield/src/driftshield/core/visibility.py
@@ -1,0 +1,140 @@
+"""Tier-aware visibility enforcement for the canonical analysed-run payload.
+
+The canonical analysis blob carries fields at different disclosure tiers. The OSS
+runtime renders only ``oss``-class fields; richer tiers expose more. This module is
+the single place that decides which field belongs to which tier, so the raw dict
+can never bypass the boundary on its way to an API response, a report, or the CLI.
+
+Every field emitted under the ``qualification``, ``provenance_environment``, and
+``delta_records`` blocks MUST appear in both ``VISIBILITY_REGISTRY`` and the matching
+``KNOWN_*`` set. A new field added without a class is caught by the build-side
+completeness test, not shipped silently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Disclosure tiers, lowest to highest. A consumer at a given tier sees its own
+# fields plus every lower tier.
+_TIER_RANK: dict[str, int] = {
+    "oss": 0,
+    "teams": 1,
+    "enterprise": 2,
+    "internal_only": 3,
+}
+
+_DEFAULT_TIER = "oss"
+
+
+# Dot-path -> minimum tier required to see the field.
+# ``block.field`` addresses a field inside a dict block.
+# ``delta_records.[].field`` addresses a field inside each delta record.
+VISIBILITY_REGISTRY: dict[str, str] = {
+    # qualification block
+    "qualification.qualification_state": "oss",
+    "qualification.qualification_reasons": "teams",
+    "qualification.qualified_at": "teams",
+    "qualification.classifiability_inputs": "teams",
+    "qualification.qualification_schema_version": "teams",
+    "qualification.qualification_policy_version": "internal_only",
+    # provenance + environment block
+    "provenance_environment.provenance_confidence": "teams",
+    "provenance_environment.environment_class": "oss",
+    "provenance_environment.environment_source": "teams",
+    # delta records (per-field; the whole list is oss-visible)
+    "delta_records": "oss",
+    "delta_records.[].delta_type": "oss",
+    "delta_records.[].delta_severity": "oss",
+    "delta_records.[].expected_ref": "oss",
+    "delta_records.[].actual_ref": "oss",
+    "delta_records.[].delta_summary": "oss",
+    "delta_records.[].delta_confidence": "oss",
+}
+
+# Source-of-truth field sets per block. The build-side completeness test asserts
+# that the actually emitted keys equal these sets.
+KNOWN_QUALIFICATION_FIELDS: frozenset[str] = frozenset(
+    {
+        "qualification_state",
+        "qualification_reasons",
+        "qualified_at",
+        "classifiability_inputs",
+        "qualification_schema_version",
+        "qualification_policy_version",
+    }
+)
+KNOWN_PROVENANCE_ENV_FIELDS: frozenset[str] = frozenset(
+    {
+        "provenance_confidence",
+        "environment_class",
+        "environment_source",
+    }
+)
+KNOWN_DELTA_RECORD_FIELDS: frozenset[str] = frozenset(
+    {
+        "delta_type",
+        "delta_severity",
+        "expected_ref",
+        "actual_ref",
+        "delta_summary",
+        "delta_confidence",
+    }
+)
+
+
+def visibility_class_for(block: str, field: str) -> str | None:
+    """Return the tier class for ``block.field``, or None if unregistered."""
+
+    return VISIBILITY_REGISTRY.get(f"{block}.{field}")
+
+
+def _tier_rank(tier: str) -> int:
+    return _TIER_RANK.get(tier, _TIER_RANK[_DEFAULT_TIER])
+
+
+def _strip_block(block: dict[str, Any], *, prefix: str, tier_rank: int) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in block.items():
+        required = VISIBILITY_REGISTRY.get(f"{prefix}.{key}", _DEFAULT_TIER)
+        if tier_rank >= _tier_rank(required):
+            out[key] = value
+    return out
+
+
+def apply_visibility(canonical: dict[str, Any], *, tier: str) -> dict[str, Any]:
+    """Return a copy of ``canonical`` with fields above ``tier`` removed.
+
+    The input is never mutated. Blocks not governed by the registry pass through
+    untouched.
+    """
+
+    rank = _tier_rank(tier)
+    result = dict(canonical)
+
+    qualification = canonical.get("qualification")
+    if isinstance(qualification, dict):
+        result["qualification"] = _strip_block(
+            qualification, prefix="qualification", tier_rank=rank
+        )
+
+    provenance_environment = canonical.get("provenance_environment")
+    if isinstance(provenance_environment, dict):
+        result["provenance_environment"] = _strip_block(
+            provenance_environment, prefix="provenance_environment", tier_rank=rank
+        )
+
+    delta_records = canonical.get("delta_records")
+    if isinstance(delta_records, list):
+        list_required = VISIBILITY_REGISTRY.get("delta_records", _DEFAULT_TIER)
+        if rank < _tier_rank(list_required):
+            result["delta_records"] = []
+        else:
+            result["delta_records"] = [
+                _strip_block(record, prefix="delta_records.[]", tier_rank=rank)
+                if isinstance(record, dict)
+                else record
+                for record in delta_records
+            ]
+
+    return result

--- a/driftshield/src/driftshield/core/visibility.py
+++ b/driftshield/src/driftshield/core/visibility.py
@@ -38,6 +38,13 @@ VISIBILITY_REGISTRY: dict[str, str] = {
     "qualification.classifiability_inputs": "teams",
     "qualification.qualification_schema_version": "teams",
     "qualification.qualification_policy_version": "internal_only",
+    # nested classifiability_inputs children (registered individually so a future
+    # nested field cannot ride the parent object's class unclassified)
+    "qualification.classifiability_inputs.extraction_quality_band": "teams",
+    "qualification.classifiability_inputs.coverage_ratio": "teams",
+    "qualification.classifiability_inputs.event_count": "teams",
+    "qualification.classifiability_inputs.has_expected_actual_delta": "teams",
+    "qualification.classifiability_inputs.ambiguity_count": "teams",
     # provenance + environment block
     "provenance_environment.provenance_confidence": "teams",
     "provenance_environment.environment_class": "oss",
@@ -81,6 +88,29 @@ KNOWN_DELTA_RECORD_FIELDS: frozenset[str] = frozenset(
         "delta_confidence",
     }
 )
+KNOWN_CLASSIFIABILITY_INPUTS_FIELDS: frozenset[str] = frozenset(
+    {
+        "extraction_quality_band",
+        "coverage_ratio",
+        "event_count",
+        "has_expected_actual_delta",
+        "ambiguity_count",
+    }
+)
+
+# Dot-paths whose value is itself a dict block to be stripped field-by-field
+# (not treated as a single leaf). Recursing here closes the gap where a nested
+# field would otherwise ride its parent object's class unclassified.
+_NESTED_BLOCK_PATHS: frozenset[str] = frozenset(
+    {
+        "qualification.classifiability_inputs",
+    }
+)
+
+# Unregistered nested fields are withheld rather than exposed: a nested field with
+# no class is treated as above every tier, so it never leaks while waiting to be
+# classified. The build-side completeness test surfaces it as a hard failure.
+_WITHHELD_RANK = max(_TIER_RANK.values()) + 1
 
 
 def visibility_class_for(block: str, field: str) -> str | None:
@@ -96,8 +126,25 @@ def _tier_rank(tier: str) -> int:
 def _strip_block(block: dict[str, Any], *, prefix: str, tier_rank: int) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for key, value in block.items():
-        required = VISIBILITY_REGISTRY.get(f"{prefix}.{key}", _DEFAULT_TIER)
-        if tier_rank >= _tier_rank(required):
+        path = f"{prefix}.{key}"
+        required = VISIBILITY_REGISTRY.get(path, _DEFAULT_TIER)
+        if tier_rank < _tier_rank(required):
+            continue
+        if path in _NESTED_BLOCK_PATHS and isinstance(value, dict):
+            out[key] = _strip_nested_block(value, prefix=path, tier_rank=tier_rank)
+        else:
+            out[key] = value
+    return out
+
+
+def _strip_nested_block(block: dict[str, Any], *, prefix: str, tier_rank: int) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in block.items():
+        registered = VISIBILITY_REGISTRY.get(f"{prefix}.{key}")
+        # An unregistered nested field is withheld at every tier so it can never
+        # leak before being classified.
+        required_rank = _tier_rank(registered) if registered is not None else _WITHHELD_RANK
+        if tier_rank >= required_rank:
             out[key] = value
     return out
 

--- a/driftshield/tests/api/test_sessions.py
+++ b/driftshield/tests/api/test_sessions.py
@@ -558,3 +558,94 @@ def test_create_session_validation_for_missing_session_returns_404(client, auth_
         json=payload,
     )
     assert resp.status_code == 404
+
+
+@pytest.fixture
+def session_with_qualification(db_session):
+    session_id = uuid.uuid4()
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            agent_id="qual-agent",
+            started_at=datetime.now(timezone.utc),
+            status="completed",
+            parser_version="claude_code@1",
+            ingested_at=datetime.now(timezone.utc),
+            metadata_json={
+                "canonical_analysis": {
+                    "analysis_session": {"session_id": str(session_id)},
+                    "normalized_events": [{"event_id": "n1", "missing_fields": []}],
+                    "expected_vs_actual_delta": {"delta_types": ["missing_required_action"]},
+                    "extraction_quality_summary": {"overall_quality_band": "high"},
+                    "qualification": {
+                        "qualification_state": "qualified_failure",
+                        "qualification_reasons": ["debug_reason"],
+                        "qualified_at": "2026-06-08T12:00:00+00:00",
+                        "classifiability_inputs": {
+                            "extraction_quality_band": "high",
+                            "coverage_ratio": 0.9,
+                            "event_count": 1,
+                            "has_expected_actual_delta": True,
+                            "ambiguity_count": 0,
+                        },
+                        "qualification_schema_version": "qualification-v1",
+                        "qualification_policy_version": "qualification-policy-v1",
+                    },
+                    "provenance_environment": {
+                        "provenance_confidence": "user_claimed",
+                        "environment_class": "production",
+                        "environment_source": "submitter_declared",
+                    },
+                    "delta_records": [
+                        {
+                            "delta_type": "missing_output",
+                            "delta_severity": "material",
+                            "expected_ref": "n1",
+                            "actual_ref": None,
+                            "delta_summary": "A required output was missing.",
+                            "delta_confidence": 0.8,
+                        }
+                    ],
+                }
+            },
+        )
+    )
+    db_session.flush()
+    return session_id
+
+
+def test_get_session_applies_oss_visibility_to_canonical_analysis(
+    client, auth_headers, session_with_qualification
+):
+    response = client.get(
+        f"/api/sessions/{session_with_qualification}", headers=auth_headers
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    canonical = body["canonical_analysis"]
+    qualification = canonical["qualification"]
+    # oss-visible
+    assert qualification["qualification_state"] == "qualified_failure"
+    # internal_only and teams fields are stripped from the raw dict
+    assert "qualification_policy_version" not in qualification
+    assert "qualification_reasons" not in qualification
+    assert "classifiability_inputs" not in qualification
+    prov = canonical["provenance_environment"]
+    assert prov == {"environment_class": "production"}
+    # delta records survive in full at the oss tier
+    assert canonical["delta_records"][0]["delta_type"] == "missing_output"
+
+
+def test_get_session_populates_typed_qualification_blocks(
+    client, auth_headers, session_with_qualification
+):
+    response = client.get(
+        f"/api/sessions/{session_with_qualification}", headers=auth_headers
+    )
+    body = response.json()
+    assert body["qualification"]["qualification_state"] == "qualified_failure"
+    # internal_only field never reaches the typed response model
+    assert "qualification_policy_version" not in body["qualification"]
+    assert body["provenance_environment"]["environment_class"] == "production"
+    assert body["delta_records"][0]["delta_severity"] == "material"

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -14,6 +14,7 @@ from driftshield.core.models import (
 )
 from driftshield.core.normalization import normalize_events
 from driftshield.core.visibility import (
+    KNOWN_CLASSIFIABILITY_INPUTS_FIELDS,
     KNOWN_DELTA_RECORD_FIELDS,
     KNOWN_PROVENANCE_ENV_FIELDS,
     KNOWN_QUALIFICATION_FIELDS,
@@ -289,6 +290,9 @@ def test_build_canonical_analysis_emits_qualification_block_for_clean_run():
     inputs = qualification["classifiability_inputs"]
     assert inputs["extraction_quality_band"] in {"high", "usable", "degraded", "insufficient_for_matching"}
     assert isinstance(inputs["has_expected_actual_delta"], bool)
+    # Completeness guard extends to nested classifiability_inputs children: a new
+    # nested field added to the emitter without a registry entry fails here.
+    assert set(inputs.keys()) == KNOWN_CLASSIFIABILITY_INPUTS_FIELDS
 
 
 def test_build_canonical_analysis_high_quality_with_material_delta_is_qualified_failure():

--- a/driftshield/tests/core/test_canonical_analysis.py
+++ b/driftshield/tests/core/test_canonical_analysis.py
@@ -3,10 +3,45 @@ from uuid import uuid4
 
 from driftshield.core.analysis.session import AnalysisResult, analyze_session
 from driftshield.core.canonical_analysis import build_canonical_analysis
+from driftshield.core.deterministic_matching import build_deterministic_match
 from driftshield.core.graph.models import LineageGraph
-from driftshield.core.models import CanonicalEvent, EventType, Session, SessionStatus
+from driftshield.core.models import (
+    CanonicalEvent,
+    EventType,
+    RiskClassification,
+    Session,
+    SessionStatus,
+)
 from driftshield.core.normalization import normalize_events
+from driftshield.core.visibility import (
+    KNOWN_DELTA_RECORD_FIELDS,
+    KNOWN_PROVENANCE_ENV_FIELDS,
+    KNOWN_QUALIFICATION_FIELDS,
+    apply_visibility,
+)
+from driftshield.db.persistence import IngestProvenance
 from driftshield.parsers.claude_code import ClaudeCodeParser
+
+
+def _completed_session(metadata=None, external_id=None):
+    return Session(
+        id=uuid4(),
+        agent_id="claude",
+        started_at=datetime.now(timezone.utc),
+        external_id=external_id,
+        status=SessionStatus.COMPLETED,
+        metadata=metadata or {},
+    )
+
+
+def _provenance(source_path=None):
+    return IngestProvenance(
+        transcript_hash="hash-1",
+        source_session_id="src-1",
+        source_path=source_path,
+        parser_version="claude_code@1",
+        ingested_at=datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc),
+    )
 
 
 def test_build_canonical_analysis_emits_result_families_for_completed_tool_calls():
@@ -207,3 +242,209 @@ def test_build_canonical_analysis_exposes_field_recovery_provenance_for_inferred
     assert "recovery_mode" in event_payload["field_recovery"]["inferred_fields"]
     assert quality["field_recovery_summary"]["inferred_event_count"] == 1
     assert quality["field_recovery_summary"]["inferred_field_count"] >= 1
+
+
+def _flagged_event(risk):
+    return CanonicalEvent(
+        id=uuid4(),
+        session_id="qual-1",
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.OUTPUT,
+        agent_id="claude",
+        action="emit",
+        summary="run output",
+        source_refs=[{"kind": "message_id", "value": "m1"}],
+        risk_classification=risk,
+    )
+
+
+def _flagged_result(events):
+    return AnalysisResult(
+        events=events,
+        graph=LineageGraph(session_id=events[0].session_id),
+        inflection_node=None,
+        total_events=len(events),
+        flagged_events=sum(1 for e in events if e.has_risk_flags()),
+    )
+
+
+def test_build_canonical_analysis_emits_qualification_block_for_clean_run():
+    transcript = "\n".join(
+        [
+            '{"sessionId":"q-1","type":"assistant","timestamp":"2026-05-04T12:00:00Z","message":{"content":[{"type":"tool_use","id":"tool_1","name":"Read","input":{"file_path":"README.md"}}]}}',
+            '{"sessionId":"q-1","type":"user","timestamp":"2026-05-04T12:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_1","content":"file contents","is_error":false}]}}',
+        ]
+    )
+    result = analyze_session(ClaudeCodeParser().parse(transcript))
+    payload = build_canonical_analysis(
+        session=_completed_session(), result=result, provenance=_provenance()
+    )
+
+    qualification = payload["qualification"]
+    assert set(qualification.keys()) == KNOWN_QUALIFICATION_FIELDS
+    # A clean run with no material delta is unclassified, not qualified_failure.
+    assert qualification["qualification_state"] in {"unclassified", "qualified_failure"}
+    assert qualification["qualification_schema_version"] == "qualification-v1"
+    assert qualification["qualification_policy_version"] == "qualification-policy-v1"
+    inputs = qualification["classifiability_inputs"]
+    assert inputs["extraction_quality_band"] in {"high", "usable", "degraded", "insufficient_for_matching"}
+    assert isinstance(inputs["has_expected_actual_delta"], bool)
+
+
+def test_build_canonical_analysis_high_quality_with_material_delta_is_qualified_failure():
+    risk = RiskClassification(coverage_gap=True)
+    payload = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([_flagged_event(risk)]),
+        provenance=_provenance(),
+    )
+    qualification = payload["qualification"]
+    assert qualification["qualification_state"] == "qualified_failure"
+    assert qualification["qualification_reasons"] == []
+    assert qualification["qualified_at"] == "2026-06-08T12:00:00+00:00"
+
+
+def test_build_canonical_analysis_emits_provenance_environment_block():
+    payload = build_canonical_analysis(
+        session=_completed_session(metadata={"environment": "production"}),
+        result=_flagged_result([_flagged_event(RiskClassification(coverage_gap=True))]),
+        provenance=_provenance(),
+    )
+    block = payload["provenance_environment"]
+    assert set(block.keys()) == KNOWN_PROVENANCE_ENV_FIELDS
+    assert block["environment_class"] == "production"
+    assert block["environment_source"] == "submitter_declared"
+    assert block["provenance_confidence"] == "user_claimed"
+
+
+def test_build_canonical_analysis_environment_defaults_unknown_never_production():
+    payload = build_canonical_analysis(
+        session=_completed_session(),  # no environment metadata
+        result=_flagged_result([_flagged_event(RiskClassification(coverage_gap=True))]),
+        provenance=None,  # no source_path to infer from
+    )
+    block = payload["provenance_environment"]
+    assert block["environment_class"] == "unknown"
+    assert block["environment_source"] == "absent"
+    assert block["environment_class"] != "production"
+
+
+def test_build_canonical_analysis_emits_delta_records_with_resolvable_refs():
+    event = _flagged_event(RiskClassification(coverage_gap=True))
+    payload = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([event]),
+        provenance=_provenance(),
+    )
+    records = payload["delta_records"]
+    assert records
+    for record in records:
+        assert set(record.keys()) == KNOWN_DELTA_RECORD_FIELDS
+    material = [r for r in records if r["delta_severity"] != "none"]
+    assert material
+    assert any(r["delta_type"] == "missing_output" for r in material)
+    # The expected_ref resolves to the real flagged event in normalized_events.
+    known_ids = {e["event_id"] for e in payload["normalized_events"]}
+    for record in records:
+        for ref in (record["expected_ref"], record["actual_ref"]):
+            assert ref is None or ref in known_ids
+
+
+def test_build_canonical_analysis_no_delta_emits_no_material_sentinel():
+    payload = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([_flagged_event(RiskClassification())]),
+        provenance=_provenance(),
+    )
+    records = payload["delta_records"]
+    assert len(records) == 1
+    assert records[0]["delta_type"] == "no_material_delta_detected"
+    assert records[0]["delta_severity"] == "none"
+
+
+def test_build_canonical_analysis_preserves_existing_delta_types_key():
+    # Regression: the deterministic matcher reads expected_vs_actual_delta.delta_types.
+    # delta_records is additive and must not disturb the existing block.
+    payload = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([_flagged_event(RiskClassification(coverage_gap=True))]),
+        provenance=_provenance(),
+    )
+    delta_block = payload["expected_vs_actual_delta"]
+    assert "delta_types" in delta_block
+    assert "supporting_event_ids" in delta_block
+    assert isinstance(delta_block["delta_types"], list)
+
+
+def test_deterministic_matching_still_reads_canonical_analysis():
+    # Prove the matcher runs end-to-end against the augmented payload.
+    result = _flagged_result([_flagged_event(RiskClassification(coverage_gap=True))])
+    payload = build_canonical_analysis(
+        session=_completed_session(), result=result, provenance=_provenance()
+    )
+    match = build_deterministic_match(canonical_analysis=payload, result=result)
+    assert isinstance(match, dict)
+
+
+def test_build_canonical_analysis_does_not_leak_recurrence_or_trust_fields():
+    import json
+
+    payload = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([_flagged_event(RiskClassification(coverage_gap=True))]),
+        provenance=_provenance(),
+    )
+    blob = json.dumps(payload)
+    for forbidden in (
+        "recurrence_count",
+        "pattern_maturity",
+        "trust_weighted",
+        "first_observation_at",
+        "trust_band",
+        "final_learning_weight",
+    ):
+        assert forbidden not in blob, f"OSS boundary leak: {forbidden}"
+
+
+def test_qualification_audit_trail_uses_provenance_timestamp():
+    # Re-analysing with a newer ingest stamps a newer qualified_at; the policy
+    # version is stable so aggregations never mix policies.
+    risk = RiskClassification(coverage_gap=True)
+    first = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([_flagged_event(risk)]),
+        provenance=_provenance(),
+    )
+    later = IngestProvenance(
+        transcript_hash="hash-1",
+        source_session_id="src-1",
+        source_path=None,
+        parser_version="claude_code@2",
+        ingested_at=datetime(2026, 6, 9, 9, 0, 0, tzinfo=timezone.utc),
+    )
+    second = build_canonical_analysis(
+        session=_completed_session(),
+        result=_flagged_result([_flagged_event(RiskClassification(coverage_gap=True))]),
+        provenance=later,
+    )
+    assert first["qualification"]["qualified_at"] != second["qualification"]["qualified_at"]
+    assert (
+        first["qualification"]["qualification_policy_version"]
+        == second["qualification"]["qualification_policy_version"]
+    )
+
+
+def test_oss_serialization_strips_internal_and_teams_fields():
+    payload = build_canonical_analysis(
+        session=_completed_session(metadata={"environment": "production"}),
+        result=_flagged_result([_flagged_event(RiskClassification(coverage_gap=True))]),
+        provenance=_provenance(),
+    )
+    oss = apply_visibility(payload, tier="oss")
+    qualification = oss["qualification"]
+    assert "qualification_state" in qualification
+    assert "qualification_policy_version" not in qualification
+    assert "qualification_reasons" not in qualification
+    assert oss["provenance_environment"] == {"environment_class": "production"}
+    # delta_records stay fully visible at the oss tier
+    assert oss["delta_records"]

--- a/driftshield/tests/core/test_delta_records.py
+++ b/driftshield/tests/core/test_delta_records.py
@@ -1,0 +1,178 @@
+"""Structured delta-record tests (driftshield#68).
+
+Delta records are an additive structure on the canonical payload. They carry a
+closed DeltaType, a severity band, and event_id refs that resolve against
+normalized_events (nulled safely when an event was lost, e.g. to redaction).
+"""
+
+from uuid import uuid4
+
+from driftshield.core.canonical_analysis import _refine_delta_records
+from driftshield.core.analysis.session import AnalysisResult
+from driftshield.core.graph.models import LineageGraph
+from driftshield.core.models import CanonicalEvent, EventType, RiskClassification
+from datetime import datetime, timezone
+
+
+def _normalized(event_ids):
+    return [{"event_id": eid} for eid in event_ids]
+
+
+def _event(event_id, *, risk=None, failure=None, tool=None, action="Read"):
+    return CanonicalEvent(
+        id=event_id,
+        session_id="s",
+        timestamp=datetime.now(timezone.utc),
+        event_type=EventType.TOOL_CALL,
+        agent_id="claude",
+        action=action,
+        risk_classification=risk,
+        failure_context=failure,
+        tool_activity=tool,
+    )
+
+
+def _result(events):
+    return AnalysisResult(
+        events=events,
+        graph=LineageGraph(session_id="s"),
+        inflection_node=None,
+        total_events=len(events),
+        flagged_events=sum(1 for e in events if e.has_risk_flags()),
+    )
+
+
+class TestNoMaterialDelta:
+    def test_no_signals_emits_single_no_material_sentinel(self):
+        records = _refine_delta_records(
+            _result([_event(uuid4())]),
+            normalized_events=_normalized(["x"]),
+            delta_types=[],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        assert len(records) == 1
+        assert records[0]["delta_type"] == "no_material_delta_detected"
+        assert records[0]["delta_severity"] == "none"
+        assert records[0]["expected_ref"] is None
+        assert records[0]["actual_ref"] is None
+
+
+class TestDeltaTypeMapping:
+    def test_coverage_gap_maps_to_missing_output(self):
+        eid = uuid4()
+        risk = RiskClassification(coverage_gap=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized([str(eid)]),
+            delta_types=["missing_required_action"],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        types = {r["delta_type"] for r in records}
+        assert "missing_output" in types
+        assert "no_material_delta_detected" not in types
+
+    def test_policy_violation_maps_to_invalid_schema_severe(self):
+        eid = uuid4()
+        risk = RiskClassification(constraint_violation=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized([str(eid)]),
+            delta_types=["policy_violation"],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        match = next(r for r in records if r["delta_type"] == "invalid_schema")
+        assert match["delta_severity"] == "severe"
+
+    def test_policy_divergence_maps_to_incorrect_output(self):
+        eid = uuid4()
+        risk = RiskClassification(policy_divergence=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized([str(eid)]),
+            delta_types=["wrong_action"],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        assert "incorrect_output" in {r["delta_type"] for r in records}
+
+
+class TestRefResolution:
+    def test_ref_present_in_normalized_events_resolves(self):
+        eid = uuid4()
+        risk = RiskClassification(coverage_gap=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized([str(eid)]),
+            delta_types=["missing_required_action"],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        material = next(r for r in records if r["delta_severity"] != "none")
+        assert material["expected_ref"] == str(eid)
+
+    def test_ref_lost_to_redaction_is_nulled_safely(self):
+        # The flagged event is NOT in normalized_events (simulating an event
+        # dropped during redaction). The ref must null, not dangle.
+        eid = uuid4()
+        risk = RiskClassification(coverage_gap=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized(["some-other-surviving-event"]),
+            delta_types=["missing_required_action"],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        for record in records:
+            for ref in (record["expected_ref"], record["actual_ref"]):
+                if ref is not None:
+                    assert ref in {"some-other-surviving-event"}
+        material = next(r for r in records if r["delta_severity"] != "none")
+        assert material["expected_ref"] is None
+
+    def test_oss_refs_only_point_at_surviving_events(self):
+        # Stronger statement of the redaction-safety invariant: no emitted ref
+        # may point at an event id that is absent from normalized_events.
+        e1, e2 = uuid4(), uuid4()
+        risk = RiskClassification(coverage_gap=True, policy_divergence=True)
+        records = _refine_delta_records(
+            _result([_event(e1, risk=risk)]),
+            normalized_events=_normalized([str(e2)]),  # e1 redacted out
+            delta_types=["missing_required_action", "wrong_action"],
+            overall_quality_band="high",
+            coverage_ratio=0.9,
+        )
+        surviving = {str(e2)}
+        for record in records:
+            for ref in (record["expected_ref"], record["actual_ref"]):
+                assert ref is None or ref in surviving
+
+
+class TestDeltaConfidence:
+    def test_confidence_bounded_by_coverage_ratio(self):
+        eid = uuid4()
+        risk = RiskClassification(coverage_gap=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized([str(eid)]),
+            delta_types=["missing_required_action"],
+            overall_quality_band="high",
+            coverage_ratio=0.4,
+        )
+        for record in records:
+            assert record["delta_confidence"] <= 0.4 + 1e-9
+
+    def test_usable_band_caps_confidence_below_high(self):
+        eid = uuid4()
+        risk = RiskClassification(coverage_gap=True)
+        records = _refine_delta_records(
+            _result([_event(eid, risk=risk)]),
+            normalized_events=_normalized([str(eid)]),
+            delta_types=["missing_required_action"],
+            overall_quality_band="usable",
+            coverage_ratio=0.95,
+        )
+        for record in records:
+            assert record["delta_confidence"] <= 0.75 + 1e-9

--- a/driftshield/tests/core/test_models.py
+++ b/driftshield/tests/core/test_models.py
@@ -5,12 +5,87 @@ from uuid import uuid4
 
 from driftshield.core.models import (
     CanonicalEvent,
+    DeltaSeverity,
+    DeltaType,
+    EnvironmentClass,
+    EnvironmentSource,
     EventType,
+    ProvenanceConfidence,
+    QualificationState,
     RiskClassification,
     Session,
     SessionStatus,
 )
 from driftshield.core.normalization import normalize_events
+
+
+class TestQualificationEnums:
+    def test_qualification_state_closed_set(self):
+        assert {state.value for state in QualificationState} == {
+            "analysed",
+            "classifiable",
+            "unclassified",
+            "not_classifiable",
+            "qualified_failure",
+        }
+
+    def test_provenance_confidence_closed_set(self):
+        assert {value.value for value in ProvenanceConfidence} == {
+            "connector_verified",
+            "user_claimed",
+            "inferred",
+            "unknown",
+        }
+
+    def test_environment_class_closed_set_never_defaults_production(self):
+        # The closed set is exactly five values. "unknown" is the absence state.
+        assert {value.value for value in EnvironmentClass} == {
+            "production",
+            "staging",
+            "test",
+            "demo",
+            "unknown",
+        }
+
+    def test_environment_source_closed_set(self):
+        assert {value.value for value in EnvironmentSource} == {
+            "connector",
+            "submitter_declared",
+            "inferred",
+            "absent",
+        }
+
+    def test_delta_type_closed_eight_values(self):
+        assert {value.value for value in DeltaType} == {
+            "missing_output",
+            "incorrect_output",
+            "contradictory_output",
+            "invalid_schema",
+            "unsafe_action",
+            "incomplete_execution",
+            "unintended_state_change",
+            "no_material_delta_detected",
+        }
+
+    def test_delta_severity_closed_set(self):
+        assert {value.value for value in DeltaSeverity} == {
+            "none",
+            "minor",
+            "material",
+            "severe",
+        }
+
+    def test_all_new_enums_are_string_enums(self):
+        for enum_cls in (
+            QualificationState,
+            ProvenanceConfidence,
+            EnvironmentClass,
+            EnvironmentSource,
+            DeltaType,
+            DeltaSeverity,
+        ):
+            for member in enum_cls:
+                assert isinstance(member.value, str)
 
 
 class TestEventType:

--- a/driftshield/tests/core/test_provenance_environment.py
+++ b/driftshield/tests/core/test_provenance_environment.py
@@ -1,0 +1,104 @@
+"""Provenance confidence + environment classification tests (driftshield#68)."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from driftshield.core.canonical_analysis import _compute_provenance_and_environment
+from driftshield.core.models import Session, SessionStatus
+from driftshield.db.persistence import IngestProvenance
+
+
+def _session(metadata=None, external_id=None):
+    return Session(
+        id=uuid4(),
+        agent_id="claude",
+        started_at=datetime.now(timezone.utc),
+        external_id=external_id,
+        status=SessionStatus.COMPLETED,
+        metadata=metadata or {},
+    )
+
+
+def _provenance(source_path=None, source_session_id="src-1"):
+    return IngestProvenance(
+        transcript_hash="hash-1",
+        source_session_id=source_session_id,
+        source_path=source_path,
+        parser_version="claude_code@1",
+        ingested_at=datetime.now(timezone.utc),
+    )
+
+
+class TestProvenanceConfidence:
+    def test_no_provenance_no_external_id_is_unknown(self):
+        block = _compute_provenance_and_environment(_session(), None)
+        assert block["provenance_confidence"] == "unknown"
+
+    def test_no_provenance_with_external_id_is_inferred(self):
+        block = _compute_provenance_and_environment(_session(external_id="ext-1"), None)
+        assert block["provenance_confidence"] == "inferred"
+
+    def test_provenance_present_is_user_claimed(self):
+        # IngestProvenance carries no connector signal today, so an attested
+        # provenance is user_claimed, never connector_verified.
+        block = _compute_provenance_and_environment(_session(), _provenance())
+        assert block["provenance_confidence"] == "user_claimed"
+
+
+class TestEnvironmentClassification:
+    def test_declared_production_is_returned_not_defaulted(self):
+        block = _compute_provenance_and_environment(
+            _session(metadata={"environment": "production"}), _provenance()
+        )
+        assert block["environment_class"] == "production"
+        assert block["environment_source"] == "submitter_declared"
+
+    def test_declared_test_is_submitter_declared(self):
+        block = _compute_provenance_and_environment(
+            _session(metadata={"environment": "test"}), _provenance()
+        )
+        assert block["environment_class"] == "test"
+        assert block["environment_source"] == "submitter_declared"
+
+    def test_declared_value_outside_closed_set_is_not_trusted(self):
+        # An unrecognised declared value must not pass through as-is; it falls to
+        # inference / unknown rather than minting a new environment class.
+        block = _compute_provenance_and_environment(
+            _session(metadata={"environment": "prod-eu-west"}), _provenance()
+        )
+        assert block["environment_class"] != "prod-eu-west"
+
+    def test_demo_path_infers_demo(self):
+        block = _compute_provenance_and_environment(
+            _session(), _provenance(source_path="/home/u/demo/run.jsonl")
+        )
+        assert block["environment_class"] == "demo"
+        assert block["environment_source"] == "inferred"
+
+    def test_test_path_infers_test(self):
+        block = _compute_provenance_and_environment(
+            _session(), _provenance(source_path="/repo/test/run.jsonl")
+        )
+        assert block["environment_class"] == "test"
+        assert block["environment_source"] == "inferred"
+
+    def test_unrecognised_path_is_unknown_inferred(self):
+        block = _compute_provenance_and_environment(
+            _session(), _provenance(source_path="/home/u/projects/app/run.jsonl")
+        )
+        assert block["environment_class"] == "unknown"
+        assert block["environment_source"] == "inferred"
+
+    def test_no_signal_is_unknown_absent_never_production(self):
+        block = _compute_provenance_and_environment(_session(), None)
+        assert block["environment_class"] == "unknown"
+        assert block["environment_source"] == "absent"
+        assert block["environment_class"] != "production"
+
+    def test_declared_environment_beats_path_inference(self):
+        block = _compute_provenance_and_environment(
+            _session(metadata={"environment": "production"}),
+            _provenance(source_path="/home/u/demo/run.jsonl"),
+        )
+        assert block["environment_class"] == "production"
+        assert block["environment_source"] == "submitter_declared"

--- a/driftshield/tests/core/test_qualification_state.py
+++ b/driftshield/tests/core/test_qualification_state.py
@@ -1,0 +1,108 @@
+"""Qualification state-machine unit tests (driftshield#68).
+
+These test the pure ``_compute_qualification_state`` decision function directly so
+the bars are pinned independently of parser machinery. End-to-end emission is
+covered in test_canonical_analysis.
+"""
+
+from driftshield.core.canonical_analysis import _compute_qualification_state
+
+
+def _events(count, *, recovery_mode="direct", missing=False):
+    return [
+        {
+            "event_id": f"e{i}",
+            "recovery_mode": recovery_mode,
+            "missing_fields": ["x"] if missing else [],
+        }
+        for i in range(count)
+    ]
+
+
+class TestDegradedHardBar:
+    def test_degraded_band_forces_unclassified_even_with_material_delta(self):
+        state, reasons = _compute_qualification_state(
+            overall_quality_band="degraded",
+            integrity_status="complete",
+            delta_types=["missing_required_action"],  # a material delta is present
+            normalized_events=_events(5),
+        )
+        assert state == "unclassified"
+        assert "extraction_quality_degraded" in reasons
+
+    def test_insufficient_band_forces_unclassified(self):
+        state, reasons = _compute_qualification_state(
+            overall_quality_band="insufficient_for_matching",
+            integrity_status="complete",
+            delta_types=["wrong_action"],
+            normalized_events=_events(3),
+        )
+        assert state == "unclassified"
+        assert "extraction_quality_degraded" in reasons
+
+    def test_degraded_never_qualified_failure_regardless_of_signals(self):
+        # The mitigation in the spec: a high-confidence candidate must NOT upgrade
+        # a degraded run. Even with every material signal, degraded stays out.
+        state, _ = _compute_qualification_state(
+            overall_quality_band="degraded",
+            integrity_status="complete",
+            delta_types=["missing_required_action", "wrong_action", "policy_violation"],
+            normalized_events=_events(8),
+        )
+        assert state != "qualified_failure"
+
+
+class TestNotClassifiable:
+    def test_no_events_returns_not_classifiable(self):
+        state, reasons = _compute_qualification_state(
+            overall_quality_band="high",
+            integrity_status="complete",
+            delta_types=["missing_required_action"],
+            normalized_events=[],
+        )
+        assert state == "not_classifiable"
+        assert "no_events" in reasons
+
+
+class TestQualifiedFailure:
+    def test_high_band_material_delta_complete_integrity_qualifies(self):
+        state, reasons = _compute_qualification_state(
+            overall_quality_band="high",
+            integrity_status="complete",
+            delta_types=["missing_required_action"],
+            normalized_events=_events(4),
+        )
+        assert state == "qualified_failure"
+        assert reasons == []
+
+    def test_usable_band_material_delta_recovered_integrity_qualifies(self):
+        # "usable" passes the extraction bar; "recovered" is acceptable integrity.
+        state, _ = _compute_qualification_state(
+            overall_quality_band="usable",
+            integrity_status="recovered",
+            delta_types=["wrong_action"],
+            normalized_events=_events(4),
+        )
+        assert state == "qualified_failure"
+
+
+class TestUnclassifiedNoDelta:
+    def test_high_band_no_delta_returns_unclassified_no_material_delta(self):
+        state, reasons = _compute_qualification_state(
+            overall_quality_band="high",
+            integrity_status="complete",
+            delta_types=[],
+            normalized_events=_events(4),
+        )
+        assert state == "unclassified"
+        assert "no_material_delta_detected" in reasons
+
+    def test_high_band_only_no_material_marker_returns_unclassified(self):
+        state, reasons = _compute_qualification_state(
+            overall_quality_band="high",
+            integrity_status="complete",
+            delta_types=["no_material_delta_detected"],
+            normalized_events=_events(4),
+        )
+        assert state == "unclassified"
+        assert "no_material_delta_detected" in reasons

--- a/driftshield/tests/core/test_visibility.py
+++ b/driftshield/tests/core/test_visibility.py
@@ -1,0 +1,148 @@
+"""Tier-aware visibility enforcement for the qualification/provenance/delta seam."""
+
+from driftshield.core.visibility import (
+    KNOWN_DELTA_RECORD_FIELDS,
+    KNOWN_PROVENANCE_ENV_FIELDS,
+    KNOWN_QUALIFICATION_FIELDS,
+    VISIBILITY_REGISTRY,
+    apply_visibility,
+    visibility_class_for,
+)
+
+
+def _sample_canonical():
+    return {
+        "qualification": {
+            "qualification_state": "qualified_failure",
+            "qualification_reasons": [],
+            "qualified_at": "2026-06-08T00:00:00+00:00",
+            "classifiability_inputs": {
+                "extraction_quality_band": "high",
+                "coverage_ratio": 0.9,
+                "event_count": 4,
+                "has_expected_actual_delta": True,
+                "ambiguity_count": 0,
+            },
+            "qualification_schema_version": "v1",
+            "qualification_policy_version": "policy-v1",
+        },
+        "provenance_environment": {
+            "provenance_confidence": "user_claimed",
+            "environment_class": "production",
+            "environment_source": "submitter_declared",
+        },
+        "delta_records": [
+            {
+                "delta_type": "missing_output",
+                "delta_severity": "material",
+                "expected_ref": "11111111-1111-1111-1111-111111111111",
+                "actual_ref": None,
+                "delta_summary": "Expected output absent.",
+                "delta_confidence": 0.8,
+            }
+        ],
+        # an untouched existing block must survive unchanged
+        "analysis_session": {"session_id": "abc"},
+    }
+
+
+class TestRegistryCompleteness:
+    def test_every_known_qualification_field_has_a_class(self):
+        for field in KNOWN_QUALIFICATION_FIELDS:
+            assert visibility_class_for("qualification", field) is not None, field
+
+    def test_every_known_provenance_env_field_has_a_class(self):
+        for field in KNOWN_PROVENANCE_ENV_FIELDS:
+            assert visibility_class_for("provenance_environment", field) is not None, field
+
+    def test_every_known_delta_record_field_has_a_class(self):
+        for field in KNOWN_DELTA_RECORD_FIELDS:
+            assert visibility_class_for("delta_records.[]", field) is not None, field
+
+    def test_registry_only_uses_valid_tier_names(self):
+        valid = {"oss", "teams", "enterprise", "internal_only"}
+        for path, tier in VISIBILITY_REGISTRY.items():
+            assert tier in valid, f"{path} -> {tier}"
+
+    def test_unregistered_field_has_no_class(self):
+        # A new field added to a block without a registry entry returns None.
+        # The build-side completeness test (test_canonical_analysis) asserts
+        # the emitted field set equals the KNOWN_* set, so an unregistered field
+        # surfaces as a failure rather than silently shipping.
+        assert visibility_class_for("qualification", "some_unregistered_field") is None
+
+
+class TestApplyVisibilityOssTier:
+    def test_oss_keeps_state_and_environment_class(self):
+        filtered = apply_visibility(_sample_canonical(), tier="oss")
+        assert filtered["qualification"]["qualification_state"] == "qualified_failure"
+        assert filtered["provenance_environment"]["environment_class"] == "production"
+
+    def test_oss_strips_teams_fields(self):
+        filtered = apply_visibility(_sample_canonical(), tier="oss")
+        q = filtered["qualification"]
+        assert "qualification_reasons" not in q
+        assert "classifiability_inputs" not in q
+        assert "qualified_at" not in q
+        assert "qualification_schema_version" not in q
+        pe = filtered["provenance_environment"]
+        assert "provenance_confidence" not in pe
+        assert "environment_source" not in pe
+
+    def test_oss_strips_internal_only_policy_version(self):
+        filtered = apply_visibility(_sample_canonical(), tier="oss")
+        assert "qualification_policy_version" not in filtered["qualification"]
+
+    def test_oss_keeps_delta_records_and_all_their_fields(self):
+        filtered = apply_visibility(_sample_canonical(), tier="oss")
+        record = filtered["delta_records"][0]
+        assert record["delta_type"] == "missing_output"
+        assert record["delta_confidence"] == 0.8
+        assert record["actual_ref"] is None
+
+    def test_oss_preserves_unrelated_blocks(self):
+        filtered = apply_visibility(_sample_canonical(), tier="oss")
+        assert filtered["analysis_session"] == {"session_id": "abc"}
+
+
+class TestApplyVisibilityHigherTiers:
+    def test_teams_keeps_reasons_and_provenance_confidence(self):
+        filtered = apply_visibility(_sample_canonical(), tier="teams")
+        assert filtered["qualification"]["qualification_reasons"] == []
+        assert filtered["qualification"]["classifiability_inputs"]["extraction_quality_band"] == "high"
+        assert filtered["provenance_environment"]["provenance_confidence"] == "user_claimed"
+
+    def test_teams_still_strips_internal_only(self):
+        filtered = apply_visibility(_sample_canonical(), tier="teams")
+        assert "qualification_policy_version" not in filtered["qualification"]
+
+    def test_internal_only_exposes_policy_version(self):
+        filtered = apply_visibility(_sample_canonical(), tier="internal_only")
+        assert filtered["qualification"]["qualification_policy_version"] == "policy-v1"
+
+    def test_does_not_mutate_input(self):
+        canonical = _sample_canonical()
+        apply_visibility(canonical, tier="oss")
+        # original retains the teams-tier field
+        assert "qualification_reasons" in canonical["qualification"]
+
+    def test_unknown_tier_defaults_to_oss(self):
+        filtered = apply_visibility(_sample_canonical(), tier="not-a-tier")
+        assert filtered["qualification"]["qualification_state"] == "qualified_failure"
+        assert "qualification_reasons" not in filtered["qualification"]
+
+
+class TestEmittedFieldsMatchRegistry:
+    """A new field added to an emitted block without a registry + KNOWN_* entry must fail."""
+
+    def test_qualification_emitted_fields_match_known_set(self):
+        emitted = set(_sample_canonical()["qualification"].keys())
+        assert emitted == KNOWN_QUALIFICATION_FIELDS
+
+    def test_provenance_env_emitted_fields_match_known_set(self):
+        emitted = set(_sample_canonical()["provenance_environment"].keys())
+        assert emitted == KNOWN_PROVENANCE_ENV_FIELDS
+
+    def test_delta_record_emitted_fields_match_known_set(self):
+        emitted = set(_sample_canonical()["delta_records"][0].keys())
+        assert emitted == KNOWN_DELTA_RECORD_FIELDS

--- a/driftshield/tests/core/test_visibility.py
+++ b/driftshield/tests/core/test_visibility.py
@@ -1,6 +1,7 @@
 """Tier-aware visibility enforcement for the qualification/provenance/delta seam."""
 
 from driftshield.core.visibility import (
+    KNOWN_CLASSIFIABILITY_INPUTS_FIELDS,
     KNOWN_DELTA_RECORD_FIELDS,
     KNOWN_PROVENANCE_ENV_FIELDS,
     KNOWN_QUALIFICATION_FIELDS,
@@ -59,6 +60,14 @@ class TestRegistryCompleteness:
         for field in KNOWN_DELTA_RECORD_FIELDS:
             assert visibility_class_for("delta_records.[]", field) is not None, field
 
+    def test_every_known_classifiability_input_field_has_a_class(self):
+        # Nested fields inside classifiability_inputs must be individually
+        # registered, not covered only by the parent object's class.
+        for field in KNOWN_CLASSIFIABILITY_INPUTS_FIELDS:
+            assert (
+                visibility_class_for("qualification.classifiability_inputs", field) is not None
+            ), field
+
     def test_registry_only_uses_valid_tier_names(self):
         valid = {"oss", "teams", "enterprise", "internal_only"}
         for path, tier in VISIBILITY_REGISTRY.items():
@@ -112,6 +121,17 @@ class TestApplyVisibilityHigherTiers:
         assert filtered["qualification"]["classifiability_inputs"]["extraction_quality_band"] == "high"
         assert filtered["provenance_environment"]["provenance_confidence"] == "user_claimed"
 
+    def test_unregistered_nested_classifiability_field_is_stripped(self):
+        # A future nested field with no registry entry must NOT leak through the
+        # parent object's tier gate. Unregistered nested fields are withheld
+        # rather than exposed.
+        canonical = _sample_canonical()
+        canonical["qualification"]["classifiability_inputs"]["secret_diagnostic"] = "LEAK"
+        for tier in ("oss", "teams", "enterprise", "internal_only"):
+            filtered = apply_visibility(canonical, tier=tier)
+            inputs = filtered["qualification"].get("classifiability_inputs", {})
+            assert "secret_diagnostic" not in inputs, tier
+
     def test_teams_still_strips_internal_only(self):
         filtered = apply_visibility(_sample_canonical(), tier="teams")
         assert "qualification_policy_version" not in filtered["qualification"]
@@ -146,3 +166,7 @@ class TestEmittedFieldsMatchRegistry:
     def test_delta_record_emitted_fields_match_known_set(self):
         emitted = set(_sample_canonical()["delta_records"][0].keys())
         assert emitted == KNOWN_DELTA_RECORD_FIELDS
+
+    def test_classifiability_inputs_emitted_fields_match_known_set(self):
+        emitted = set(_sample_canonical()["qualification"]["classifiability_inputs"].keys())
+        assert emitted == KNOWN_CLASSIFIABILITY_INPUTS_FIELDS


### PR DESCRIPTION
## Summary

- **What changed:** the canonical analysed-run payload (`build_canonical_analysis`) now emits three new structured blocks — `qualification`, `provenance_environment`, and `delta_records[]` — plus a tier-aware visibility serializer and typed API responses.
- **Why:** the runtime previously left run qualification, environment/provenance, and explicit outcome-delta as half-implicit seams. This makes them first-class, machine-readable fields so a downstream consumer can gate on `qualification_state` and `environment_class` without re-deriving them.

All new state lives in the existing JSONB `metadata_json`. **No DB migration.**

### Qualification (5-state machine)
`analysed` (entry) → `classifiable` → `qualified_failure` / `unclassified` / `not_classifiable`.
- `qualified_failure` requires HIGH/USABLE extraction **AND** a material delta **AND** acceptable integrity.
- **Degraded extraction is a hard `unclassified` bar** — never upgraded to `qualified_failure`, even with a high-confidence candidate. Qualification is structural and is kept separate from `trust_band` (integrity owns trust).
- Emits `qualification_state`, `qualification_reasons[]`, `classifiability_inputs{}`, `qualified_at`, `qualification_schema_version`, `qualification_policy_version`.

### Provenance + environment
`provenance_confidence` (connector_verified/user_claimed/inferred/unknown), `environment_class` (production/staging/test/demo/unknown), `environment_source` (connector/submitter_declared/inferred/absent).
- Environment **never silently defaults to production**: a declared value is trusted only if it is in the closed set, otherwise the source path is inspected, and absence resolves to `unknown`.

### Delta records
Closed 8-value `DeltaType` + `DeltaSeverity` (none/minor/material/severe). `delta_records[]` is **additive** to the existing `expected_vs_actual_delta` block (the `delta_types`/`supporting_event_ids` keys the deterministic matcher reads are untouched). Refs are `event_id` UUIDs into `normalized_events`, resolved against the event set and **nulled safely on redaction loss**.

### Visibility
A new `core/visibility.py` serializer strips fields above a requested tier. The OSS API applies `tier="oss"` in `_extract_canonical_analysis` so the raw stored dict cannot bypass the boundary. Every new field carries a visibility class; an unregistered field fails a completeness test.

## Seam mapping (1:1, for the downstream consumer to pin against)

| Emitted field | Emitted location | type / enum | Visibility |
|---|---|---|---|
| `qualification_state` | `canonical_analysis.qualification.qualification_state` | analysed/classifiable/unclassified/not_classifiable/qualified_failure | oss |
| `qualification_reasons[]` | `canonical_analysis.qualification.qualification_reasons` | list[str] reason codes | teams |
| `qualification_policy_version` | `canonical_analysis.qualification.qualification_policy_version` | str (immutable per analysis) | internal_only |
| `provenance_confidence` | `canonical_analysis.provenance_environment.provenance_confidence` | connector_verified/user_claimed/inferred/unknown | teams |
| `environment_class` | `canonical_analysis.provenance_environment.environment_class` | production/staging/test/demo/unknown | oss |
| `environment_source` | `canonical_analysis.provenance_environment.environment_source` | connector/submitter_declared/inferred/absent | teams |
| `extraction_quality_band` | `canonical_analysis.qualification.classifiability_inputs.extraction_quality_band` | high/usable/degraded/insufficient_for_matching | teams |
| `has_expected_actual_delta` | `canonical_analysis.qualification.classifiability_inputs.has_expected_actual_delta` | bool | teams |
| `delta_records[]` | `canonical_analysis.delta_records` | {delta_type(8-enum), delta_severity, expected_ref, actual_ref, delta_summary, delta_confidence} | oss |

Notes for the consumer:
- Read these values as authoritative — do not re-derive. `qualification_policy_version` is set at analysis time and must be read verbatim so aggregations never mix policies.
- The same field name can carry different classes by context: `qualification_state` and `environment_class` are `oss` here as a run-local badge; a cross-run recurrence gate may treat them as `internal_only`. This producer ships them `oss`.
- A cross-run first-observation timestamp is **deliberately not emitted** — that is cross-run state, not a run-local fact this producer can know.
- `extraction_quality_band` is emitted with the four runtime values (`high/usable/degraded/insufficient_for_matching`). The classifiable bar treats `degraded` and `insufficient_for_matching` identically (both fail). The consumer should treat anything other than `high`/`usable` as below the bar.
- `actual_ref` is currently always `null`: there is no clean per-event "actual outcome" id in the existing signals, and fabricating one would break the resolve-or-null discipline. `expected_ref` resolves to the owning flagged event. This is a documented bound, not a dangling ref.

## Verification

Real repo gate, run locally in a clean venv (`pip install -e ".[dev]"`):

```
# public OSS boundary
$ ./scripts/check-public-scope.sh
[public-scope] Checking tracked files for public-OSS boundary leaks
[public-scope] OK

# full backend suite
$ PYTHONPATH=src python -m pytest tests -q
634 passed, 3 skipped, 2 warnings in 114.44s

# lint + types (pyproject configures ruff + mypy --strict)
$ ruff check src tests
All checks passed!
$ mypy src/driftshield
Success: no issues found in 100 source files
```

The 3 skips are pre-existing and unrelated to this change. `canonical_analysis.py`, `visibility.py`, and `api/routes/sessions.py` are not in the mypy override ignore-list, so the new code passes `mypy --strict`.

New tests (all passing):
- `tests/core/test_qualification_state.py` — degraded → `unclassified` (never `qualified_failure` even with a material delta); HIGH + material delta → `qualified_failure`; HIGH + no delta → `unclassified` (`no_material_delta_detected`); empty run → `not_classifiable`.
- `tests/core/test_provenance_environment.py` — environment default `unknown`/`absent` (never production); declared-in-closed-set trusted; path inference; declared-beats-inference.
- `tests/core/test_delta_records.py` — DeltaType mapping; ref resolves to a real event; **a redacted-out ref is nulled safely**; no oss-tier ref points at a redacted-out event; confidence bounded by coverage_ratio.
- `tests/core/test_visibility.py` — oss strips teams/internal_only fields; a field with no visibility class is caught by the completeness test; input is not mutated.
- `tests/core/test_canonical_analysis.py` — end-to-end emission; existing `expected_vs_actual_delta.delta_types` preserved; deterministic matcher still runs; OSS boundary grep returns 0 for recurrence/trust fields; audit trail.
- `tests/api/test_sessions.py` — the public API strips internal_only/teams fields from `canonical_analysis` and populates the typed response blocks.

## OSS-safety checklist

- [x] No DB migration — new state lives in JSONB `metadata_json` only.
- [x] No recurrence/trust fields leaked — `test_build_canonical_analysis_does_not_leak_recurrence_or_trust_fields` asserts a JSON grep returns 0 for `recurrence_count`, `pattern_maturity`, `trust_weighted*`, `first_observation_at`, `trust_band`, `final_learning_weight`.
- [x] Qualification not collapsed into trust — `integrity.py` is untouched; qualification reads `integrity_status` only.
- [x] Public-repo clean — `./scripts/check-public-scope.sh` passes; no private-sibling or planning references in the tree.
- [x] Existing matcher contract preserved — `expected_vs_actual_delta` block unchanged; regression test runs `build_deterministic_match` over the augmented payload.

## Links

Closes #68

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- `provenance_confidence` cannot reach `connector_verified` until the ingest provenance record carries a source-kind marker (no connector signal today; documented in code). Until then connector-sourced runs report `user_claimed`.
- `actual_ref` population would need a per-event "actual outcome" id that the current signals do not provide.
