### PR TITLE
feat(cli): zero-config community opt-in, production by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 
 - After analysing a finished run locally, opt its signature run into the community pool:
   `driftshield telemetry submit-session --path <session.json> --tier oss`
-- No setup is needed. The community intake URL is baked in as the default; `remote-enable` is only for pointing at a different intake.
+- No setup is needed. The community intake URL is baked in as the default; `remote-enable` is only for pointing at a different intake. `telemetry remote-disable` opts out entirely, baked default included.
 - `--tier oss` is the unauthenticated community lane. No API key is sent.
 - Opting in declares the run as a production run by default. Do not pass `--environment` in the normal path.
 - Only the redacted, community-safe envelope leaves the machine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,16 @@
 - When preparing a prompt for another agent, make it autonomous by default.
 - Tell the agent to inspect the issue and codebase first, produce a concrete spec and plan, then implement, verify and summarise the result without waiting for a human in the loop.
 
+## Community signature opt-in
+
+- After analysing a finished run locally, opt its signature run into the community pool:
+  `driftshield telemetry submit-session --path <session.json> --tier oss`
+- No setup is needed. The community intake URL is baked in as the default; `remote-enable` is only for pointing at a different intake.
+- `--tier oss` is the unauthenticated community lane. No API key is sent.
+- Opting in declares the run as a production run by default. Do not pass `--environment` in the normal path.
+- Only the redacted, community-safe envelope leaves the machine.
+- Override note: a non-production contribution can pass `--environment staging|test|demo`, but this is the uncommon case, not the documented path.
+
 ## Review guidelines
 
 - For pull request reviews, use the repo-local review skill at `.agents/skills/driftshield-pr-review`.

--- a/driftshield/src/driftshield/cli/commands/show_result.py
+++ b/driftshield/src/driftshield/cli/commands/show_result.py
@@ -8,7 +8,7 @@ from urllib import error, request
 import typer
 from rich.console import Console
 
-from driftshield.telemetry import TelemetryService
+from driftshield.telemetry import TelemetryService, effective_oss_intake_url
 
 
 console = Console(force_terminal=True)
@@ -19,20 +19,29 @@ def show_result(
     intake_url: str | None = typer.Option(
         None,
         "--intake-url",
-        help="Override the intake URL. Defaults to the value persisted by `telemetry remote-enable`.",
+        help=(
+            "Override the intake URL. Defaults to the value persisted by "
+            "`telemetry remote-enable`, falling back to the baked community "
+            "intake URL."
+        ),
     ),
     json_output: bool = typer.Option(False, "--json", help="Print the raw JSON response."),
 ) -> None:
-    """Fetch the OSS-safe result triple for a submission from the configured intake URL."""
+    """Fetch the OSS-safe result triple for a submission from the configured intake URL.
+
+    Zero-config like ``telemetry submit-session --tier oss``: with nothing
+    configured the baked community intake URL is used, so submit followed by
+    show-result needs no ``remote-enable``. After ``telemetry remote-disable``
+    the baked default does not apply; an explicit ``--intake-url`` always works.
+    """
     base_url = intake_url
     if base_url is None:
-        config = TelemetryService().load_config()
-        base_url = config.remote_intake_url
+        base_url = effective_oss_intake_url(TelemetryService().load_config())
     if not base_url:
         console.print(
-            "[red]Error:[/red] No intake URL configured. "
-            "Run `driftshield telemetry remote-enable --intake-url URL` first, "
-            "or pass --intake-url."
+            "[red]Error:[/red] Remote submission is disabled "
+            "(`telemetry remote-disable`). Run `driftshield telemetry "
+            "remote-enable --intake-url URL` to re-enable, or pass --intake-url."
         )
         raise typer.Exit(1)
 

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -42,8 +42,8 @@ from driftshield.remote_upload import (
     submit_teams_via_presigned_upload,
 )
 from driftshield.telemetry import (
-    DEFAULT_COMMUNITY_INTAKE_URL,
     TelemetryService,
+    effective_oss_intake_url,
     validate_outcome_status,
 )
 
@@ -65,6 +65,11 @@ def telemetry_status(
         "event_stream_path": config.event_stream_path,
         "remote_enabled": config.remote_intake_url is not None,
         "remote_intake_url": config.remote_intake_url,
+        "remote_opt_out": config.remote_opt_out,
+        # The URL an OSS-lane submission will actually use right now: the
+        # configured override, the baked community default, or null after
+        # remote-disable.
+        "effective_oss_intake_url": effective_oss_intake_url(config),
     }
     if json_output:
         typer.echo(json.dumps(payload))
