### PR TITLE
fix(analysis): surface OpenClaw trajectory tool failures so genuine failures qualify and match

### DIFF
--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -397,6 +397,23 @@ def _refine_delta_records(
             }
         )
 
+    if "tool_execution_failure" in delta_types and DeltaType.INCOMPLETE_EXECUTION.value not in seen:
+        seen.add(DeltaType.INCOMPLETE_EXECUTION.value)
+        failed_tool_ref = next(
+            (str(event.id) for event in result.events if _is_failed_tool_event(event) and str(event.id) in known_ids),
+            None,
+        )
+        records.append(
+            {
+                "delta_type": DeltaType.INCOMPLETE_EXECUTION.value,
+                "delta_severity": DeltaSeverity.MATERIAL.value,
+                "expected_ref": _resolve_ref(failed_tool_ref, known_ids),
+                "actual_ref": None,
+                "delta_summary": "A tool reported a failure that the run did not recover before completing.",
+                "delta_confidence": delta_confidence,
+            }
+        )
+
     if not records:
         # A material delta_type was present but did not map to a per-event flag
         # (for example, an unresolved ambiguity). Emit one honest record.
@@ -1001,9 +1018,48 @@ def _delta_types(result: AnalysisResult) -> list[str]:
         delta_types.append("retrieval_failure_or_omission")
     if summary.get("policy_divergence"):
         delta_types.append("wrong_action")
+    if _unrecovered_tool_failure(result.events):
+        delta_types.append("tool_execution_failure")
     if result.candidate_break_point and not result.candidate_break_point.is_identified and result.flagged_events:
         delta_types.append("unresolved_ambiguity")
     return sorted(set(delta_types))
+
+
+def _is_failed_tool_event(event: CanonicalEvent) -> bool:
+    """A tool/handoff call the run itself reported as failed.
+
+    Keyed on the structural tool outcome (``tool_activity.status`` /
+    ``failure_context`` set by normalisation from the run's own error flag), not
+    on scrubbed free text. An aborted or timed-out model turn lands on an
+    OUTPUT/system event, not a tool event, so it is not counted here.
+    """
+    if event.event_type not in {EventType.TOOL_CALL, EventType.HANDOFF}:
+        return False
+    if (event.tool_activity or {}).get("status") == "error":
+        return True
+    return bool(event.failure_context and event.failure_context.get("status") == "error")
+
+
+def _unrecovered_tool_failure(events: list[CanonicalEvent]) -> bool:
+    """True when a failed tool call was not followed by a successful tool call.
+
+    A failed tool the run recovered from (a later successful tool invocation) is
+    not a material delta. A failed tool with no later successful tool is a
+    genuine, unrecovered execution failure: the structural shape the
+    deterministic matcher recognises as ``tool_misuse``. Surfacing it as a
+    material delta lets the run qualify, the same way a claude_code transcript
+    with the equivalent tool failure does.
+    """
+    last_failure_index: int | None = None
+    for index, event in enumerate(events):
+        if _is_failed_tool_event(event):
+            last_failure_index = index
+    if last_failure_index is None:
+        return False
+    for event in events[last_failure_index + 1 :]:
+        if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF} and not _is_failed_tool_event(event):
+            return False
+    return True
 
 
 def _severity_hint(result: AnalysisResult) -> str:

--- a/driftshield/src/driftshield/core/canonical_analysis.py
+++ b/driftshield/src/driftshield/core/canonical_analysis.py
@@ -1041,14 +1041,18 @@ def _is_failed_tool_event(event: CanonicalEvent) -> bool:
 
 
 def _unrecovered_tool_failure(events: list[CanonicalEvent]) -> bool:
-    """True when a failed tool call was not followed by a successful tool call.
+    """True when a failed tool call was not followed by a recovering tool call.
 
