### PR TITLE
feat(cli): OpenClaw trajectory shape, ruleset.v2 redaction, derived run provenance

### DIFF
--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -30,6 +30,7 @@ from driftshield.remote_submission import (
     UnknownTranscriptShapeError,
     build_oss_submission_request,
     build_redacted_payload,
+    derive_openclaw_provenance,
     detect_shape,
     post_oss_submission,
     redact_payload_with_manifest,
@@ -337,6 +338,15 @@ def telemetry_submit_session(
                 "(or API_KEY) in the environment."
             )
             raise typer.Exit(1)
+
+    # Real provenance for OpenClaw trajectories: the harness/agent and the
+    # driving provider/model come from the trajectory itself when the caller
+    # did not pass explicit values. Explicit flags always win.
+    derived_provenance = derive_openclaw_provenance(payload)
+    if agent_id is None:
+        agent_id = derived_provenance.get("agent_id")
+    if model_name is None:
+        model_name = derived_provenance.get("model_name")
 
     # Community opt-in is the production declaration: stamp the declared
     # environment before redaction so it rides both the inline and the

--- a/driftshield/src/driftshield/recursive_redactor.py
+++ b/driftshield/src/driftshield/recursive_redactor.py
@@ -37,7 +37,7 @@ from driftshield.intake_contract import REQUIRED_REDACTION_FIELDS
 
 
 REDACTOR_VERSION = "recursive-redactor.v2.0.0"
-REDACTION_RULESET_VERSION = "ruleset.v1"
+REDACTION_RULESET_VERSION = "ruleset.v2"
 
 _TOOL_IO_KEYS: frozenset[str] = frozenset(
     {
@@ -101,8 +101,37 @@ _FAILURE_BODY_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# OpenClaw trajectory content keys (ruleset.v2).
+#
+# OpenClaw runtime trajectories carry the conversation and tool surface
+# under their own key names, which the v1 ruleset did not cover: the
+# generic rules redacted path-shaped strings and ``_TOOL_IO_KEYS`` values
+# inside them, but the free-text prompt/response bodies survived. None of
+# these keys feed the deterministic matcher, so dropping them costs no
+# matcher signal:
+#  * ``prompt`` / ``systemPrompt`` / ``finalPromptText``  submitted prompt
+#    text and the compiled system prompt (tool inventories, agent config)
+#  * ``assistantTexts``       model response bodies
+#  * ``messagesSnapshot``     full message-history snapshot
+#  * ``messagingToolSentTexts``  outbound messages sent via messaging tools
+#  * ``toolMetas``            per-tool-call free-text meta (command lines)
+_OPENCLAW_CONTENT_KEYS: frozenset[str] = frozenset(
+    {
+        "prompt",
+        "systemPrompt",
+        "finalPromptText",
+        "assistantTexts",
+        "messagesSnapshot",
+        "messagingToolSentTexts",
+        "toolMetas",
+    }
+)
+
 _DROPPED_KEYS: frozenset[str] = (
-    REQUIRED_REDACTION_FIELDS | _PROMPT_RESPONSE_KEYS | _FAILURE_BODY_KEYS
+    REQUIRED_REDACTION_FIELDS
+    | _PROMPT_RESPONSE_KEYS
+    | _FAILURE_BODY_KEYS
+    | _OPENCLAW_CONTENT_KEYS
 )
 
 

--- a/driftshield/src/driftshield/remote_submission.py
+++ b/driftshield/src/driftshield/remote_submission.py
@@ -73,8 +73,12 @@ def derive_oss_inline_submit_url(intake_url: str) -> str:
 _DEFAULT_SOURCE_SYSTEM = "driftshield-oss"
 
 
+# Top-level key hints for the shapes recognisable from the payload's key-set
+# alone. The two events-carrying shapes (openclaw_trajectory and claude_code)
+# are NOT in this table: both arrive as a ``payload["events"]`` list, so they
+# are told apart by probing the event records themselves in
+# :func:`detect_shape`.
 _KNOWN_SHAPE_HINTS: dict[str, frozenset[str]] = {
-    "claude_code": frozenset({"events"}),
     "claude_desktop": frozenset({"conversation", "messages"}),
     "codex": frozenset({"session", "turns"}),
     "openai_chat": frozenset({"choices", "model"}),
@@ -82,6 +86,36 @@ _KNOWN_SHAPE_HINTS: dict[str, frozenset[str]] = {
     "crewai": frozenset({"crew", "tasks"}),
     "generic_session": frozenset({"session_id"}),
 }
+
+# OpenClaw runtime trajectory events carry this envelope on every record
+# (run/trace correlation + schema version), which native Claude Code JSONL
+# lines never do. Probed before the claude_code fallback so OpenClaw
+# trajectories stop mislabelling as claude_code.
+_OPENCLAW_EVENT_KEYS: frozenset[str] = frozenset(
+    {"runId", "traceId", "schemaVersion", "seq", "source"}
+)
+
+
+def _looks_like_openclaw_trajectory(events: Any) -> bool:
+    if not isinstance(events, list) or len(events) == 0:
+        return False
+    probed = [event for event in events[:8] if isinstance(event, dict)]
+    if len(probed) == 0:
+        return False
+    return all(_OPENCLAW_EVENT_KEYS.issubset(event.keys()) for event in probed)
+
+
+def _looks_like_claude_code_events(events: Any) -> bool:
+    # Native Claude Code JSONL lines all carry a string ``type``
+    # discriminator (user / assistant / summary / system). Requiring it
+    # stops arbitrary line-delimited JSON from waving through the
+    # unknown-shape redaction guard as claude_code.
+    if not isinstance(events, list) or len(events) == 0:
+        return False
+    return any(
+        isinstance(event, dict) and isinstance(event.get("type"), str)
+        for event in events
+    )
 
 
 class UnknownTranscriptShapeError(ValueError):
@@ -110,14 +144,67 @@ def detect_shape(payload: dict[str, Any]) -> str | None:
     Detection is best-effort and heuristic. It exists so the CLI can refuse
     to submit payloads the recursive redactor was not designed against,
     rather than silently under-redacting them.
+
+    Events-carrying payloads are content-probed: OpenClaw runtime
+    trajectories detect as ``openclaw_trajectory``, native Claude Code
+    lines as ``claude_code``. An events list matching neither probe is not
+    claude_code; it falls to the key-hint table (and then to unknown).
     """
     if not isinstance(payload, dict):
         return None
+    events = payload.get("events")
+    if isinstance(events, list) and len(events) > 0:
+        if _looks_like_openclaw_trajectory(events):
+            return "openclaw_trajectory"
+        if _looks_like_claude_code_events(events):
+            return "claude_code"
     keys = set(payload.keys())
     for shape, required in _KNOWN_SHAPE_HINTS.items():
         if required.issubset(keys):
             return shape
     return None
+
+
+def derive_openclaw_provenance(payload: dict[str, Any]) -> dict[str, str]:
+    """Best-effort real provenance from an OpenClaw trajectory payload.
+
+    OpenClaw trajectory events carry the driving provider/model
+    (``provider`` / ``modelId``) and the agent name
+    (``data.agentId``) on the runtime records. Returns ``agent_id`` /
+    ``model_name`` values for the envelope, or an empty dict when the
+    payload is not an OpenClaw trajectory. Callers apply explicit flags
+    first; this only fills gaps.
+    """
+    events = payload.get("events")
+    if not _looks_like_openclaw_trajectory(events):
+        return {}
+    agent_suffix: str | None = None
+    provider: str | None = None
+    model_id: str | None = None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if provider is None and isinstance(event.get("provider"), str):
+            provider = event["provider"]
+        if model_id is None and isinstance(event.get("modelId"), str):
+            model_id = event["modelId"]
+        data = event.get("data")
+        if (
+            agent_suffix is None
+            and isinstance(data, dict)
+            and isinstance(data.get("agentId"), str)
+        ):
+            agent_suffix = data["agentId"]
+        if provider is not None and model_id is not None and agent_suffix is not None:
+            break
+    provenance: dict[str, str] = {
+        "agent_id": "openclaw" if agent_suffix is None else f"openclaw:{agent_suffix}",
+    }
+    if model_id is not None:
+        provenance["model_name"] = (
+            model_id if provider is None else f"{provider}/{model_id}"
+        )
+    return provenance
 
 
 def redact_payload_with_manifest(payload: dict[str, Any]) -> RedactionResult:
@@ -173,8 +260,9 @@ def build_oss_submission_request(
     """Build an unauthenticated OSS submission request.
 
     ``force_unknown_shape`` defaults to False. The recursive redactor was
-    designed against the six known transcript shapes listed in
-    :data:`_KNOWN_SHAPE_HINTS`; an unrecognised top-level shape raises
+    designed against the known transcript shapes (the key-hint shapes in
+    :data:`_KNOWN_SHAPE_HINTS` plus the two events-probed shapes,
+    openclaw_trajectory and claude_code); an unrecognised shape raises
     :class:`UnknownTranscriptShapeError` unless the caller passes
     ``force_unknown_shape=True``.
 
@@ -318,6 +406,9 @@ __all__ = [
     "UnknownTranscriptShapeError",
     "build_oss_submission_request",
     "build_redacted_payload",
+    "derive_intake_base_url",
+    "derive_openclaw_provenance",
+    "derive_oss_inline_submit_url",
     "detect_shape",
     "post_oss_submission",
     "redact_payload",

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -1565,3 +1565,96 @@ def test_zero_config_inline_oss_posts_to_live_oss_route(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert captured["url"] == "https://api.driftshield.ai/v1/oss/submissions"
     assert "X-api-key" not in captured["headers"]
+
+
+def test_submit_session_openclaw_trajectory_stamps_real_provenance(
+    tmp_path, monkeypatch
+):
+    """An OpenClaw trajectory submitted with no provenance flags carries the
+    harness/agent and driving provider/model derived from the trajectory."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    event = {
+        "type": "session.started",
+        "runId": "run-1",
+        "traceId": "trace-1",
+        "schemaVersion": 1,
+        "seq": 1,
+        "source": "runtime",
+        "provider": "openai-codex",
+        "modelId": "gpt-5.4",
+        "data": {"agentId": "engineering"},
+    }
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-oc", "events": [event]}
+    )
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["agent_id"] = submission.envelope.agent_id
+        captured["model_name"] = submission.envelope.model_name
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "oss"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["agent_id"] == "openclaw:engineering"
+    assert captured["model_name"] == "openai-codex/gpt-5.4"
+
+
+def test_submit_session_explicit_provenance_flags_win_over_derived(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    event = {
+        "type": "session.started",
+        "runId": "run-1",
+        "traceId": "trace-1",
+        "schemaVersion": 1,
+        "seq": 1,
+        "source": "runtime",
+        "provider": "openai-codex",
+        "modelId": "gpt-5.4",
+        "data": {"agentId": "engineering"},
+    }
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-oc", "events": [event]}
+    )
+
+    captured = {}
+
+    def fake_post(*, config, submission, opener=None):  # noqa: ARG001
+        captured["agent_id"] = submission.envelope.agent_id
+        captured["model_name"] = submission.envelope.model_name
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "telemetry",
+            "submit-session",
+            "--path",
+            str(session_path),
+            "--tier",
+            "oss",
+            "--agent-id",
+            "my-agent",
+            "--model-name",
+            "my-model",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["agent_id"] == "my-agent"
+    assert captured["model_name"] == "my-model"

--- a/driftshield/tests/test_recursive_redactor.py
+++ b/driftshield/tests/test_recursive_redactor.py
@@ -48,7 +48,7 @@ def _load(name: str) -> dict[str, object]:
 
 def test_module_pins_redactor_and_ruleset_versions():
     assert REDACTOR_VERSION.startswith("recursive-redactor.v2")
-    assert REDACTION_RULESET_VERSION == "ruleset.v1"
+    assert REDACTION_RULESET_VERSION == "ruleset.v2"
 
 
 def test_aws_access_key_redacted_anywhere():

--- a/driftshield/tests/test_remote_submission.py
+++ b/driftshield/tests/test_remote_submission.py
@@ -23,6 +23,7 @@ from driftshield.remote_submission import (
     build_oss_submission_request,
     post_oss_submission,
     redact_payload,
+    redact_payload_with_manifest,
 )
 
 
@@ -571,3 +572,134 @@ def test_post_oss_submission_routes_v1_intake_to_oss_submissions():
     )
 
     assert captured["url"] == "https://api.example/v1/oss/submissions"
+
+
+def _openclaw_event(event_type: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "type": event_type,
+        "runId": "run-1",
+        "traceId": "trace-1",
+        "schemaVersion": 1,
+        "seq": 1,
+        "source": "runtime",
+        "sessionId": "8ad36b0f-9181-4961-9263-770f657db9f5",
+        "provider": "openai-codex",
+        "modelId": "gpt-5.4",
+        "modelApi": "openai-codex-responses",
+        "data": data or {},
+    }
+
+
+def _openclaw_payload() -> dict[str, Any]:
+    return {
+        "session_id": "8ad36b0f-9181-4961-9263-770f657db9f5",
+        "events": [
+            _openclaw_event("session.started", {"agentId": "engineering", "trigger": "cron"}),
+            _openclaw_event("prompt.submitted", {"prompt": "run the heartbeat"}),
+            _openclaw_event("session.ended", {"status": "success"}),
+        ],
+    }
+
+
+def test_detect_shape_openclaw_trajectory():
+    from driftshield.remote_submission import detect_shape
+
+    assert detect_shape(_openclaw_payload()) == "openclaw_trajectory"
+
+
+def test_detect_shape_claude_code_lines_still_detect():
+    from driftshield.remote_submission import detect_shape
+
+    payload = {
+        "session_id": "sess-1",
+        "events": [
+            {"type": "assistant", "sessionId": "sess-1", "message": {"content": []}},
+            {"type": "user", "sessionId": "sess-1", "message": {"content": []}},
+        ],
+    }
+    assert detect_shape(payload) == "claude_code"
+
+
+def test_detect_shape_unrecognisable_events_are_not_claude_code():
+    """Arbitrary line-delimited JSON without the type discriminator must not
+    wave through the unknown-shape redaction guard as claude_code."""
+    from driftshield.remote_submission import detect_shape
+
+    payload = {"events": [{"foo": 1}, {"bar": 2}]}
+    assert detect_shape(payload) is None
+
+
+def test_openclaw_payload_submits_without_force_unknown_shape():
+    submission = build_oss_submission_request(
+        source_session_id="sess-oc",
+        payload=_openclaw_payload(),
+    )
+    assert submission.envelope.payload["events"]
+
+
+def test_derive_openclaw_provenance_extracts_agent_and_model():
+    from driftshield.remote_submission import derive_openclaw_provenance
+
+    provenance = derive_openclaw_provenance(_openclaw_payload())
+    assert provenance == {
+        "agent_id": "openclaw:engineering",
+        "model_name": "openai-codex/gpt-5.4",
+    }
+
+
+def test_derive_openclaw_provenance_empty_for_other_shapes():
+    from driftshield.remote_submission import derive_openclaw_provenance
+
+    assert derive_openclaw_provenance({"session_id": "sess-1"}) == {}
+    assert (
+        derive_openclaw_provenance(
+            {"events": [{"type": "assistant", "message": {}}]}
+        )
+        == {}
+    )
+
+
+def test_openclaw_content_keys_redacted():
+    """ruleset.v2: OpenClaw prompt/response/tool free text never rides the
+    envelope. The keys are dropped with recorded entries."""
+    payload = {
+        "session_id": "sess-oc",
+        "events": [
+            _openclaw_event(
+                "context.compiled",
+                {
+                    "prompt": "secret prompt text",
+                    "systemPrompt": "you are an agent with these tools",
+                    "imagesCount": 0,
+                },
+            ),
+            _openclaw_event(
+                "trace.artifacts",
+                {
+                    "assistantTexts": ["model reply"],
+                    "toolMetas": [{"toolName": "exec", "meta": "rm -rf notes"}],
+                    "messagingToolSentTexts": ["sent message"],
+                    "messagesSnapshot": [{"role": "user"}],
+                    "finalPromptText": "final prompt",
+                    "finalStatus": "success",
+                },
+            ),
+        ],
+    }
+    result = redact_payload_with_manifest(payload)
+    events = result.payload["events"]
+    assert "prompt" not in events[0]["data"]
+    assert "systemPrompt" not in events[0]["data"]
+    assert events[0]["data"]["imagesCount"] == 0
+    for key in (
+        "assistantTexts",
+        "toolMetas",
+        "messagingToolSentTexts",
+        "messagesSnapshot",
+        "finalPromptText",
+    ):
+        assert key not in events[1]["data"]
+    assert events[1]["data"]["finalStatus"] == "success"
+    dropped_paths = {e.path for e in result.entries if e.category == "dropped_key"}
+    assert "events[0].data.prompt" in dropped_paths
+    assert "events[1].data.assistantTexts" in dropped_paths


### PR DESCRIPTION
## Summary

- What changed
  - **OpenClaw trajectories are their own detected shape.** `detect_shape` now content-probes events-carrying payloads: records carrying the OpenClaw runtime envelope (`runId`/`traceId`/`schemaVersion`/`seq`/`source` on every event) detect as `openclaw_trajectory`; native Claude Code lines (string `type` discriminator) stay `claude_code`. An events list matching neither probe is no longer waved through as claude_code, so the unknown-shape redaction guard actually fires on arbitrary line-delimited JSON.
  - **ruleset.v2: OpenClaw content keys are redacted.** The v1 ruleset's generic rules caught path-shaped strings and `_TOOL_IO_KEYS` inside OpenClaw events, but the free-text bodies survived (verified on a live community submission: `prompt`, `systemPrompt`, `assistantTexts` reached the pool intact). These plus `finalPromptText`, `messagesSnapshot`, `messagingToolSentTexts` and `toolMetas` are now dropped keys with recorded manifest entries. None feed the deterministic matcher, so there is no matcher-signal cost. `REDACTION_RULESET_VERSION` bumped to `ruleset.v2`.
  - **Real provenance derived from the trajectory.** `derive_openclaw_provenance` reads the harness/agent (`data.agentId`) and the driving provider/model (`provider`/`modelId`) off the events; `submit-session` stamps them as envelope `agent_id` / `model_name` when the caller passed no explicit flags (explicit flags always win). Example: `agent_id=openclaw:engineering`, `model_name=openai-codex/gpt-5.4`.
- Why it changed
  - The first live community batch (50 OpenClaw trajectories) landed labelled `CLAUDE_CODE` with no provenance: the old claude_code hint was just "has an `events` key", so any JSONL matched it, bypassing the shape guard the redactor relies on and hiding what actually produced the runs.

## Verification

- [x] Automated tests run

```
$ PYTHONPATH=src python -m pytest tests -q
669 passed, 3 skipped, 1 warning in 404.50s (0:06:44)
```

Ruff on changed files: `All checks passed!`. `./scripts/check-public-scope.sh`: OK.

- [x] CLI flow exercised if command behavior changed — new CLI tests cover the zero-flag OpenClaw submit stamping derived provenance on the envelope and explicit flags winning over the derived values; shape/redaction/provenance unit tests use a fixture mirroring a real trajectory's event structure.
- [ ] Browser flow exercised if UI changed (no UI in this repo; the console-side surfacing ships separately)

## Links

Follow-up to #137/#138, caught on the first live community batch.

## Workflow

- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- A matcher parser for OpenClaw trajectories. Detection and redaction are fixed here; the deterministic matcher still extracts nothing from runtime lifecycle events, so OpenClaw submissions remain unmatched until a parser exists.
