### PR TITLE
fix(cli): derive the inline OSS submit route from the canonical intake URL

### DIFF
--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -38,6 +38,37 @@ from driftshield.recursive_redactor import (
 
 SERVER_CONTRACT_VERSION_HEADER = "X-DriftShield-Contract-Version"
 
+# Known submit suffixes a configured (or baked) intake URL may carry. Routes
+# are derived from the base so one canonical intake URL serves every lane.
+_OSS_SUBMIT_SUFFIXES = ("/v1/intake", "/v1/oss/submissions")
+
+# The live route for the unauthenticated inline OSS submission. POSTing the
+# inline body to /v1/intake instead hits the authenticated intake route and
+# fails with 422 missing installation_id.
+OSS_INLINE_SUBMIT_PATH = "/v1/oss/submissions"
+
+
+def derive_intake_base_url(intake_url: str) -> str:
+    """Strip the known submit suffix from a configured intake URL.
+
+    The configured ``remote_intake_url`` ends with ``/v1/intake`` or
+    ``/v1/oss/submissions``; strip it so per-lane paths can be appended to
+    the same host without double-pathing.
+    """
+    trimmed = intake_url.rstrip("/")
+    for suffix in _OSS_SUBMIT_SUFFIXES:
+        if trimmed.endswith(suffix):
+            return trimmed[: -len(suffix)]
+    return trimmed
+
+
+def derive_oss_inline_submit_url(intake_url: str) -> str:
+    """Resolve the inline OSS submission endpoint from any intake URL shape.
+
+    Idempotent for URLs already ending in ``/v1/oss/submissions``.
+    """
+    return derive_intake_base_url(intake_url) + OSS_INLINE_SUBMIT_PATH
+
 
 _DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
 
@@ -240,12 +271,14 @@ def post_oss_submission(
 ) -> OssSubmissionResult:
     """Single unauthenticated POST to /v1/oss/submissions. No retry on failure.
 
-    No X-API-Key header. No Authorization header. The intake URL is taken
-    verbatim from TelemetryConfig.remote_intake_url.
+    No X-API-Key header. No Authorization header. The endpoint is derived
+    from ``config.intake_url`` (a ``/v1/intake`` or ``/v1/oss/submissions``
+    suffix is normalised to the inline OSS route), so the canonical
+    community intake URL works for the inline lane too.
     """
     body = submission.model_dump_json().encode("utf-8")
     req = request.Request(
-        config.intake_url,
+        derive_oss_inline_submit_url(config.intake_url),
         data=body,
         method="POST",
         headers={

--- a/driftshield/src/driftshield/remote_upload.py
+++ b/driftshield/src/driftshield/remote_upload.py
@@ -24,6 +24,7 @@ from driftshield.remote_submission import (
     SERVER_CONTRACT_VERSION_HEADER,
     OssSubmissionResult,
     RemoteSubmissionError,
+    derive_intake_base_url,
 )
 
 
@@ -33,25 +34,10 @@ from driftshield.remote_submission import (
 # envelope cap while sending anything substantial via S3.
 INLINE_PAYLOAD_THRESHOLD_BYTES = 200 * 1024
 
-_OSS_SUBMIT_SUFFIXES = ("/v1/intake", "/v1/oss/submissions")
 _PRESIGN_PATH = "/v1/oss/uploads/presign"
 _FINALISE_PATH = "/v1/oss/uploads/finalise"
 _TEAMS_PRESIGN_PATH = "/v1/teams/uploads/presign"
 _TEAMS_FINALISE_PATH = "/v1/teams/uploads/finalise"
-
-
-def derive_intake_base_url(intake_url: str) -> str:
-    """Strip the known submit suffix from a configured intake URL.
-
-    The configured ``remote_intake_url`` ends with ``/v1/intake`` or
-    ``/v1/oss/submissions``; strip it so the presign + finalise paths can
-    be appended to the same host without double-pathing.
-    """
-    trimmed = intake_url.rstrip("/")
-    for suffix in _OSS_SUBMIT_SUFFIXES:
-        if trimmed.endswith(suffix):
-            return trimmed[: -len(suffix)]
-    return trimmed
 
 
 def _post_json(

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -1518,3 +1518,50 @@ def test_status_reports_effective_oss_intake_url(tmp_path, monkeypatch):
     enabled = json.loads(runner.invoke(app, ["telemetry", "status", "--json"]).stdout)
     assert enabled["remote_opt_out"] is False
     assert enabled["effective_oss_intake_url"] == _OSS_TEST_INTAKE_URL
+
+
+def test_zero_config_inline_oss_posts_to_live_oss_route(tmp_path, monkeypatch):
+    """End to end through the real transport seam: zero-config community
+    opt-in must POST the inline envelope to the unauthenticated OSS route
+    derived from the baked canonical base, never to /v1/intake verbatim
+    (which 422s on unauthenticated inline submits)."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    class _FakeResp:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def read(self) -> bytes:
+            return self._body
+
+    def fake_urlopen(req):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        return _FakeResp(
+            json.dumps(
+                {"submission_id": "sub_abc", "processing_status": "received"}
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr(
+        "driftshield.remote_submission.request.urlopen", fake_urlopen
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["url"] == "https://api.driftshield.ai/v1/oss/submissions"
+    assert "X-api-key" not in captured["headers"]

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -512,3 +512,62 @@ def test_redact_call_site_passes_only_payload():
     assert "signature_summary" not in inner_payload
     assert inner_payload["session_id"] == "sess-1"
     assert inner_payload["metadata"] == {"foo": "bar"}
+
+
+def test_derive_oss_inline_submit_url_from_canonical_intake():
+    from driftshield.remote_submission import derive_oss_inline_submit_url
+
+    assert (
+        derive_oss_inline_submit_url("https://api.example/v1/intake")
+        == "https://api.example/v1/oss/submissions"
+    )
+
+
+def test_derive_oss_inline_submit_url_idempotent_on_oss_route():
+    from driftshield.remote_submission import derive_oss_inline_submit_url
+
+    assert (
+        derive_oss_inline_submit_url("https://api.example/v1/oss/submissions")
+        == "https://api.example/v1/oss/submissions"
+    )
+    assert (
+        derive_oss_inline_submit_url("https://api.example/v1/oss/submissions/")
+        == "https://api.example/v1/oss/submissions"
+    )
+
+
+def test_derive_oss_inline_submit_url_appends_to_bare_base():
+    from driftshield.remote_submission import derive_oss_inline_submit_url
+
+    assert (
+        derive_oss_inline_submit_url("https://api.example")
+        == "https://api.example/v1/oss/submissions"
+    )
+
+
+def test_post_oss_submission_routes_v1_intake_to_oss_submissions():
+    """The canonical /v1/intake base must NOT be hit by the inline OSS POST:
+    that route is the authenticated intake and 422s on unauthenticated inline
+    submits. The inline lane derives the OSS route from the same base."""
+    captured: dict[str, Any] = {}
+
+    def fake_opener(req: Any) -> _FakeHttpResponse:
+        captured["url"] = req.full_url
+        return _FakeHttpResponse(
+            json.dumps(
+                {"submission_id": "sub_abc", "processing_status": "received"}
+            ).encode("utf-8"),
+            headers={SERVER_CONTRACT_VERSION_HEADER: SUPPORTED_CONTRACT_VERSION},
+        )
+
+    submission = build_oss_submission_request(
+        source_session_id="sess-1",
+        payload={"session_id": "sess-1"},
+    )
+    post_oss_submission(
+        config=OssRemoteSubmissionConfig(intake_url="https://api.example/v1/intake"),
+        submission=submission,
+        opener=fake_opener,
+    )
+
+    assert captured["url"] == "https://api.example/v1/oss/submissions"


### PR DESCRIPTION
## Summary

- What changed
  - The inline OSS submission lane now derives its endpoint from the configured (or baked) intake URL instead of POSTing to it verbatim: `derive_oss_inline_submit_url()` strips a known `/v1/intake` or `/v1/oss/submissions` suffix and appends the inline OSS route. Idempotent for URLs already pointing at `/v1/oss/submissions`.
  - `derive_intake_base_url` moved from `remote_upload` to `remote_submission` (single source; `remote_upload` imports and re-exports it, so existing imports keep working). The presigned lanes already derived their per-route paths this way; the inline lane was the only verbatim POSTer.
- Why it changed
  - Caught on the first live community batch after #137: the baked canonical base `https://api.driftshield.ai/v1/intake` routes to the authenticated intake, so unauthenticated inline OSS submits failed with `422 missing installation_id`. The live inline OSS route is `/v1/oss/submissions`. With this change the zero-config community opt-in works against the live deployment: one canonical base URL, per-lane route derivation, consistent with `show-result` and the presign/finalise paths.

## Verification

- [x] Automated tests run

```
$ PYTHONPATH=src python -m pytest tests -q
660 passed, 3 skipped, 1 warning in 398.90s (0:06:38)
```

Ruff on changed files: `All checks passed!`. `./scripts/check-public-scope.sh`: OK.

- [x] CLI flow exercised if command behavior changed — new end-to-end test stubs the transport seam (`request.urlopen`) and asserts the zero-config `submit-session --tier oss` POSTs to `https://api.driftshield.ai/v1/oss/submissions` with no API key header. Plus deriver unit tests (canonical base, idempotency, bare base) and a transport test that a `/v1/intake` config never receives the inline POST.
- [ ] Browser flow exercised if UI changed (no UI change)

## Links

Follow-up to #137. Fixes the inline-lane 422 observed on the first live community batch.

## Workflow

- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- The presigned OSS lane returned `413 payload_too_large_for_envelope` on large payloads in the same batch run. That is server-side behaviour (the presign/finalise routes are derived correctly client-side) and is tracked outside this repo.