-    A failed tool the run recovered from (a later successful tool invocation) is
-    not a material delta. A failed tool with no later successful tool is a
-    genuine, unrecovered execution failure: the structural shape the
-    deterministic matcher recognises as ``tool_misuse``. Surfacing it as a
-    material delta lets the run qualify, the same way a claude_code transcript
-    with the equivalent tool failure does.
+    A failed tool the run recovered from is not a material delta, but recovery
+    needs structural evidence: a later tool that actually *completed*
+    (``tool_activity.status == "completed"``), not merely a later tool that was
+    present. A trajectory's successful toolMetas normalise to ``pending`` (the
+    runtime carries no per-tool result body), so a failed trajectory tool
+    followed by more pending tools is still an unrecovered failure, not a
+    recovery. A failed tool with no later completed tool is a genuine execution
+    failure: the structural shape the deterministic matcher recognises as
+    ``tool_misuse``. Surfacing it as a material delta lets the run qualify, the
+    same way a claude_code transcript with the equivalent tool failure does.
     """
     last_failure_index: int | None = None
     for index, event in enumerate(events):
@@ -1057,7 +1061,11 @@ def _unrecovered_tool_failure(events: list[CanonicalEvent]) -> bool:
     if last_failure_index is None:
         return False
     for event in events[last_failure_index + 1 :]:
-        if event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF} and not _is_failed_tool_event(event):
+        if (
+            event.event_type in {EventType.TOOL_CALL, EventType.HANDOFF}
+            and not _is_failed_tool_event(event)
+            and (event.tool_activity or {}).get("status") == "completed"
+        ):
             return False
     return True
 

--- a/driftshield/src/driftshield/parsers/openclaw_trajectory.py
+++ b/driftshield/src/driftshield/parsers/openclaw_trajectory.py
@@ -229,6 +229,13 @@ class OpenClawTrajectoryParser:
                 meta = entry.get("meta")
                 if isinstance(meta, str) and meta.strip():
                     inputs["meta"] = meta.strip()
+                # A toolMetas entry the runtime marked as failed must reach the
+                # canonical event as a failed tool, not a clean pending call.
+                # ``normalize_events`` derives ``failure_context`` from
+                # outputs.error / outputs.is_error, which in turn drives the
+                # deterministic matcher's failed-tool path. The signal is the
+                # runtime's own structural flag/string, not scrubbed free text.
+                outputs = self._tool_meta_outputs(entry)
                 event = self._event(
                     session_id=session_id,
                     timestamp=timestamp + timedelta(microseconds=offset),
@@ -237,7 +244,7 @@ class OpenClawTrajectoryParser:
                     action=tool_name,
                     parent_id=parent_id,
                     inputs=inputs,
-                    outputs={},
+                    outputs=outputs,
                     semantic_category=self.TOOL_CATEGORY_MAP.get(action_key, "other"),
                 )
                 events.append(event)
@@ -288,6 +295,50 @@ class OpenClawTrajectoryParser:
             outputs=outputs,
             semantic_category="session",
         )
+
+    @staticmethod
+    def _tool_meta_outputs(entry: dict[str, Any]) -> dict[str, Any]:
+        """Surface a per-tool failure from a toolMetas entry, if present.
+
+        The runtime marks a failed tool either with an ``isError`` boolean, an
+        explicit ``error`` / ``errorMessage`` string, or a non-success
+        ``status`` / non-zero ``exitCode``. Any of these is a structural failure
+        signal that survives redaction. A successful tool returns no outputs, so
+        it stays a clean call and carries no failure_context.
+        """
+        error = OpenClawTrajectoryParser._tool_meta_error_text(entry)
+        is_error = entry.get("isError") is True or error is not None
+        status = entry.get("status")
+        if (
+            not is_error
+            and isinstance(status, str)
+            and status.strip()
+            and status.strip().lower() not in {"success", "ok", "completed", "done"}
+        ):
+            is_error = True
+        exit_code = entry.get("exitCode")
+        if not is_error and isinstance(exit_code, int) and exit_code != 0:
+            is_error = True
+
+        if not is_error:
+            return {}
+
+        outputs: dict[str, Any] = {"is_error": True}
+        if error is None and isinstance(status, str) and status.strip():
+            error = f"tool reported status {status.strip()}"
+        if error is None and isinstance(exit_code, int) and exit_code != 0:
+            error = f"tool exited with code {exit_code}"
+        if error is not None:
+            outputs["error"] = error
+        return outputs
+
+    @staticmethod
+    def _tool_meta_error_text(entry: dict[str, Any]) -> str | None:
+        for key in ("error", "errorMessage"):
+            value = entry.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
 
     @staticmethod
     def _failure_reason(data: dict[str, Any]) -> str | None:

--- a/driftshield/tests/parsers/test_openclaw_trajectory.py
+++ b/driftshield/tests/parsers/test_openclaw_trajectory.py
@@ -160,6 +160,83 @@ class TestOpenClawTrajectoryParser:
         assert ended.outputs["error"] == "session ended with status error"
         assert ended.failure_context is not None
 
+    def test_tool_meta_is_error_surfaces_failure_context(self):
+        # A toolMetas entry the runtime marked as failed must reach the canonical
+        # event as a failed tool, not a clean pending call. Without this the
+        # deterministic matcher never sees a failed tool_result and a genuine
+        # trajectory tool failure stays unclassified (intel#228).
+        records = [
+            _record("prompt.submitted", 0, {"prompt": "run the build"}),
+            _record(
+                "trace.artifacts",
+                1,
+                {
+                    "finalStatus": "success",
+                    "toolMetas": [
+                        {"toolName": "exec", "meta": "make build", "isError": True},
+                    ],
+                },
+            ),
+        ]
+        events = OpenClawTrajectoryParser().parse(
+            "\n".join(json.dumps(record) for record in records)
+        )
+
+        tool = next(e for e in events if e.action == "exec")
+        assert tool.event_type == EventType.TOOL_CALL
+        assert tool.outputs.get("is_error") is True
+        assert tool.failure_context is not None
+        assert tool.failure_context["status"] == "error"
+
+    def test_tool_meta_error_string_surfaces_failure_context(self):
+        # The runtime may stamp the failure as an explicit error string rather
+        # than a boolean flag. Either structural signal must surface.
+        records = [
+            _record(
+                "trace.artifacts",
+                0,
+                {
+                    "finalStatus": "success",
+                    "toolMetas": [
+                        {"toolName": "exec", "meta": "run", "error": "exit code 1"},
+                    ],
+                },
+            ),
+        ]
+        events = OpenClawTrajectoryParser().parse(
+            "\n".join(json.dumps(record) for record in records)
+        )
+
+        tool = next(e for e in events if e.action == "exec")
+        assert tool.outputs.get("error") == "exit code 1"
+        assert tool.outputs.get("is_error") is True
+        assert tool.failure_context is not None
+
+    def test_successful_tool_meta_carries_no_failure_context(self):
+        # Tools the runtime did not mark as failed must stay clean: surfacing a
+        # failure only on the failed entry, never on a success.
+        records = [
+            _record(
+                "trace.artifacts",
+                0,
+                {
+                    "finalStatus": "success",
+                    "toolMetas": [
+                        {"toolName": "exec", "meta": "ls", "isError": False},
+                        {"toolName": "read", "meta": "open file"},
+                    ],
+                },
+            ),
+        ]
+        events = OpenClawTrajectoryParser().parse(
+            "\n".join(json.dumps(record) for record in records)
+        )
+
+        for action in ("exec", "read"):
+            tool = next(e for e in events if e.action == action)
+            assert tool.failure_context is None
+            assert "is_error" not in tool.outputs
+
     def test_failed_final_status_emits_run_outcome_event(self):
         records = [
             _record(

--- a/driftshield/tests/test_public_analyse.py
+++ b/driftshield/tests/test_public_analyse.py
@@ -135,6 +135,160 @@ def test_clean_run_has_no_matches() -> None:
     assert out["signature_summary"]["matches"] == []
 
 
+# --------------------------------------------------------------------------- #
+# Trajectory tool-failure extraction parity (intel#228)
+#
+# A genuine structural tool failure in an OpenClaw trajectory must reach the same
+# verdict a claude_code transcript with the equivalent failure reaches. The real
+# captured prod payload is a user abort, which stays honestly unclassified.
+# --------------------------------------------------------------------------- #
+
+
+def _trajectory(events: list[dict]) -> str:
+    return json.dumps(
+        {
+            "events": events,
+            "metadata": {"environment": "test"},
+            "session_id": "00000000-0000-0000-0000-0000000000aa",
+        }
+    )
+
+
+def _traj_record(seq: int, record_type: str, data: dict) -> dict:
+    return {
+        "ts": f"2026-05-03T05:25:{seq:02d}.000Z",
+        "seq": seq,
+        "type": record_type,
+        "data": data,
+        "runId": "00000000-0000-0000-0000-0000000000bb",
+        "source": "runtime",
+        "modelId": "gpt-5.4",
+        "traceId": "00000000-0000-0000-0000-0000000000aa",
+        "schemaVersion": 1,
+        "sessionId": "00000000-0000-0000-0000-0000000000aa",
+        "sessionKey": "k",
+        "sourceSeq": seq,
+        "modelApi": "openai-codex-responses",
+    }
+
+
+def _claude_code_lines(lines: list[dict]) -> str:
+    return "\n".join(json.dumps(line) for line in lines)
+
+
+# The same logical failure expressed in both formats: a tool the runtime ran
+# returned an error, then the run claimed completion without recovering.
+_TRAJECTORY_TOOL_FAILURE = _trajectory(
+    [
+        _traj_record(4, "prompt.submitted", {"prompt": "Run the build and finish."}),
+        _traj_record(5, "model.completed", {"assistantTexts": ["Running the build."]}),
+        _traj_record(
+            6,
+            "trace.artifacts",
+            {
+                "finalStatus": "success",
+                "toolMetas": [{"toolName": "exec", "meta": "make build", "isError": True}],
+            },
+        ),
+        _traj_record(7, "model.completed", {"assistantTexts": ["All done, build complete."]}),
+        _traj_record(8, "session.ended", {"status": "success"}),
+    ]
+)
+
+_CLAUDE_CODE_TOOL_FAILURE = _claude_code_lines(
+    [
+        {
+            "sessionId": "s1",
+            "type": "user",
+            "timestamp": "2026-03-01T11:00:00Z",
+            "message": {"role": "user", "content": [{"type": "text", "text": "Run the build and finish."}]},
+        },
+        {
+            "sessionId": "s1",
+            "type": "assistant",
+            "timestamp": "2026-03-01T11:00:01Z",
+            "message": {"model": "c", "content": [{"type": "tool_use", "id": "t1", "name": "bash", "input": {"command": "make build"}}]},
+        },
+        {
+            "sessionId": "s1",
+            "type": "user",
+            "timestamp": "2026-03-01T11:00:02Z",
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "is_error": True, "content": "error: build failed"}]},
+        },
+        {
+            "sessionId": "s1",
+            "type": "assistant",
+            "timestamp": "2026-03-01T11:00:03Z",
+            "message": {"model": "c", "content": [{"type": "text", "text": "All done, build complete."}]},
+        },
+    ]
+)
+
+
+def test_trajectory_tool_failure_qualifies_and_matches() -> None:
+    out = analyse(_TRAJECTORY_TOOL_FAILURE)
+    assert out["source_format"] == "openclaw_trajectory"
+    assert out["qualification"]["qualification_state"] == "qualified_failure"
+    matches = out["signature_summary"]["matches"]
+    assert len(matches) >= 1
+    mechanisms = {m["signature_id"] for m in matches}
+    assert "mechanism:tool_misuse" in mechanisms
+
+
+def test_trajectory_and_claude_code_tool_failure_reach_same_state() -> None:
+    # Verdict parity across parsers: the same logical failure must produce the
+    # same qualification_state, whichever format carried it.
+    traj_out = analyse(_TRAJECTORY_TOOL_FAILURE)
+    cc_out = analyse(_CLAUDE_CODE_TOOL_FAILURE, source="claude_code")
+    assert (
+        traj_out["qualification"]["qualification_state"]
+        == cc_out["qualification"]["qualification_state"]
+        == "qualified_failure"
+    )
+    assert {m["signature_id"] for m in cc_out["signature_summary"]["matches"]} >= {"mechanism:tool_misuse"}
+    assert {m["signature_id"] for m in traj_out["signature_summary"]["matches"]} >= {"mechanism:tool_misuse"}
+
+
+def test_trajectory_abort_stays_unclassified_with_no_match() -> None:
+    # An aborted run carries is_error on the model/session events but no failed
+    # tool. It must stay honestly unclassified, never a fabricated tool match.
+    aborted = _trajectory(
+        [
+            _traj_record(4, "prompt.submitted", {"prompt": "do x"}),
+            _traj_record(
+                5,
+                "model.completed",
+                {"aborted": True, "externalAbort": True, "error": "prompt error", "is_error": True},
+            ),
+            _traj_record(6, "trace.artifacts", {"finalStatus": "error", "toolMetas": []}),
+            _traj_record(7, "session.ended", {"status": "error", "error": "run aborted", "aborted": True}),
+        ]
+    )
+    out = analyse(aborted)
+    assert out["qualification"]["qualification_state"] == "unclassified"
+    assert out["signature_summary"]["matches"] == []
+
+
+def test_trajectory_thin_telemetry_stays_unclassified() -> None:
+    # A thin success trajectory (telemetry, no failed tool) carries no material
+    # delta and must not be forced into a match.
+    thin = _trajectory(
+        [
+            _traj_record(4, "prompt.submitted", {"prompt": "summarise the log"}),
+            _traj_record(5, "model.completed", {"assistantTexts": ["Summary done."]}),
+            _traj_record(
+                6,
+                "trace.artifacts",
+                {"finalStatus": "success", "toolMetas": [{"toolName": "read", "meta": "open log"}]},
+            ),
+            _traj_record(7, "session.ended", {"status": "success"}),
+        ]
+    )
+    out = analyse(thin)
+    assert out["qualification"]["qualification_state"] == "unclassified"
+    assert out["signature_summary"]["matches"] == []
+
+
 @pytest.mark.parametrize(
     "source", ["codex_desktop", "claude_desktop"]
 )

--- a/driftshield/tests/test_public_analyse.py
+++ b/driftshield/tests/test_public_analyse.py
@@ -289,6 +289,76 @@ def test_trajectory_thin_telemetry_stays_unclassified() -> None:
     assert out["signature_summary"]["matches"] == []
 
 
+def test_trajectory_failed_tool_followed_by_pending_tool_still_qualifies() -> None:
+    # Regression: a trajectory's successful toolMetas normalise to pending (no
+    # per-tool result body). A failed tool followed by another, merely-present
+    # pending tool must NOT be read as recovery; the genuine failure must still
+    # qualify. (Reviewer finding on the first cut of this fix.)
+    failed_then_pending = _trajectory(
+        [
+            _traj_record(4, "prompt.submitted", {"prompt": "Build, then read the log."}),
+            _traj_record(
+                6,
+                "trace.artifacts",
+                {
+                    "finalStatus": "success",
+                    "toolMetas": [
+                        {"toolName": "exec", "meta": "make build", "isError": True},
+                        {"toolName": "read", "meta": "open log"},
+                    ],
+                },
+            ),
+            _traj_record(7, "model.completed", {"assistantTexts": ["All done."]}),
+            _traj_record(8, "session.ended", {"status": "success"}),
+        ]
+    )
+    out = analyse(failed_then_pending)
+    assert out["qualification"]["qualification_state"] == "qualified_failure"
+    assert {m["signature_id"] for m in out["signature_summary"]["matches"]} >= {"mechanism:tool_misuse"}
+
+
+def test_claude_code_failed_tool_recovered_by_completed_tool_is_unclassified() -> None:
+    # The recovery exclusion is real, but recovery needs a structurally
+    # completed tool, not a merely-present one. A failed tool followed by a tool
+    # that actually returned a successful result is recovered, not a delta.
+    recovered = _claude_code_lines(
+        [
+            {
+                "sessionId": "s1",
+                "type": "assistant",
+                "timestamp": "2026-03-01T11:00:01Z",
+                "message": {"model": "c", "content": [{"type": "tool_use", "id": "t1", "name": "bash", "input": {"command": "make build"}}]},
+            },
+            {
+                "sessionId": "s1",
+                "type": "user",
+                "timestamp": "2026-03-01T11:00:02Z",
+                "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "is_error": True, "content": "error: build failed"}]},
+            },
+            {
+                "sessionId": "s1",
+                "type": "assistant",
+                "timestamp": "2026-03-01T11:00:03Z",
+                "message": {"model": "c", "content": [{"type": "tool_use", "id": "t2", "name": "bash", "input": {"command": "make build --fix"}}]},
+            },
+            {
+                "sessionId": "s1",
+                "type": "user",
+                "timestamp": "2026-03-01T11:00:04Z",
+                "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "build succeeded"}]},
+            },
+            {
+                "sessionId": "s1",
+                "type": "assistant",
+                "timestamp": "2026-03-01T11:00:05Z",
+                "message": {"model": "c", "content": [{"type": "text", "text": "Fixed and built."}]},
+            },
+        ]
+    )
+    out = analyse(recovered, source="claude_code")
+    assert out["qualification"]["qualification_state"] == "unclassified"
+
+
 @pytest.mark.parametrize(
     "source", ["codex_desktop", "claude_desktop"]
 )


### PR DESCRIPTION
## What

Close the OpenClaw trajectory extraction gap so genuine trajectory tool failures actually reach a verdict and a match through `analyse()`.

## Diagnosis (verified at HEAD before this branch)

OSS matching flows through `driftshield.public.analyse()`. Claude-Code-shaped genuine failures already reach `qualified_failure` + a match. OpenClaw **trajectory** failures did not. Parity matrix before the fix:

| Scenario | claude_code | trajectory |
|---|---|---|
| tool failure + premature completion | `unclassified` + `mechanism:tool_misuse` match | `unclassified` + **no match** |
| user abort | n/a | `unclassified` + no match (correct) |

Two independent structural gaps:

1. **Parser dropped per-tool failure.** `OpenClawTrajectoryParser._trace_artifact_events` mapped each `toolMetas` entry to a `TOOL_CALL` with `outputs={}` and never read its `isError`. So a genuinely failed tool carried no failure signal, `normalize_events` derived no `failure_context`, no `tool_result` event was produced, and the deterministic matcher's failed-tool path (`SEQ-TOOL-001` / `tool_misuse`) could never fire. claude_code surfaces a tool error as a `TOOL_CALL` with `failure_context.status=error`.

2. **A structurally-failed tool was not a material delta.** Even with a proper failed `tool_result`, the matcher fired `tool_misuse` but `canonical_analysis._delta_types()` only read the five risk-heuristic flags + unresolved ambiguity. It never surfaced a failed tool, so `delta_present=False` and qualification stayed `unclassified` for **both** parsers. That is why claude_code's pure tool failure was `unclassified` + match.

## Fix

1. `parsers/openclaw_trajectory.py`: read each `toolMetas` entry's structural failure flag (`isError`, an explicit `error`/`errorMessage` string, a non-success `status`, a non-zero `exitCode`) and surface it on the `TOOL_CALL` outputs so normalisation derives `failure_context` and a `tool_result` event. Success tools stay clean.
2. `core/canonical_analysis.py::_delta_types`: when an **unrecovered** failed tool is present (a `TOOL_CALL`/`HANDOFF` with `tool_activity.status=error` and no later successful tool), emit an `incomplete_execution` material delta + a structured delta record. Applies to both parsers, so claude_code's equivalent failure also rises to `qualified_failure` — full parity.

## Honesty fence

Both fixes key on signals that survive redaction: the runtime's own `isError` boolean / status string / exit code, and a failed tool event's structural `tool_activity.status`. No semantic delta is derived from scrubbed prose. An abort or timeout lands on OUTPUT/system events, not tool events, so **aborts stay `unclassified` with no fabricated match** (pinned by test). A failure the run recovered from (a later successful tool) is not a delta (pinned by test).

## Tests

- `tests/parsers/test_openclaw_trajectory.py`: per-tool `isError` / error-string surfaces `failure_context`; a successful tool stays clean.
- `tests/test_public_analyse.py`: trajectory tool failure → `qualified_failure` + `mechanism:tool_misuse`; cross-parser parity (claude_code ≡ trajectory); abort stays `unclassified` no match; thin success stays `unclassified`.
- Full unit suite: **720 passed, 3 skipped**. Ruff clean. `scripts/check-public-scope.sh` green. Synthetic fixtures only.