@@ -108,9 +113,12 @@ def telemetry_remote_enable(
 
 @app.command("remote-disable")
 def telemetry_remote_disable() -> None:
-    """Clear remote intake configuration. Local telemetry capture is unaffected."""
+    """Opt out of remote submission entirely. Local telemetry capture is unaffected."""
     TelemetryService().remote_disable()
-    console.print("Remote submission configuration cleared.")
+    console.print(
+        "Remote submission disabled. The baked community default no longer "
+        "applies; run `telemetry remote-enable` to re-enable."
+    )
 
 
 @app.command("submit-session")
@@ -195,7 +203,8 @@ def telemetry_submit_session(
     or consent_state is included in the request. The server binds the persisted row
     to the in-stack OSS fallback installation + consent. When no intake URL is
     configured, the OSS lane submits to the baked-in community intake URL, so
-    community opt-in needs no prior ``remote-enable``.
+    community opt-in needs no prior ``remote-enable``. An explicit
+    ``telemetry remote-disable`` opts out of the baked default too.
 
     Community opt-in is the act of declaring the run real: on the oss lane the
     declared environment defaults to ``production`` unless the session JSON or
@@ -270,15 +279,23 @@ def telemetry_submit_session(
             raise typer.Exit(1)
 
     config = TelemetryService().load_config()
-    intake_url = config.remote_intake_url
-    if intake_url is None and resolved_tier == "oss":
-        intake_url = DEFAULT_COMMUNITY_INTAKE_URL
-    if intake_url is None:
-        console.print(
-            "[red]Error:[/red] Remote submission is not configured. "
-            "Run `driftshield telemetry remote-enable --intake-url URL` first."
-        )
-        raise typer.Exit(1)
+    if resolved_tier == "oss":
+        intake_url = effective_oss_intake_url(config)
+        if intake_url is None:
+            console.print(
+                "[red]Error:[/red] Remote submission is disabled "
+                "(`telemetry remote-disable`). Run `driftshield telemetry "
+                "remote-enable --intake-url URL` to re-enable."
+            )
+            raise typer.Exit(1)
+    else:
+        intake_url = config.remote_intake_url
+        if intake_url is None:
+            console.print(
+                "[red]Error:[/red] Remote submission is not configured. "
+                "Run `driftshield telemetry remote-enable --intake-url URL` first."
+            )
+            raise typer.Exit(1)
 
     resolved_workflow_reference = workflow_reference
     if resolved_workflow_reference is None:

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from driftshield.core.canonical_analysis import DECLARED_ENVIRONMENTS
+from driftshield.core.models import EnvironmentClass
 from driftshield.intake_contract import (
     DEFAULT_WORKFLOW_REFERENCE,
     REDACTION_MANIFEST_VERSION,
@@ -39,7 +41,11 @@ from driftshield.remote_upload import (
     submit_oss_via_presigned_upload,
     submit_teams_via_presigned_upload,
 )
-from driftshield.telemetry import TelemetryService, validate_outcome_status
+from driftshield.telemetry import (
+    DEFAULT_COMMUNITY_INTAKE_URL,
+    TelemetryService,
+    validate_outcome_status,
+)
 
 console = Console(force_terminal=True)
 app = typer.Typer(help="Manage opt-in telemetry.")
@@ -172,12 +178,29 @@ def telemetry_submit_session(
             "transcripts upload via presigned storage on either tier."
         ),
     ),
+    environment: str | None = typer.Option(
+        None,
+        "--environment",
+        help=(
+            "Declared run environment for the community (oss) lane: "
+            "production, staging, test, or demo. Community opt-in declares "
+            "production by default; pass this only for the uncommon "
+            "non-production contribution."
+        ),
+    ),
 ) -> None:
     """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
 
     The OSS lane is unauthenticated. No X-API-Key header is sent, no installation_id
     or consent_state is included in the request. The server binds the persisted row
-    to the in-stack OSS fallback installation + consent.
+    to the in-stack OSS fallback installation + consent. When no intake URL is
+    configured, the OSS lane submits to the baked-in community intake URL, so
+    community opt-in needs no prior ``remote-enable``.
+
+    Community opt-in is the act of declaring the run real: on the oss lane the
+    declared environment defaults to ``production`` unless the session JSON or
+    ``--environment`` says otherwise. The server records it as a
+    submitter-declared value; the server itself never defaults to production.
 
     ``workflow_reference`` precedence: --workflow-reference flag, then
     session JSON's ``workflow_reference`` field, then ``"default"``. Distinct
@@ -225,8 +248,32 @@ def telemetry_submit_session(
             typer.echo(json.dumps(manifest_payload, indent=2))
         return
 
+    resolved_tier = tier.strip().lower()
+    if resolved_tier not in {"oss", "teams"}:
+        console.print("[red]Error:[/red] --tier must be 'oss' or 'teams'.")
+        raise typer.Exit(1)
+
+    resolved_environment: str | None = None
+    if environment is not None:
+        resolved_environment = environment.strip().lower()
+        if resolved_environment not in DECLARED_ENVIRONMENTS:
+            valid = ", ".join(sorted(DECLARED_ENVIRONMENTS))
+            console.print(
+                f"[red]Error:[/red] --environment must be one of: {valid}."
+            )
+            raise typer.Exit(1)
+        if resolved_tier != "oss":
+            console.print(
+                "[red]Error:[/red] --environment applies to the community "
+                "(oss) lane only."
+            )
+            raise typer.Exit(1)
+
     config = TelemetryService().load_config()
-    if not config.remote_intake_url:
+    intake_url = config.remote_intake_url
+    if intake_url is None and resolved_tier == "oss":
+        intake_url = DEFAULT_COMMUNITY_INTAKE_URL
+    if intake_url is None:
         console.print(
             "[red]Error:[/red] Remote submission is not configured. "
             "Run `driftshield telemetry remote-enable --intake-url URL` first."
@@ -262,11 +309,6 @@ def telemetry_submit_session(
             )
             raise typer.Exit(code=2)
 
-    resolved_tier = tier.strip().lower()
-    if resolved_tier not in {"oss", "teams"}:
-        console.print("[red]Error:[/red] --tier must be 'oss' or 'teams'.")
-        raise typer.Exit(1)
-
     teams_api_key: str | None = None
     if resolved_tier == "teams":
         teams_api_key = os.environ.get("DRIFTSHIELD_API_KEY") or os.environ.get(
@@ -278,6 +320,22 @@ def telemetry_submit_session(
                 "(or API_KEY) in the environment."
             )
             raise typer.Exit(1)
+
+    # Community opt-in is the production declaration: stamp the declared
+    # environment before redaction so it rides both the inline and the
+    # presigned lanes. An environment already declared in the session JSON
+    # is kept; --environment wins over everything.
+    if resolved_tier == "oss":
+        metadata = payload.get("metadata")
+        if not isinstance(metadata, dict):
+            # The envelope contract expects a metadata mapping; a malformed
+            # value cannot carry the declared environment.
+            metadata = {}
+            payload["metadata"] = metadata
+        if resolved_environment is not None:
+            metadata["environment"] = resolved_environment
+        else:
+            metadata.setdefault("environment", EnvironmentClass.PRODUCTION.value)
 
     # Redact once to measure the canonical size (uncapped) and decide the
     # lane. The size-capped SubmissionEnvelope model is only built on the
@@ -323,7 +381,7 @@ def telemetry_submit_session(
             assert teams_api_key is not None
             result = submit_teams_via_presigned_upload(
                 config=TeamsUploadConfig(
-                    intake_url=config.remote_intake_url, api_key=teams_api_key
+                    intake_url=intake_url, api_key=teams_api_key
                 ),
                 payload=redacted_payload,
                 workflow_reference=resolved_workflow_reference,
@@ -332,7 +390,7 @@ def telemetry_submit_session(
             )
         elif is_large:
             result = submit_oss_via_presigned_upload(
-                config=OssUploadConfig(intake_url=config.remote_intake_url),
+                config=OssUploadConfig(intake_url=intake_url),
                 payload=redacted_payload,
                 workflow_reference=resolved_workflow_reference,
                 file_name=path.name,
@@ -358,9 +416,7 @@ def telemetry_submit_session(
                     "Inspect the payload with --dry-run-redaction first."
                 )
                 raise typer.Exit(1) from exc
-            submission_config = OssRemoteSubmissionConfig(
-                intake_url=config.remote_intake_url
-            )
+            submission_config = OssRemoteSubmissionConfig(intake_url=intake_url)
             result = post_oss_submission(
                 config=submission_config, submission=submission
             )

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -34,7 +34,8 @@ _NON_QUALIFYING_INTEGRITY = {"corrupted_but_usable"}
 
 # Declared environment values trusted verbatim. Anything outside this set falls to
 # inference; absence falls to unknown. Never silently defaults to production.
-_DECLARED_ENVIRONMENTS = {
+# Public so the CLI validates submitter-declared values against the same closed set.
+DECLARED_ENVIRONMENTS = {
     EnvironmentClass.PRODUCTION.value,
     EnvironmentClass.STAGING.value,
     EnvironmentClass.TEST.value,
@@ -319,7 +320,7 @@ def _environment_classification(
     provenance: IngestProvenance | None,
 ) -> tuple[EnvironmentClass, EnvironmentSource]:
     declared = session.metadata.get("environment") if isinstance(session.metadata, dict) else None
-    if isinstance(declared, str) and declared in _DECLARED_ENVIRONMENTS:
+    if isinstance(declared, str) and declared in DECLARED_ENVIRONMENTS:
         return EnvironmentClass(declared), EnvironmentSource.SUBMITTER_DECLARED
 
     source_path = provenance.source_path if provenance else None

--- a/driftshield/src/driftshield/telemetry/__init__.py
+++ b/driftshield/src/driftshield/telemetry/__init__.py
@@ -1,10 +1,17 @@
 """Telemetry primitives."""
 
 from driftshield.telemetry.service import (
+    DEFAULT_COMMUNITY_INTAKE_URL,
     TelemetryConfig,
     TelemetryEvent,
     TelemetryService,
     validate_outcome_status,
 )
 
-__all__ = ["TelemetryConfig", "TelemetryEvent", "TelemetryService", "validate_outcome_status"]
+__all__ = [
+    "DEFAULT_COMMUNITY_INTAKE_URL",
+    "TelemetryConfig",
+    "TelemetryEvent",
+    "TelemetryService",
+    "validate_outcome_status",
+]

--- a/driftshield/src/driftshield/telemetry/__init__.py
+++ b/driftshield/src/driftshield/telemetry/__init__.py
@@ -5,6 +5,7 @@ from driftshield.telemetry.service import (
     TelemetryConfig,
     TelemetryEvent,
     TelemetryService,
+    effective_oss_intake_url,
     validate_outcome_status,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "TelemetryConfig",
     "TelemetryEvent",
     "TelemetryService",
+    "effective_oss_intake_url",
     "validate_outcome_status",
 ]

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -29,6 +29,10 @@ class TelemetryConfig:
     remote_intake_url: str | None = None
     remote_api_key: str | None = None
     remote_installation_id: str | None = None
+    # Explicit opt-out from remote submission. Distinguishes "never configured"
+    # (community default applies on the OSS lane) from "user ran remote-disable"
+    # (no remote target at all, baked default included).
+    remote_opt_out: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,6 +66,7 @@ class TelemetryService:
             remote_intake_url=_optional_string(data.get("remote_intake_url")),
             remote_api_key=_optional_string(data.get("remote_api_key")),
             remote_installation_id=_optional_string(data.get("remote_installation_id")),
+            remote_opt_out=bool(data.get("remote_opt_out", False)),
         )
 
     def enable(self) -> TelemetryConfig:
@@ -117,6 +122,7 @@ class TelemetryService:
             raise ValueError("intake_url must not be empty")
         config = self.load_config()
         config.remote_intake_url = intake_url_clean
+        config.remote_opt_out = False
         # Migrate legacy auth fields out of the on-disk config on first use.
         config.remote_api_key = None
         config.remote_installation_id = None
@@ -126,10 +132,17 @@ class TelemetryService:
         return config
 
     def remote_disable(self) -> TelemetryConfig:
+        """Clear remote configuration and opt out of remote submission.
+
+        The opt-out is persisted so the OSS lane's baked community default
+        does not apply either: after remote-disable, no submission target
+        exists until remote-enable runs again.
+        """
         config = self.load_config()
         config.remote_intake_url = None
         config.remote_api_key = None
         config.remote_installation_id = None
+        config.remote_opt_out = True
         if not config.event_stream_path:
             config.event_stream_path = str(self._default_stream_path)
         self._save_config(config)
@@ -202,6 +215,19 @@ class TelemetryService:
         stream_path.parent.mkdir(parents=True, exist_ok=True)
         with stream_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(asdict(event), sort_keys=True) + "\n")
+
+
+def effective_oss_intake_url(config: TelemetryConfig) -> str | None:
+    """Resolve the URL the OSS lane will use.
+
+    A configured override wins; otherwise the baked community default applies,
+    unless the user explicitly opted out via remote-disable (then None).
+    """
+    if config.remote_intake_url:
+        return config.remote_intake_url
+    if config.remote_opt_out:
+        return None
+    return DEFAULT_COMMUNITY_INTAKE_URL
 
 
 def _telemetry_home() -> Path:

--- a/driftshield/src/driftshield/telemetry/service.py
+++ b/driftshield/src/driftshield/telemetry/service.py
@@ -13,6 +13,11 @@ from typing import Any
 
 _VALID_OUTCOME_STATUSES = {"matched", "unclassified", "not_classifiable"}
 
+# Canonical community intake endpoint. The OSS lane submits here when no
+# remote_intake_url has been configured, so community opt-in is zero-config.
+# An explicit `telemetry remote-enable --intake-url ...` always overrides.
+DEFAULT_COMMUNITY_INTAKE_URL = "https://api.driftshield.ai/v1/intake"
+
 
 @dataclass(slots=True)
 class TelemetryConfig:

--- a/driftshield/tests/cli/test_show_result.py
+++ b/driftshield/tests/cli/test_show_result.py
@@ -183,13 +183,68 @@ def test_show_result_overrides_intake_url(tmp_path, monkeypatch):
     assert captured["url"] == "https://override.example.test/v1/oss/submissions/sub_abc"
 
 
-def test_show_result_fails_when_no_url_configured_or_provided(tmp_path, monkeypatch):
+def test_show_result_zero_config_uses_community_default(tmp_path, monkeypatch):
+    """With nothing configured, show-result derives from the baked community URL."""
+    from driftshield.telemetry import DEFAULT_COMMUNITY_INTAKE_URL
+
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        captured["url"] = req.full_url
+        return _FakeHttpResponse(
+            json.dumps({
+                "submission_id": "sub_abc",
+                "processing_status": "processed",
+                "signature_label": None,
+                "signature_family": None,
+                "confidence_band": None,
+            }).encode("utf-8")
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(app, ["show-result", "sub_abc"])
+
+    assert result.exit_code == 0
+    expected_base = DEFAULT_COMMUNITY_INTAKE_URL.removesuffix("/v1/intake")
+    assert captured["url"] == f"{expected_base}/v1/oss/submissions/sub_abc"
+
+
+def test_show_result_fails_after_remote_disable(tmp_path, monkeypatch):
+    """remote-disable opts out of the baked default; show-result has no target."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "remote-disable"])
 
     result = runner.invoke(app, ["show-result", "sub_abc"])
 
     assert result.exit_code == 1
-    assert "no intake url configured" in result.stdout.lower()
+    assert "disabled" in result.stdout.lower()
+
+
+def test_show_result_intake_url_flag_works_after_remote_disable(tmp_path, monkeypatch):
+    """An explicit --intake-url is per-invocation intent and wins over the opt-out."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "remote-disable"])
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        captured["url"] = req.full_url
+        return _FakeHttpResponse(
+            json.dumps({"submission_id": "sub_abc", "processing_status": "processed"}).encode("utf-8")
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    result = runner.invoke(
+        app,
+        ["show-result", "sub_abc", "--intake-url", "https://override.example.test/v1/intake"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["url"] == "https://override.example.test/v1/oss/submissions/sub_abc"
 
 
 def test_show_result_404_renders_not_found(tmp_path, monkeypatch):
@@ -238,3 +293,58 @@ def test_show_result_non_json_response(tmp_path, monkeypatch):
 
     assert result.exit_code == 1
     assert "non-json" in result.stdout.lower()
+
+
+def test_zero_config_submit_then_show_result_roundtrip(tmp_path, monkeypatch):
+    """The full community happy path needs no remote-enable: submit-session
+    resolves to the baked default and show-result fetches from the same base."""
+    from driftshield.intake_contract import IntakeSubmissionResponse
+    from driftshield.remote_submission import OssSubmissionResult
+    from driftshield.telemetry import DEFAULT_COMMUNITY_INTAKE_URL
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = tmp_path / "session.json"
+    session_path.write_text(json.dumps({"session_id": "sess-1"}), encoding="utf-8")
+
+    captured: dict[str, Any] = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["submit_url"] = config.intake_url
+        return OssSubmissionResult(
+            response=IntakeSubmissionResponse(
+                submission_id="sub_rt1", processing_status="received"
+            ),
+            server_contract_version="phase3g.v1",
+        )
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    submit = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+    assert submit.exit_code == 0
+    assert "sub_rt1" in submit.stdout
+    assert captured["submit_url"] == DEFAULT_COMMUNITY_INTAKE_URL
+
+    def fake_urlopen(req: Any) -> _FakeHttpResponse:
+        captured["result_url"] = req.full_url
+        return _FakeHttpResponse(
+            json.dumps({
+                "submission_id": "sub_rt1",
+                "processing_status": "processed",
+                "signature_label": "drift_signature_v1",
+                "signature_family": "tool_misuse",
+                "confidence_band": "high",
+            }).encode("utf-8")
+        )
+
+    monkeypatch.setattr("driftshield.cli.commands.show_result.request.urlopen", fake_urlopen)
+
+    shown = runner.invoke(app, ["show-result", "sub_rt1"])
+    assert shown.exit_code == 0
+    assert "sub_rt1" in shown.stdout
+    expected_base = DEFAULT_COMMUNITY_INTAKE_URL.removesuffix("/v1/intake")
+    assert captured["result_url"] == f"{expected_base}/v1/oss/submissions/sub_rt1"

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -1436,3 +1436,85 @@ def test_community_lane_payload_classifies_production_submitter_declared(
     env_class, env_source = _environment_classification(session, None)
     assert env_class is EnvironmentClass.PRODUCTION
     assert env_source is EnvironmentSource.SUBMITTER_DECLARED
+
+
+# ---------------------------------------------------------------------------
+# remote-disable is an explicit opt-out: the baked default must not apply
+# ---------------------------------------------------------------------------
+
+
+def test_remote_disable_blocks_community_default(tmp_path, monkeypatch):
+    """After remote-disable, the OSS lane has no target: the baked default
+    must not resurrect remote submission behind the user's back."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "remote-disable"])
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    submitted = {"called": False}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        submitted["called"] = True
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 1
+    assert "disabled" in result.stdout.lower()
+    assert submitted["called"] is False
+
+
+def test_remote_enable_after_disable_restores_submission(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, ["telemetry", "remote-disable"])
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["intake_url"] = config.intake_url
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["intake_url"] == _OSS_TEST_INTAKE_URL
+
+    config = TelemetryService().load_config()
+    assert config.remote_opt_out is False
+
+
+def test_status_reports_effective_oss_intake_url(tmp_path, monkeypatch):
+    """status must reflect what an OSS submit will actually do in all three
+    states: zero-config (baked default), opted out (null), configured."""
+    from driftshield.telemetry import DEFAULT_COMMUNITY_INTAKE_URL
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+
+    fresh = json.loads(runner.invoke(app, ["telemetry", "status", "--json"]).stdout)
+    assert fresh["remote_opt_out"] is False
+    assert fresh["effective_oss_intake_url"] == DEFAULT_COMMUNITY_INTAKE_URL
+
+    runner.invoke(app, ["telemetry", "remote-disable"])
+    disabled = json.loads(runner.invoke(app, ["telemetry", "status", "--json"]).stdout)
+    assert disabled["remote_opt_out"] is True
+    assert disabled["effective_oss_intake_url"] is None
+
+    runner.invoke(app, _remote_enable_argv())
+    enabled = json.loads(runner.invoke(app, ["telemetry", "status", "--json"]).stdout)
+    assert enabled["remote_opt_out"] is False
+    assert enabled["effective_oss_intake_url"] == _OSS_TEST_INTAKE_URL

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -486,12 +486,15 @@ def test_submit_session_no_deprecation_warning_when_server_on_phase3g_v1(
     assert "deprecation" not in result.stdout.lower()
 
 
-def test_submit_session_fails_when_remote_not_configured(tmp_path, monkeypatch):
+def test_submit_session_teams_fails_when_remote_not_configured(tmp_path, monkeypatch):
+    """The baked community default is OSS-only; teams still needs remote-enable."""
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "ds_teams_key")
     session_path = _write_session(tmp_path, {"session_id": "sess-1"})
 
     result = runner.invoke(
-        app, ["telemetry", "submit-session", "--path", str(session_path)]
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "teams"],
     )
 
     assert result.exit_code == 1
@@ -1055,3 +1058,381 @@ def test_submit_session_teams_tier_without_api_key_errors(tmp_path, monkeypatch)
     )
     assert result.exit_code == 1
     assert "DRIFTSHIELD_API_KEY" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Zero-config community lane: baked default intake URL
