### PR TITLE
feat(parsers): OpenClaw runtime trajectory parser with auto-detection

### DIFF
--- a/driftshield/src/driftshield/cli/parsers.py
+++ b/driftshield/src/driftshield/cli/parsers.py
@@ -1,5 +1,6 @@
 """Parser registry and auto-detection for CLI."""
 
+import json
 from pathlib import Path
 
 from driftshield.parsers.claude_code import ClaudeCodeParser
@@ -9,6 +10,7 @@ from driftshield.parsers.codex_desktop import CodexDesktopParser
 from driftshield.parsers.crewai import CrewAIParser
 from driftshield.parsers.langchain import LangChainParser
 from driftshield.parsers.openclaw import OpenClawParser
+from driftshield.parsers.openclaw_trajectory import OpenClawTrajectoryParser
 from driftshield.parsers.protocol import TranscriptParser
 
 
@@ -24,6 +26,7 @@ PARSERS: dict[str, type[TranscriptParser]] = {
     "crewai": CrewAIParser,
     "langchain": LangChainParser,
     "openclaw": OpenClawParser,
+    "openclaw_trajectory": OpenClawTrajectoryParser,
 }
 
 
@@ -36,8 +39,41 @@ def get_parser(name: str) -> TranscriptParser:
     return PARSERS[name]()
 
 
+# OpenClaw runtime trajectory records carry this envelope on every line.
+# Mirrors remote_submission's shape probe.
+_OPENCLAW_TRAJECTORY_KEYS = frozenset(
+    {"runId", "traceId", "schemaVersion", "seq", "source"}
+)
+
+
+def _sniff_openclaw_trajectory(path: Path) -> bool:
+    """Peek the first parseable line for the trajectory record envelope.
+
+    Tolerates unreadable files (detection then falls back to the suffix
+    rules), so non-existent paths keep their historical detection result.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    return False
+                return isinstance(entry, dict) and _OPENCLAW_TRAJECTORY_KEYS.issubset(
+                    entry.keys()
+                )
+    except OSError:
+        return False
+    return False
+
+
 def detect_parser(path: Path) -> str | None:
     path_str = str(path.resolve())
+    if path_str.endswith(".trajectory.jsonl"):
+        return "openclaw_trajectory"
     if ".openclaw/agents/" in path_str and "/sessions/" in path_str:
         return "openclaw"
     if ".claude/projects/" in path_str or ".claude\\projects\\" in path_str:
@@ -49,5 +85,9 @@ def detect_parser(path: Path) -> str | None:
     if ".codex-desktop/sessions/" in path_str or ".codex-desktop\\sessions\\" in path_str:
         return "codex_desktop"
     if path.suffix == ".jsonl":
+        # A trajectory file not named *.trajectory.jsonl is still a
+        # trajectory; content wins over the claude_code suffix default.
+        if _sniff_openclaw_trajectory(path):
+            return "openclaw_trajectory"
         return "claude_code"
     return None

--- a/driftshield/src/driftshield/cli/parsers.py
+++ b/driftshield/src/driftshield/cli/parsers.py
@@ -46,25 +46,34 @@ _OPENCLAW_TRAJECTORY_KEYS = frozenset(
 )
 
 
-def _sniff_openclaw_trajectory(path: Path) -> bool:
-    """Peek the first parseable line for the trajectory record envelope.
+# How many leading lines the sniffer inspects before giving up. Bounds the
+# read on large files while tolerating a banner/preamble or corrupt lines.
+_SNIFF_LINE_LIMIT = 25
 
-    Tolerates unreadable files (detection then falls back to the suffix
-    rules), so non-existent paths keep their historical detection result.
+
+def _sniff_openclaw_trajectory(path: Path) -> bool:
+    """Probe the leading lines for the trajectory record envelope.
+
+    Mirrors the parser's tolerance: undecodable lines are skipped, not
+    treated as a verdict. The verdict comes from the first line that parses
+    to a JSON object — trajectory envelope keys present or not. Unreadable
+    files return False so non-existent paths keep their historical
+    detection result.
     """
     try:
         with path.open("r", encoding="utf-8") as handle:
-            for raw_line in handle:
+            for line_number, raw_line in enumerate(handle):
+                if line_number >= _SNIFF_LINE_LIMIT:
+                    return False
                 line = raw_line.strip()
                 if not line:
                     continue
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
-                    return False
-                return isinstance(entry, dict) and _OPENCLAW_TRAJECTORY_KEYS.issubset(
-                    entry.keys()
-                )
+                    continue
+                if isinstance(entry, dict):
+                    return _OPENCLAW_TRAJECTORY_KEYS.issubset(entry.keys())
     except OSError:
         return False
     return False

--- a/driftshield/src/driftshield/parsers/openclaw_trajectory.py
+++ b/driftshield/src/driftshield/parsers/openclaw_trajectory.py
@@ -1,0 +1,390 @@
+"""Parser for OpenClaw runtime trajectory JSONL files.
+
+OpenClaw writes two distinct JSONL formats. The session transcript
+(``~/.openclaw/agents/<agent>/sessions/<id>.jsonl``) carries the full
+conversation and is handled by :class:`~driftshield.parsers.openclaw.OpenClawParser`.
+The runtime trajectory (``*.trajectory.jsonl``) is the telemetry the runtime
+emits per run: lifecycle records (``session.started`` → ``trace.metadata`` →
+``context.compiled`` → ``prompt.submitted`` → ``model.completed`` →
+``trace.artifacts`` → ``session.ended``), each wrapped in a run/trace
+correlation envelope (``runId`` / ``traceId`` / ``schemaVersion`` / ``seq`` /
+``source``).
+
+This parser maps the trajectory into canonical events so trajectory
+submissions stop being unparseable: the prompt, the model completion (with
+its abort/timeout failure signals), the per-tool-call records recovered from
+``trace.artifacts.toolMetas``, and the run outcome. Failure information is
+emitted through ``outputs.error`` / ``outputs.is_error`` so
+:func:`driftshield.core.normalization.normalize_events` derives the
+``failure_context`` the deterministic matcher keys on.
+
+Trajectory records the parser does not recognise are skipped, so newer
+runtime schema versions degrade to a thinner trace instead of failing.
+``context.compiled`` is skipped deliberately: its prompt/system-prompt/tool
+content duplicates ``prompt.submitted`` and the tool inventory while being
+the most sensitive record in the file.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from driftshield.core.models import CanonicalEvent, EventType
+from driftshield.core.normalization import normalize_events
+from driftshield.parsers.openclaw import OpenClawParser
+
+
+class OpenClawTrajectoryParser:
+    """Parse OpenClaw runtime trajectories into canonical events."""
+
+    # Same handoff/category semantics as the session-transcript parser, so
+    # the two OpenClaw formats classify tools identically.
+    HANDOFF_TOOLS = OpenClawParser.HANDOFF_TOOLS
+    TOOL_CATEGORY_MAP = OpenClawParser.TOOL_CATEGORY_MAP
+
+    @property
+    def source_type(self) -> str:
+        return "openclaw_trajectory"
+
+    def parse_file(self, file_path: str) -> list[CanonicalEvent]:
+        return normalize_events(
+            self.parse(Path(file_path).read_text()),
+            source_type=self.source_type,
+            source_path=file_path,
+        )
+
+    def parse(self, content: str) -> list[CanonicalEvent]:
+        records = self._load_records(content)
+        if not records:
+            return []
+
+        session_id = "unknown"
+        for record in records:
+            candidate = record.get("sessionId")
+            if isinstance(candidate, str) and candidate:
+                session_id = candidate
+                break
+
+        base_time = self._base_time(records)
+        events: list[CanonicalEvent] = []
+        previous_event_id: UUID | None = None
+
+        for index, record in enumerate(records):
+            record_type = record.get("type")
+            data = record.get("data")
+            data = data if isinstance(data, dict) else {}
+            timestamp = self._record_time(record, base_time, index)
+
+            new_events: list[CanonicalEvent] = []
+            if record_type == "session.started":
+                new_events.append(
+                    self._event(
+                        session_id=session_id,
+                        timestamp=timestamp,
+                        event_type=EventType.OUTPUT,
+                        agent_id="system",
+                        action="session_started",
+                        parent_id=previous_event_id,
+                        outputs=self._scalars(
+                            data, ("trigger", "agentId", "toolCount", "messageChannel")
+                        ),
+                        semantic_category="session",
+                    )
+                )
+            elif record_type == "trace.metadata":
+                model = data.get("model")
+                model = model if isinstance(model, dict) else {}
+                snapshot = self._scalars(
+                    model, ("provider", "name", "api", "thinkLevel")
+                )
+                for key in ("provider", "modelId", "modelApi"):
+                    value = record.get(key)
+                    if isinstance(value, (str, int, float, bool)):
+                        snapshot.setdefault(key, value)
+                new_events.append(
+                    self._event(
+                        session_id=session_id,
+                        timestamp=timestamp,
+                        event_type=EventType.BRANCH,
+                        agent_id="system",
+                        action="model_snapshot",
+                        parent_id=previous_event_id,
+                        outputs=snapshot,
+                        semantic_category="model",
+                    )
+                )
+            elif record_type == "prompt.submitted":
+                prompt = data.get("prompt")
+                if isinstance(prompt, str) and prompt.strip():
+                    new_events.append(
+                        self._event(
+                            session_id=session_id,
+                            timestamp=timestamp,
+                            event_type=EventType.OUTPUT,
+                            agent_id="user",
+                            action="user_message",
+                            parent_id=previous_event_id,
+                            outputs={"text": prompt.strip()},
+                            semantic_category="user_input",
+                        )
+                    )
+            elif record_type == "model.completed":
+                new_events.append(
+                    self._model_completed_event(
+                        session_id=session_id,
+                        timestamp=timestamp,
+                        parent_id=previous_event_id,
+                        data=data,
+                    )
+                )
+            elif record_type == "trace.artifacts":
+                new_events.extend(
+                    self._trace_artifact_events(
+                        session_id=session_id,
+                        timestamp=timestamp,
+                        parent_id=previous_event_id,
+                        data=data,
+                    )
+                )
+            elif record_type == "session.ended":
+                new_events.append(
+                    self._session_ended_event(
+                        session_id=session_id,
+                        timestamp=timestamp,
+                        parent_id=previous_event_id,
+                        data=data,
+                    )
+                )
+
+            for event in new_events:
+                events.append(event)
+                previous_event_id = event.id
+
+        return normalize_events(events, source_type=self.source_type)
+
+    def _model_completed_event(
+        self,
+        *,
+        session_id: str,
+        timestamp: datetime,
+        parent_id: UUID | None,
+        data: dict[str, Any],
+    ) -> CanonicalEvent:
+        outputs: dict[str, Any] = {}
+        assistant_texts = data.get("assistantTexts")
+        if isinstance(assistant_texts, list):
+            joined = "\n".join(
+                text.strip() for text in assistant_texts if isinstance(text, str) and text.strip()
+            )
+            if joined:
+                outputs["text"] = joined
+        error = self._failure_reason(data)
+        if error is not None:
+            outputs["error"] = error
+            outputs["is_error"] = True
+        usage = data.get("usage")
+        metadata_extra: dict[str, Any] = {}
+        if isinstance(usage, dict) and isinstance(usage.get("total"), (int, float)):
+            metadata_extra["token_total"] = usage["total"]
+        return self._event(
+            session_id=session_id,
+            timestamp=timestamp,
+            event_type=EventType.OUTPUT,
+            agent_id="assistant",
+            action="model_completed",
+            parent_id=parent_id,
+            outputs=outputs,
+            semantic_category="reply",
+            metadata_extra=metadata_extra,
+        )
+
+    def _trace_artifact_events(
+        self,
+        *,
+        session_id: str,
+        timestamp: datetime,
+        parent_id: UUID | None,
+        data: dict[str, Any],
+    ) -> list[CanonicalEvent]:
+        events: list[CanonicalEvent] = []
+        tool_metas = data.get("toolMetas")
+        if isinstance(tool_metas, list):
+            for offset, entry in enumerate(tool_metas):
+                if not isinstance(entry, dict):
+                    continue
+                tool_name = entry.get("toolName")
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                action_key = tool_name.lower()
+                event_type = (
+                    EventType.HANDOFF
+                    if action_key in self.HANDOFF_TOOLS
+                    else EventType.TOOL_CALL
+                )
+                inputs: dict[str, Any] = {}
+                meta = entry.get("meta")
+                if isinstance(meta, str) and meta.strip():
+                    inputs["meta"] = meta.strip()
+                event = self._event(
+                    session_id=session_id,
+                    timestamp=timestamp + timedelta(microseconds=offset),
+                    event_type=event_type,
+                    agent_id="assistant",
+                    action=tool_name,
+                    parent_id=parent_id,
+                    inputs=inputs,
+                    outputs={},
+                    semantic_category=self.TOOL_CATEGORY_MAP.get(action_key, "other"),
+                )
+                events.append(event)
+                parent_id = event.id
+
+        final_status = data.get("finalStatus")
+        if isinstance(final_status, str) and final_status and final_status != "success":
+            error = self._failure_reason(data) or f"run finished with status {final_status}"
+            events.append(
+                self._event(
+                    session_id=session_id,
+                    timestamp=timestamp + timedelta(milliseconds=1),
+                    event_type=EventType.OUTPUT,
+                    agent_id="system",
+                    action="run_outcome",
+                    parent_id=parent_id,
+                    outputs={"status": final_status, "error": error, "is_error": True},
+                    semantic_category="session",
+                )
+            )
+        return events
+
+    def _session_ended_event(
+        self,
+        *,
+        session_id: str,
+        timestamp: datetime,
+        parent_id: UUID | None,
+        data: dict[str, Any],
+    ) -> CanonicalEvent:
+        status = data.get("status")
+        outputs: dict[str, Any] = {}
+        if isinstance(status, str) and status:
+            outputs["status"] = status
+        error = self._failure_reason(data)
+        if error is None and isinstance(status, str) and status and status != "success":
+            error = f"session ended with status {status}"
+        if error is not None:
+            outputs["error"] = error
+            outputs["is_error"] = True
+        return self._event(
+            session_id=session_id,
+            timestamp=timestamp,
+            event_type=EventType.OUTPUT,
+            agent_id="system",
+            action="session_ended",
+            parent_id=parent_id,
+            outputs=outputs,
+            semantic_category="session",
+        )
+
+    @staticmethod
+    def _failure_reason(data: dict[str, Any]) -> str | None:
+        """Map the runtime's failure flags to one explicit reason string."""
+        prompt_error = data.get("promptErrorSource")
+        if isinstance(prompt_error, str) and prompt_error.strip():
+            return f"prompt error: {prompt_error.strip()}"
+        if data.get("aborted") is True or data.get("externalAbort") is True:
+            return "run aborted"
+        if data.get("timedOut") is True or data.get("timedOutDuringCompaction") is True:
+            return "run timed out"
+        if data.get("idleTimedOut") is True:
+            return "run idle timed out"
+        return None
+
+    @staticmethod
+    def _scalars(data: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+        return {
+            key: data[key]
+            for key in keys
+            if isinstance(data.get(key), (str, int, float, bool))
+        }
+
+    def _event(
+        self,
+        *,
+        session_id: str,
+        timestamp: datetime,
+        event_type: EventType,
+        agent_id: str,
+        action: str,
+        parent_id: UUID | None,
+        outputs: dict[str, Any],
+        semantic_category: str,
+        inputs: dict[str, Any] | None = None,
+        metadata_extra: dict[str, Any] | None = None,
+    ) -> CanonicalEvent:
+        metadata: dict[str, Any] = {
+            "semantic_action_category": semantic_category,
+            "raw_action": action,
+        }
+        if metadata_extra:
+            metadata.update(metadata_extra)
+        return CanonicalEvent(
+            id=uuid4(),
+            session_id=session_id,
+            timestamp=timestamp,
+            event_type=event_type,
+            agent_id=agent_id,
+            action=action,
+            parent_event_id=parent_id,
+            inputs=inputs or {},
+            outputs=outputs,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _load_records(content: str) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        for raw_line in content.strip().splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(entry, dict):
+                records.append(entry)
+        return records
+
+    def _base_time(self, records: list[dict[str, Any]]) -> datetime:
+        """Earliest ``data.capturedAt`` in the file, else now.
+
+        Trajectory records carry no per-record timestamp; ordering comes from
+        ``seq``. The base anchors the synthetic per-record timestamps.
+        """
+        captured: list[datetime] = []
+        for record in records:
+            data = record.get("data")
+            if not isinstance(data, dict):
+                continue
+            raw = data.get("capturedAt")
+            if not isinstance(raw, str):
+                continue
+            try:
+                captured.append(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+            except ValueError:
+                continue
+        if captured:
+            return min(captured)
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _record_time(
+        record: dict[str, Any], base_time: datetime, index: int
+    ) -> datetime:
+        seq = record.get("seq")
+        offset = seq if isinstance(seq, int) and seq >= 0 else index
+        return base_time + timedelta(milliseconds=offset)

--- a/driftshield/src/driftshield/parsers/openclaw_trajectory.py
+++ b/driftshield/src/driftshield/parsers/openclaw_trajectory.py
@@ -357,7 +357,20 @@ class OpenClawTrajectoryParser:
                 continue
             if isinstance(entry, dict):
                 records.append(entry)
-        return records
+        # The runtime stamps a monotonic ``seq`` on every record, but the
+        # file itself can be emitted or concatenated out of order. The event
+        # chain (parent links, ordering, synthetic timestamps) must follow
+        # ``seq``, not file order. A record without a usable seq keeps its
+        # file position as the key; the stable sort leaves all-unseq'd files
+        # in file order.
+        def _sort_key(pair: tuple[int, dict[str, Any]]) -> tuple[int, int]:
+            index, record = pair
+            seq = record.get("seq")
+            if isinstance(seq, int) and seq >= 0:
+                return (seq, index)
+            return (index, index)
+
+        return [record for _, record in sorted(enumerate(records), key=_sort_key)]
 
     def _base_time(self, records: list[dict[str, Any]]) -> datetime:
         """Earliest ``data.capturedAt`` in the file, else now.

--- a/driftshield/tests/cli/test_parsers.py
+++ b/driftshield/tests/cli/test_parsers.py
@@ -93,3 +93,86 @@ class TestDetectParser:
 
     def test_unknown_format_returns_none(self):
         assert detect_parser(Path("unknown.xyz")) is None
+
+
+class TestDetectOpenClawTrajectory:
+    _RECORD = (
+        '{"type":"session.started","runId":"run-1","traceId":"trace-1",'
+        '"schemaVersion":1,"seq":0,"source":"runtime",'
+        '"sessionId":"8ad36b0f-9181-4961-9263-770f657db9f5",'
+        '"data":{"agentId":"engineering"}}'
+    )
+
+    def test_detects_trajectory_suffix(self, tmp_path):
+        path = tmp_path / "8ad36b0f.trajectory.jsonl"
+        path.touch()
+
+        assert detect_parser(path) == "openclaw_trajectory"
+
+    def test_detects_trajectory_content_in_plain_jsonl(self, tmp_path):
+        path = tmp_path / "session.jsonl"
+        path.write_text(self._RECORD + "\n", encoding="utf-8")
+
+        assert detect_parser(path) == "openclaw_trajectory"
+
+    def test_plain_jsonl_without_trajectory_envelope_stays_claude_code(
+        self, tmp_path
+    ):
+        path = tmp_path / "session.jsonl"
+        path.write_text(
+            '{"type":"assistant","sessionId":"s","message":{}}\n', encoding="utf-8"
+        )
+
+        assert detect_parser(path) == "claude_code"
+
+    def test_missing_jsonl_file_keeps_claude_code_fallback(self):
+        assert detect_parser(Path("does-not-exist.jsonl")) == "claude_code"
+
+    def test_get_parser_resolves_openclaw_trajectory(self):
+        parser = get_parser("openclaw_trajectory")
+        assert parser.source_type == "openclaw_trajectory"
+
+
+class TestOpenClawTrajectoryAnalysisSeam:
+    def test_signature_summary_builds_from_trajectory_file(self, tmp_path):
+        """--include-analysis works end to end on a trajectory: the parser is
+        detected, events parse, and the matcher produces a summary object
+        (zero matches is a valid outcome for a clean run)."""
+        import json as _json
+
+        from driftshield.cli._signature_summary import (
+            build_signature_summary_from_session,
+        )
+
+        def record(record_type, seq, data):
+            return {
+                "type": record_type,
+                "runId": "run-1",
+                "traceId": "trace-1",
+                "schemaVersion": 1,
+                "seq": seq,
+                "source": "runtime",
+                "sessionId": "8ad36b0f-9181-4961-9263-770f657db9f5",
+                "data": data,
+            }
+
+        records = [
+            record("session.started", 0, {"agentId": "engineering", "trigger": "cron"}),
+            record("prompt.submitted", 1, {"prompt": "run the heartbeat"}),
+            record(
+                "model.completed",
+                2,
+                {"timedOut": True, "assistantTexts": []},
+            ),
+            record("session.ended", 3, {"status": "error"}),
+        ]
+        path = tmp_path / "run.trajectory.jsonl"
+        path.write_text(
+            "\n".join(_json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+
+        summary = build_signature_summary_from_session(path)
+
+        assert summary is not None
+        assert summary.schema_version
+        assert isinstance(summary.matches, list)

--- a/driftshield/tests/cli/test_parsers.py
+++ b/driftshield/tests/cli/test_parsers.py
@@ -176,3 +176,34 @@ class TestOpenClawTrajectoryAnalysisSeam:
         assert summary is not None
         assert summary.schema_version
         assert isinstance(summary.matches, list)
+
+    def test_sniff_tolerates_corrupt_leading_lines(self, tmp_path):
+        """A banner or corrupt first line must not force a false claude_code
+        classification (reviewer repro on PR 140)."""
+        path = tmp_path / "session.jsonl"
+        path.write_text(
+            "not json\n" + TestDetectOpenClawTrajectory._RECORD + "\n",
+            encoding="utf-8",
+        )
+
+        assert detect_parser(path) == "openclaw_trajectory"
+
+    def test_sniff_corrupt_line_then_claude_code_record_stays_claude_code(
+        self, tmp_path
+    ):
+        path = tmp_path / "session.jsonl"
+        path.write_text(
+            'not json\n{"type":"assistant","sessionId":"s","message":{}}\n',
+            encoding="utf-8",
+        )
+
+        assert detect_parser(path) == "claude_code"
+
+    def test_sniff_gives_up_after_line_limit(self, tmp_path):
+        path = tmp_path / "session.jsonl"
+        path.write_text(
+            "garbage\n" * 30 + TestDetectOpenClawTrajectory._RECORD + "\n",
+            encoding="utf-8",
+        )
+
+        assert detect_parser(path) == "claude_code"

--- a/driftshield/tests/parsers/test_openclaw_trajectory.py
+++ b/driftshield/tests/parsers/test_openclaw_trajectory.py
@@ -1,0 +1,207 @@
+"""Tests for the OpenClaw runtime trajectory parser."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from driftshield.core.models import EventType
+from driftshield.parsers.openclaw_trajectory import OpenClawTrajectoryParser
+
+
+SESSION_ID = "8ad36b0f-9181-4961-9263-770f657db9f5"
+
+
+def _record(record_type: str, seq: int, data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": record_type,
+        "runId": "run-1",
+        "traceId": "trace-1",
+        "schemaVersion": 1,
+        "seq": seq,
+        "source": "runtime",
+        "sessionId": SESSION_ID,
+        "sessionKey": "agent:engineering:cron:run-1",
+        "sourceSeq": seq,
+        "provider": "openai-codex",
+        "modelId": "gpt-5.4",
+        "modelApi": "openai-codex-responses",
+        "data": data,
+    }
+
+
+def _success_trajectory() -> str:
+    records = [
+        _record(
+            "session.started",
+            0,
+            {"agentId": "engineering", "trigger": "cron", "toolCount": 20},
+        ),
+        _record(
+            "trace.metadata",
+            1,
+            {
+                "capturedAt": "2026-05-01T03:00:00.000Z",
+                "model": {
+                    "api": "openai-codex-responses",
+                    "name": "gpt-5.4",
+                    "provider": "openai-codex",
+                    "thinkLevel": "low",
+                },
+            },
+        ),
+        _record(
+            "context.compiled",
+            2,
+            {"prompt": "secret compiled prompt", "systemPrompt": "tool inventory"},
+        ),
+        _record("prompt.submitted", 3, {"prompt": "Run the engineering heartbeat"}),
+        _record(
+            "model.completed",
+            4,
+            {
+                "aborted": False,
+                "timedOut": False,
+                "idleTimedOut": False,
+                "assistantTexts": ["Heartbeat complete."],
+                "usage": {"total": 399242},
+            },
+        ),
+        _record(
+            "trace.artifacts",
+            5,
+            {
+                "capturedAt": "2026-05-01T03:04:36.759Z",
+                "finalStatus": "success",
+                "toolMetas": [
+                    {"toolName": "exec", "meta": "date -u +%F"},
+                    {"toolName": "sessions_spawn", "meta": "spawn the reviewer"},
+                ],
+            },
+        ),
+        _record("session.ended", 6, {"status": "success", "aborted": False}),
+    ]
+    return "\n".join(json.dumps(record) for record in records)
+
+
+class TestOpenClawTrajectoryParser:
+    def test_parses_success_heartbeat_into_canonical_events(self):
+        events = OpenClawTrajectoryParser().parse(_success_trajectory())
+
+        actions = [event.action for event in events]
+        assert actions == [
+            "session_started",
+            "model_snapshot",
+            "user_message",
+            "model_completed",
+            "exec",
+            "sessions_spawn",
+            "session_ended",
+        ]
+        assert all(event.session_id == SESSION_ID for event in events)
+
+        user = events[2]
+        assert user.event_type == EventType.OUTPUT
+        assert user.outputs["text"] == "Run the engineering heartbeat"
+
+        completed = events[3]
+        assert completed.outputs["text"] == "Heartbeat complete."
+        assert "error" not in completed.outputs
+        assert completed.metadata["token_total"] == 399242
+
+        tool = events[4]
+        assert tool.event_type == EventType.TOOL_CALL
+        assert tool.inputs == {"meta": "date -u +%F"}
+        assert tool.metadata["semantic_action_category"] == "shell"
+
+        handoff = events[5]
+        assert handoff.event_type == EventType.HANDOFF
+
+        ended = events[6]
+        assert ended.outputs["status"] == "success"
+        assert "error" not in ended.outputs
+
+    def test_success_run_carries_no_failure_context(self):
+        events = OpenClawTrajectoryParser().parse(_success_trajectory())
+        assert all(event.failure_context is None for event in events)
+
+    def test_context_compiled_content_never_becomes_an_event(self):
+        events = OpenClawTrajectoryParser().parse(_success_trajectory())
+        serialised = json.dumps(
+            [
+                {"inputs": event.inputs, "outputs": event.outputs}
+                for event in events
+            ]
+        )
+        assert "secret compiled prompt" not in serialised
+        assert "tool inventory" not in serialised
+
+    def test_timed_out_model_call_yields_failure_context(self):
+        records = [
+            _record("prompt.submitted", 0, {"prompt": "do the thing"}),
+            _record(
+                "model.completed",
+                1,
+                {"aborted": False, "timedOut": True, "assistantTexts": []},
+            ),
+            _record("session.ended", 2, {"status": "error"}),
+        ]
+        content = "\n".join(json.dumps(record) for record in records)
+
+        events = OpenClawTrajectoryParser().parse(content)
+
+        completed = next(e for e in events if e.action == "model_completed")
+        assert completed.outputs["error"] == "run timed out"
+        assert completed.outputs["is_error"] is True
+        assert completed.failure_context is not None
+        assert completed.failure_context["status"] == "error"
+
+        ended = next(e for e in events if e.action == "session_ended")
+        assert ended.outputs["error"] == "session ended with status error"
+        assert ended.failure_context is not None
+
+    def test_failed_final_status_emits_run_outcome_event(self):
+        records = [
+            _record(
+                "trace.artifacts",
+                0,
+                {
+                    "finalStatus": "error",
+                    "promptErrorSource": "rate_limit",
+                    "toolMetas": [],
+                },
+            ),
+        ]
+        events = OpenClawTrajectoryParser().parse(
+            "\n".join(json.dumps(record) for record in records)
+        )
+
+        assert [event.action for event in events] == ["run_outcome"]
+        outcome = events[0]
+        assert outcome.outputs["status"] == "error"
+        assert outcome.outputs["error"] == "prompt error: rate_limit"
+        assert outcome.failure_context is not None
+
+    def test_unknown_record_types_and_bad_lines_are_skipped(self):
+        content = "\n".join(
+            [
+                "not json at all",
+                json.dumps(_record("trace.future-thing", 0, {"x": 1})),
+                json.dumps(_record("prompt.submitted", 1, {"prompt": "hello"})),
+            ]
+        )
+        events = OpenClawTrajectoryParser().parse(content)
+        assert [event.action for event in events] == ["user_message"]
+
+    def test_empty_content_parses_to_no_events(self):
+        assert OpenClawTrajectoryParser().parse("") == []
+
+    def test_ordering_is_stable_from_seq_with_synthetic_timestamps(self):
+        events = OpenClawTrajectoryParser().parse(_success_trajectory())
+        timestamps = [event.timestamp for event in events]
+        assert timestamps == sorted(timestamps)
+        # Base time anchors on the earliest capturedAt in the file.
+        assert timestamps[0].isoformat().startswith("2026-05-01T03:00:00")
+
+    def test_source_type(self):
+        assert OpenClawTrajectoryParser().source_type == "openclaw_trajectory"

--- a/driftshield/tests/parsers/test_openclaw_trajectory.py
+++ b/driftshield/tests/parsers/test_openclaw_trajectory.py
@@ -205,3 +205,44 @@ class TestOpenClawTrajectoryParser:
 
     def test_source_type(self):
         assert OpenClawTrajectoryParser().source_type == "openclaw_trajectory"
+
+    def test_out_of_order_records_are_sorted_by_seq(self):
+        """A trajectory emitted or concatenated out of file order must still
+        produce the seq-ordered event chain (reviewer repro on PR 140)."""
+        records = [
+            _record(
+                "model.completed", 4, {"assistantTexts": ["done"], "aborted": False}
+            ),
+            _record("prompt.submitted", 3, {"prompt": "do the thing"}),
+            _record("session.started", 0, {"agentId": "engineering"}),
+        ]
+        content = "\n".join(json.dumps(record) for record in records)
+
+        events = OpenClawTrajectoryParser().parse(content)
+
+        assert [event.action for event in events] == [
+            "session_started",
+            "user_message",
+            "model_completed",
+        ]
+        timestamps = [event.timestamp for event in events]
+        assert timestamps == sorted(timestamps)
+        # The parent chain follows seq order, not file order.
+        assert events[1].parent_event_id == events[0].id
+        assert events[2].parent_event_id == events[1].id
+
+    def test_records_without_seq_keep_file_order(self):
+        records = [
+            _record("session.started", 0, {"agentId": "engineering"}),
+            _record("prompt.submitted", 1, {"prompt": "first"}),
+        ]
+        for record in records:
+            del record["seq"]
+        content = "\n".join(json.dumps(record) for record in records)
+
+        events = OpenClawTrajectoryParser().parse(content)
+
+        assert [event.action for event in events] == [
+            "session_started",
+            "user_message",
+        ]


### PR DESCRIPTION
## Summary

- What changed
  - **New `OpenClawTrajectoryParser`** (`parsers/openclaw_trajectory.py`). OpenClaw writes two JSONL formats: the session transcript (already handled by `OpenClawParser`) and the runtime trajectory (`*.trajectory.jsonl`) — the format community submissions arrive in, which until now no parser could read. The new parser maps the runtime lifecycle records into canonical events: `session.started`/`session.ended` boundaries, the `trace.metadata` model snapshot, `prompt.submitted` as the user message, `model.completed` as the assistant reply (with abort/timeout/prompt-error failure signals emitted through `outputs.error`/`outputs.is_error`, so `normalize_events` derives the `failure_context` the deterministic matcher keys on), per-tool-call `TOOL_CALL`/`HANDOFF` events recovered from `trace.artifacts.toolMetas` (same handoff set and category map as the session parser), and a `run_outcome` failure event when `finalStatus` is not success. Unknown record types and unparseable lines are skipped so newer runtime schema versions degrade to a thinner trace. `context.compiled` is skipped deliberately: its prompt/system-prompt/tool content duplicates other records and is the most sensitive record in the file.
  - **Auto-detection**: `*.trajectory.jsonl` detects as `openclaw_trajectory` by suffix; a plain `.jsonl` is content-sniffed (first line carrying the runtime envelope keys) before the historical claude_code fallback, which is preserved for everything else including unreadable paths.
  - Trajectory records carry no per-record timestamp, so the parser anchors on the earliest `data.capturedAt` in the file and orders by `seq` deterministically.
- Why it changed
  - Community trajectory submissions parse to nothing today, so they can never produce signature matches (the live coverage lane shows 0/53 matched). This closes the parser gap client-side: `--include-analysis` and `analyze`/`ingest` now work on trajectory files.

## Verification

- [x] Automated tests run

```
$ PYTHONPATH=src python -m pytest tests -q
684 passed, 3 skipped, 1 warning in 314.79s (0:05:14)
```

Ruff on changed files: `All checks passed!`. `./scripts/check-public-scope.sh`: OK.

- [x] CLI flow exercised if command behavior changed — 15 new tests: parser unit coverage (success heartbeat, timeout failure with derived `failure_context`, failed `finalStatus` → `run_outcome`, sensitive `context.compiled` content never becoming an event, unknown-record tolerance, deterministic ordering), detection (suffix, content sniff, claude_code fallback preserved for plain and missing files), and the end-to-end seam (`build_signature_summary_from_session` on a trajectory file returns a summary). Additionally smoke-parsed a real persisted community trajectory: 39 canonical events including 34 real tool calls recovered from `toolMetas`, correct session id, zero false failure signals on the success run.
- [ ] Browser flow exercised if UI changed (no UI change)

## Workflow

- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- Server-side matching of OSS trajectory submissions needs the worker to pick this parser up (package rev bump) — backend work outside this repo. Note the redacted envelope no longer carries `toolMetas` free text (ruleset.v2), so server-side re-derivation sees a thinner trace than local analysis; the client-side `--include-analysis` summary is the full-fidelity path, consistent with the existing contract.
- The already-persisted 53 community rows stay unmatched until a re-match runs after the backend picks this up.