+# ---------------------------------------------------------------------------
+
+
+def test_submit_session_oss_defaults_to_community_intake_url(tmp_path, monkeypatch):
+    """With no remote-enable, the OSS lane submits to the baked community URL."""
+    from driftshield.telemetry import DEFAULT_COMMUNITY_INTAKE_URL
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["intake_url"] = config.intake_url
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert DEFAULT_COMMUNITY_INTAKE_URL == "https://api.driftshield.ai/v1/intake"
+    assert captured["intake_url"] == DEFAULT_COMMUNITY_INTAKE_URL
+
+
+def test_submit_session_oss_default_url_applies_to_presigned_lane(tmp_path, monkeypatch):
+    """A large zero-config OSS payload also resolves to the baked default."""
+    from driftshield.telemetry import DEFAULT_COMMUNITY_INTAKE_URL
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-1", "metadata": {"blob": "x" * 300_000}}
+    )
+
+    captured = {}
+
+    def fake_presigned(*, config, payload, workflow_reference, file_name, mode="file", provenance=None, opener=None):  # noqa: ARG001
+        captured["intake_url"] = config.intake_url
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.submit_oss_via_presigned_upload",
+        fake_presigned,
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert captured["intake_url"] == DEFAULT_COMMUNITY_INTAKE_URL
+
+
+def test_submit_session_remote_enable_overrides_default_url(tmp_path, monkeypatch):
+    """An explicitly configured intake URL wins over the baked default."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["intake_url"] = config.intake_url
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["intake_url"] == _OSS_TEST_INTAKE_URL
+
+
+# ---------------------------------------------------------------------------
+# Community opt-in declares production by default (client-side, declared)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_session_oss_defaults_environment_to_production_inline(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["metadata"] = submission.envelope.payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "production"
+
+
+def test_submit_session_oss_defaults_environment_to_production_presigned(
+    tmp_path, monkeypatch
+):
+    """The production stamp lands before redaction, so the large lane carries it too."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-1", "metadata": {"blob": "x" * 300_000}}
+    )
+
+    captured = {}
+
+    def fake_presigned(*, config, payload, workflow_reference, file_name, mode="file", provenance=None, opener=None):  # noqa: ARG001
+        captured["metadata"] = payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.submit_oss_via_presigned_upload",
+        fake_presigned,
+    )
+
+    result = runner.invoke(
+        app, ["telemetry", "submit-session", "--path", str(session_path)]
+    )
+
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "production"
+
+
+def test_submit_session_environment_flag_overrides_production_default(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["metadata"] = submission.envelope.payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--tier",
+            "oss",
+            "--environment",
+            "staging",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "staging"
+
+
+def test_submit_session_preserves_environment_declared_in_session_json(
+    tmp_path, monkeypatch
+):
+    """A declared environment in the session JSON counts as the submitter
+    saying otherwise; the production default must not clobber it."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-1", "metadata": {"environment": "test"}}
+    )
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["metadata"] = submission.envelope.payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "test"
+
+
+def test_submit_session_environment_flag_wins_over_session_json_value(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-1", "metadata": {"environment": "test"}}
+    )
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["metadata"] = submission.envelope.payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--tier",
+            "oss",
+            "--environment",
+            "demo",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "demo"
+
+
+def test_submit_session_rejects_invalid_environment(tmp_path, monkeypatch):
+    """An arbitrary string never rides the envelope: clean exit 1, no submission."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    submitted = {"called": False}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        submitted["called"] = True
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--tier",
+            "oss",
+            "--environment",
+            "prod",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--environment must be one of" in result.stdout
+    assert submitted["called"] is False
+
+
+def test_submit_session_environment_flag_rejected_on_teams_tier(tmp_path, monkeypatch):
+    """--environment is a community-lane flag; teams behaviour stays untouched."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "ds_teams_key")
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--tier",
+            "teams",
+            "--environment",
+            "production",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "oss" in result.stdout
+
+
+def test_submit_session_teams_tier_does_not_stamp_environment(tmp_path, monkeypatch):
+    """The production default is community-lane only; teams payloads stay as-is."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "ds_teams_key")
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-1", "metadata": {"foo": "bar"}}
+    )
+
+    captured = {}
+
+    def fake_teams(*, config, payload, workflow_reference, file_name, mode="file", provenance=None, opener=None):  # noqa: ARG001
+        captured["metadata"] = payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.submit_teams_via_presigned_upload",
+        fake_teams,
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "teams"],
+    )
+
+    assert result.exit_code == 0
+    assert "environment" not in captured["metadata"]
+
+
+def test_community_lane_payload_classifies_production_submitter_declared(
+    tmp_path, monkeypatch
+):
+    """End to end seam: the metadata the zero-config community lane submits
+    classifies server-side as PRODUCTION with source SUBMITTER_DECLARED,
+    never as a server-side silent default."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    from driftshield.core.canonical_analysis import _environment_classification
+    from driftshield.core.models import (
+        EnvironmentClass,
+        EnvironmentSource,
+        Session,
+        SessionStatus,
+    )
+
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["metadata"] = submission.envelope.payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+    assert result.exit_code == 0
+
+    session = Session(
+        id=uuid4(),
+        agent_id="claude",
+        started_at=datetime.now(timezone.utc),
+        status=SessionStatus.COMPLETED,
+        metadata=captured["metadata"],
+    )
+    env_class, env_source = _environment_classification(session, None)
+    assert env_class is EnvironmentClass.PRODUCTION
+    assert env_source is EnvironmentSource.SUBMITTER_DECLARED


### PR DESCRIPTION
## Summary

- What changed
  - **Baked default community intake URL (zero-config).** `DEFAULT_COMMUNITY_INTAKE_URL = "https://api.driftshield.ai/v1/intake"` is a named constant in `telemetry/service.py`, exported from `driftshield.telemetry`. When `--tier oss` runs with no configured `remote_intake_url`, `submit-session` now falls back to this default instead of erroring "run remote-enable first". An explicit `telemetry remote-enable --intake-url ...` still overrides (there is no intake-URL env var today, so the config file is the only override surface). The `teams` tier is untouched: with no configured URL it still errors.
  - **Community opt-in declares production by default (client-side, submitter-declared).** On the oss lane the CLI stamps `metadata.environment = "production"` before the redacted envelope is built, so the declaration rides both the inline and the presigned-large lanes. An environment already declared in the session JSON is kept; the new `--environment` flag (validated against the closed set `production/staging/test/demo`, invalid input is a clean exit 1 with nothing submitted) wins over everything. The flag is an escape hatch for the uncommon non-production contribution, not the documented path. On `--tier teams` the flag is rejected and no stamping happens.
  - **Server rule untouched.** `_environment_classification` still records a declared value as `SUBMITTER_DECLARED` and never silently defaults to production server-side; the existing guard test (`test_build_canonical_analysis_environment_defaults_unknown_never_production`) is unchanged and passing. The only server-file change is making the closed set public (`DECLARED_ENVIRONMENTS`) so the CLI validates against the same single source.
  - **AGENTS.md "Community signature opt-in" section** instructing any agent running DriftShield locally to opt finished runs in with the zero-config command `driftshield telemetry submit-session --path <session.json> --tier oss`.
  - The OSS lane stays **unauthenticated**: no `X-API-Key`, no `installation_id`, no key needed for `--tier oss`.
  - **Explicit opt-out (review round 1).** `remote-disable` persists `remote_opt_out`; the baked default applies only when not opted out, so `remote-disable` genuinely disables the OSS lane again. `status` reports `remote_opt_out` and `effective_oss_intake_url` (override / baked default / null after disable). `show-result` is zero-config through the same shared resolver (`effective_oss_intake_url()`), with explicit `--intake-url` still winning, so submit -> show-result needs no `remote-enable` end to end.
- Why it changed
  - Opting a run into the community pool should be effortless and consistent: the act of opting in is the production declaration. Zero config, no key, no flags in the happy path.

## Verification

- [x] Automated tests run
- [ ] Browser flow exercised if UI changed (no UI change)
- [x] CLI flow exercised if command behavior changed

Full backend suite (the CI gate), run from `driftshield/`:

```
$ PYTHONPATH=src python -m pytest tests -q
655 passed, 3 skipped, 1 warning in 399.37s (0:06:39)
```

Ruff on the changed files:

```
$ python -m ruff check src/driftshield/cli/commands/telemetry.py src/driftshield/telemetry/ src/driftshield/core/canonical_analysis.py tests/cli/test_telemetry.py
All checks passed!
```

Public-scope boundary:

```
$ ./scripts/check-public-scope.sh
[public-scope] Checking tracked files for public-OSS boundary leaks
[public-scope] OK
```

Real CLI exercised: `submit-session --help` shows the new flag and the production-default wording; `--environment prod` exits 1 with `--environment must be one of: demo, production, staging, test.` and submits nothing. `api.driftshield.ai` resolves (API Gateway alias); no live submission was made from this branch.

New tests cover: baked default URL on inline + presigned lanes, `remote-enable` override, teams still requiring `remote-enable`, production default on inline + presigned lanes, session-JSON-declared environment preserved, `--environment` override (and winning over the session value), invalid value rejected with nothing submitted, teams payloads not stamped, `--environment` rejected on teams, and an end-to-end seam test that the community-lane metadata classifies as `PRODUCTION`/`SUBMITTER_DECLARED` through `_environment_classification`.

## Links

Closes #

## Workflow

- [ ] Linked issue remains `In Progress` until this PR is merged (no linked issue)
- [ ] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- None known. If the canonical intake route ever moves, the constant is the single place to update.

