### PR TITLE
feat(cli): make driftshield submit the canonical customer upload path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@
 ## Community signature opt-in
 
 - After analysing a finished run locally, opt its signature run into the community pool:
-  `driftshield telemetry submit-session --path <session.json> --tier oss`
+  `driftshield submit --path <session.json>`
 - No setup is needed. The community intake URL is baked in as the default; `remote-enable` is only for pointing at a different intake. `telemetry remote-disable` opts out entirely, baked default included.
-- `--tier oss` is the unauthenticated community lane. No API key is sent.
+- The default tier is `oss`, the unauthenticated community lane. No API key is sent.
 - Opting in declares the run as a production run by default. Do not pass `--environment` in the normal path.
 - Only the redacted, community-safe envelope leaves the machine.
 - Override note: a non-production contribution can pass `--environment staging|test|demo`, but this is the uncommon case, not the documented path.

--- a/README.md
+++ b/README.md
@@ -167,16 +167,14 @@ source .venv/bin/activate
 DRIFTSHIELD_API_KEY=... driftshield submit --path <session.json> --tier teams
 ```
 
-Pass `--include-analysis` to attach the local matcher verdict. This lets the hosted
-DriftShield investigation match what you see locally:
+Pass `--include-analysis` to attach the local matcher verdict. The hosted investigation then uses the same verdict your local matcher produced:
 
 ```bash
 driftshield submit --path <session.json> --include-analysis
 ```
 
-The hosted intel layer persists the investigation and serves the investigation surface.
-Teams customers upload via this command; no separate configuration is needed beyond
-the API key.
+The hosted intel layer persists the investigation and makes it available on the investigation surface.
+Teams customers set `DRIFTSHIELD_API_KEY` and pass `--tier teams`; no other configuration is needed.
 
 ### 5. Run the full local stack
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,41 @@ cd ..
 ./scripts/dev-verify.sh
 ```
 
-### 4. Run the full local stack
+### 4. Upload a session for hosted investigation
 
-The API ingest flow and web dashboard expect a local Postgres instance. The supported dev path
+`driftshield submit` is the customer upload command. The client redacts the transcript
+locally before upload. No raw transcript data leaves the machine unredacted.
+
+OSS community lane (unauthenticated):
+
+```bash
+cd driftshield
+source .venv/bin/activate
+driftshield submit --path <session.json>
+```
+
+Teams lane (authenticated; requires `DRIFTSHIELD_API_KEY`):
+
+```bash
+cd driftshield
+source .venv/bin/activate
+DRIFTSHIELD_API_KEY=... driftshield submit --path <session.json> --tier teams
+```
+
+Pass `--include-analysis` to attach the local matcher verdict. This lets the hosted
+DriftShield investigation match what you see locally:
+
+```bash
+driftshield submit --path <session.json> --include-analysis
+```
+
+The hosted intel layer persists the investigation and serves the investigation surface.
+Teams customers upload via this command; no separate configuration is needed beyond
+the API key.
+
+### 5. Run the full local stack
+
+The local API and web dashboard expect a local Postgres instance. The supported dev path
 is `docker-compose.dev.yml`; the production `docker-compose.yml` is not the primary quickstart.
 
 Start the backend:
@@ -182,7 +214,10 @@ forensic report inline.
 
 ![DriftShield dashboard, investigation graph view](docs/media/theme-shots/after/02-investigation-desktop.png)
 
-### 5. Ingest a transcript into the local API
+### 6. Feed the local dashboard (self-host path)
+
+`driftshield ingest` uploads directly to a running local `/api/ingest` server. This is the
+self-host and vetted-integration path, not the normal customer upload path.
 
 ```bash
 cd driftshield
@@ -256,10 +291,21 @@ Risk detectors are additive. Each implements a `RiskHeuristic` interface and can
 All commands run from the `driftshield/` directory after `source .venv/bin/activate`.
 
 ```bash
-# Ingest a transcript file
-driftshield ingest --path <file.jsonl>
+# Upload a session for hosted failure investigation (OSS community lane)
+driftshield submit --path <session.json>
 
-# Ingest the latest Claude Code session
+# Upload with local matcher verdict attached (hosted investigation matches local result)
+driftshield submit --path <session.json> --include-analysis
+
+# Upload via the Teams lane (requires DRIFTSHIELD_API_KEY)
+DRIFTSHIELD_API_KEY=... driftshield submit --path <session.json> --tier teams
+
+# Inspect what the redactor would strip, without uploading
+driftshield submit --path <session.json> --dry-run-redaction
+driftshield submit --path <session.json> --show-manifest
+
+# Feed the local self-hosted dashboard (direct upload to /api/ingest)
+driftshield ingest --path <file.jsonl>
 driftshield ingest --latest
 
 # List ingested sessions

--- a/driftshield/docs/redactor-v2.md
+++ b/driftshield/docs/redactor-v2.md
@@ -90,15 +90,14 @@ public detection surface or the rule-evaluation order changes.
 
 ## CLI inspection
 
-Two flags on `driftshield telemetry submit-session` let you inspect the
-redactor's behaviour without submitting:
+Two flags on `driftshield submit` let you inspect the redactor's behaviour without submitting:
 
 ```sh
 # Print the structured list of redaction entries that would apply.
-driftshield telemetry submit-session --path session.json --dry-run-redaction
+driftshield submit --path session.json --dry-run-redaction
 
 # Print the manifest that would accompany the submission.
-driftshield telemetry submit-session --path session.json --show-manifest
+driftshield submit --path session.json --show-manifest
 ```
 
 Both flags exit 0 without posting to the intake URL.

--- a/driftshield/docs/telemetry.md
+++ b/driftshield/docs/telemetry.md
@@ -8,6 +8,9 @@ The current OSS transport is intentionally simple:
 - events are appended to a local NDJSON stream under `DRIFTSHIELD_HOME/telemetry/` or `~/.driftshield/telemetry/`
 - this keeps the consent boundary, event inventory, and smoke path testable before broader instrumentation lands
 
+Uploading a session for hosted investigation is a separate action. Use `driftshield submit`
+for that. Telemetry opt-in does not trigger or gate uploads.
+
 ## Consent boundary
 
 - default state: disabled
@@ -66,7 +69,7 @@ Current OSS emission path:
 - the `/api/ingest` flow now emits one `analysis_result` event for newly analysed runs when telemetry is enabled
 - deduplicated re-ingest responses do not emit a second `analysis_result` event
 
-## CLI smoke path
+## CLI reference
 
 ```bash
 # show current consent state
@@ -74,6 +77,9 @@ DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry status
 
 # opt in and register this install
 DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry enable
+
+# opt out
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry disable
 
 # emit one heartbeat
 DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry heartbeat
@@ -83,7 +89,30 @@ DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry emit-analysis \
   --outcome-status matched \
   --match-count 1 \
   --primary-mechanism-id coverage_gap
+
+# configure or clear the OSS intake URL override
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry remote-enable --intake-url <url>
+DRIFTSHIELD_HOME=/tmp/driftshield driftshield telemetry remote-disable
 ```
+
+## Uploading sessions
+
+Uploading a session to DriftShield for hosted investigation is done with `driftshield submit`,
+not via the telemetry commands. The client redacts the transcript locally before upload.
+
+OSS community lane:
+
+```bash
+driftshield submit --path <session.json>
+```
+
+Teams lane (requires `DRIFTSHIELD_API_KEY`):
+
+```bash
+DRIFTSHIELD_API_KEY=... driftshield submit --path <session.json> --tier teams
+```
+
+Pass `--include-analysis` to attach the local matcher verdict to the submission.
 
 ## Out of scope
 

--- a/driftshield/src/driftshield/cli/_session_payload.py
+++ b/driftshield/src/driftshield/cli/_session_payload.py
@@ -1,6 +1,6 @@
 """Load a session file as the envelope payload dict.
 
-Both ``telemetry submit-session`` and ``ingest`` accept a ``--path``
+Both ``driftshield submit`` and ``ingest`` accept a ``--path``
 pointing at the user's local session. Historically the file had to be a
 single JSON object (the envelope payload). Native Claude Code sessions
 ship as JSONL: a line-delimited transcript. This helper accepts either

--- a/driftshield/src/driftshield/cli/_signature_summary.py
+++ b/driftshield/src/driftshield/cli/_signature_summary.py
@@ -1,6 +1,6 @@
 """Build a signature summary from a finished session file.
 
-Shared helper between the ``telemetry submit-session`` and ``ingest``
+Shared helper between the ``driftshield submit`` and ``ingest``
 commands. Given a session file path, parse it through the local
 deterministic matcher and project the result into the public envelope
 shape (:class:`driftshield.intake_contract.SignatureSummary`).

--- a/driftshield/src/driftshield/cli/_submit.py
+++ b/driftshield/src/driftshield/cli/_submit.py
@@ -1,0 +1,333 @@
+"""Shared upload implementation for the submit command surface."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Callable
+
+import typer
+from rich.console import Console
+
+from driftshield.core.canonical_analysis import DECLARED_ENVIRONMENTS
+from driftshield.core.models import EnvironmentClass
+from driftshield.intake_contract import (
+    DEFAULT_WORKFLOW_REFERENCE,
+    REDACTION_MANIFEST_VERSION,
+    REQUIRED_REDACTION_FIELDS,
+    SUPPORTED_CONTRACT_VERSION,
+    RedactionManifest,
+)
+from driftshield.recursive_redactor import (
+    REDACTION_RULESET_VERSION,
+    REDACTOR_VERSION,
+)
+from driftshield.cli._session_payload import load_session_payload
+from driftshield.cli._signature_summary import build_signature_summary_from_session
+from driftshield.remote_submission import (
+    OssRemoteSubmissionConfig,
+    RemoteSubmissionError,
+    UnknownTranscriptShapeError,
+    build_oss_submission_request,
+    build_redacted_payload,
+    derive_openclaw_provenance,
+    detect_shape,
+    post_oss_submission,
+    redact_payload_with_manifest,
+)
+from driftshield.remote_upload import (
+    INLINE_PAYLOAD_THRESHOLD_BYTES,
+    OssUploadConfig,
+    TeamsUploadConfig,
+    submit_oss_via_presigned_upload,
+    submit_teams_via_presigned_upload,
+)
+from driftshield.telemetry import (
+    TelemetryService,
+    effective_oss_intake_url,
+)
+
+console = Console(force_terminal=True)
+
+
+def run_submit(
+    *,
+    path: Path,
+    source_session_id: str | None,
+    workflow_reference: str | None,
+    project_reference: str | None,
+    source_report_id: str | None,
+    agent_id: str | None,
+    model_name: str | None,
+    model_version: str | None,
+    dry_run_redaction: bool,
+    show_manifest: bool,
+    force_unknown_shape: bool,
+    include_analysis: bool,
+    tier: str,
+    environment: str | None,
+    # Callable overrides — used by tests that monkeypatch via the telemetry
+    # module's namespace.  callers that do not need to swap these out should
+    # leave them as None so the module-level defaults are used.
+    _post_oss_submission: Callable | None = None,
+    _submit_oss_via_presigned_upload: Callable | None = None,
+    _submit_teams_via_presigned_upload: Callable | None = None,
+    _build_signature_summary_from_session: Callable | None = None,
+) -> None:
+    """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL."""
+    _post = _post_oss_submission if _post_oss_submission is not None else post_oss_submission
+    _oss_presigned = _submit_oss_via_presigned_upload if _submit_oss_via_presigned_upload is not None else submit_oss_via_presigned_upload
+    _teams_presigned = _submit_teams_via_presigned_upload if _submit_teams_via_presigned_upload is not None else submit_teams_via_presigned_upload
+    _build_summary = _build_signature_summary_from_session if _build_signature_summary_from_session is not None else build_signature_summary_from_session
+
+    try:
+        payload = load_session_payload(path)
+    except OSError as exc:
+        console.print(f"[red]Error:[/red] Could not read session file: {exc}")
+        raise typer.Exit(1) from exc
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}.")
+        raise typer.Exit(1) from exc
+
+    if dry_run_redaction or show_manifest:
+        redaction_result = redact_payload_with_manifest(payload)
+        shape = detect_shape(payload) or "unknown"
+        if dry_run_redaction:
+            entries = [
+                {
+                    "path": entry.path,
+                    "category": entry.category,
+                    "sample_hash": entry.sample_hash,
+                }
+                for entry in redaction_result.entries
+            ]
+            typer.echo(
+                json.dumps(
+                    {"detected_shape": shape, "entries": entries},
+                    indent=2,
+                )
+            )
+        if show_manifest:
+            manifest = RedactionManifest(
+                manifest_version=REDACTION_MANIFEST_VERSION,
+                redaction_applied=True,
+                redacted_fields=sorted(REQUIRED_REDACTION_FIELDS),
+                redactor_version=REDACTOR_VERSION,
+                redaction_ruleset_version=REDACTION_RULESET_VERSION,
+            )
+            manifest_payload = manifest.model_dump(mode="json")
+            manifest_payload["detected_shape"] = shape
+            manifest_payload["ruleset_entry_count"] = len(redaction_result.entries)
+            typer.echo(json.dumps(manifest_payload, indent=2))
+        return
+
+    resolved_tier = tier.strip().lower()
+    if resolved_tier not in {"oss", "teams"}:
+        console.print("[red]Error:[/red] --tier must be 'oss' or 'teams'.")
+        raise typer.Exit(1)
+
+    resolved_environment: str | None = None
+    if environment is not None:
+        resolved_environment = environment.strip().lower()
+        if resolved_environment not in DECLARED_ENVIRONMENTS:
+            valid = ", ".join(sorted(DECLARED_ENVIRONMENTS))
+            console.print(
+                f"[red]Error:[/red] --environment must be one of: {valid}."
+            )
+            raise typer.Exit(1)
+        if resolved_tier != "oss":
+            console.print(
+                "[red]Error:[/red] --environment applies to the community "
+                "(oss) lane only."
+            )
+            raise typer.Exit(1)
+
+    config = TelemetryService().load_config()
+    if resolved_tier == "oss":
+        intake_url = effective_oss_intake_url(config)
+        if intake_url is None:
+            console.print(
+                "[red]Error:[/red] Remote submission is disabled "
+                "(`telemetry remote-disable`). Run `driftshield telemetry "
+                "remote-enable --intake-url URL` to re-enable."
+            )
+            raise typer.Exit(1)
+    else:
+        intake_url = config.remote_intake_url
+        if intake_url is None:
+            console.print(
+                "[red]Error:[/red] Remote submission is not configured. "
+                "Run `driftshield telemetry remote-enable --intake-url URL` first."
+            )
+            raise typer.Exit(1)
+
+    resolved_workflow_reference = workflow_reference
+    if resolved_workflow_reference is None:
+        payload_workflow = payload.get("workflow_reference")
+        if isinstance(payload_workflow, str) and payload_workflow.strip():
+            resolved_workflow_reference = payload_workflow
+    if resolved_workflow_reference is None:
+        resolved_workflow_reference = DEFAULT_WORKFLOW_REFERENCE
+
+    summary = None
+    if include_analysis:
+        try:
+            summary = _build_summary(path)
+        except Exception as exc:  # noqa: BLE001
+            typer.echo(
+                "error: --include-analysis specified but "
+                f"build_signature_summary_from_session(...) failed: {exc}",
+                err=True,
+            )
+            raise typer.Exit(code=2) from exc
+        if summary is None:
+            typer.echo(
+                "error: --include-analysis specified but "
+                "build_signature_summary_from_session(...) could not produce "
+                "a summary (no parser detected or session yielded no events). "
+                "Re-run without --include-analysis or supply a parseable session.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+
+    teams_api_key: str | None = None
+    if resolved_tier == "teams":
+        teams_api_key = os.environ.get("DRIFTSHIELD_API_KEY") or os.environ.get(
+            "API_KEY"
+        )
+        if not teams_api_key:
+            console.print(
+                "[red]Error:[/red] --tier teams requires DRIFTSHIELD_API_KEY "
+                "(or API_KEY) in the environment."
+            )
+            raise typer.Exit(1)
+
+    # Real provenance for OpenClaw trajectories: the harness/agent and the
+    # driving provider/model come from the trajectory itself when the caller
+    # did not pass explicit values. Explicit flags always win.
+    derived_provenance = derive_openclaw_provenance(payload)
+    if agent_id is None:
+        agent_id = derived_provenance.get("agent_id")
+    if model_name is None:
+        model_name = derived_provenance.get("model_name")
+
+    # Community opt-in is the production declaration: stamp the declared
+    # environment before redaction so it rides both the inline and the
+    # presigned lanes. An environment already declared in the session JSON
+    # is kept; --environment wins over everything.
+    if resolved_tier == "oss":
+        metadata = payload.get("metadata")
+        if not isinstance(metadata, dict):
+            # The envelope contract expects a metadata mapping; a malformed
+            # value cannot carry the declared environment.
+            metadata = {}
+            payload["metadata"] = metadata
+        if resolved_environment is not None:
+            metadata["environment"] = resolved_environment
+        else:
+            metadata.setdefault("environment", EnvironmentClass.PRODUCTION.value)
+
+    # Redact once to measure the canonical size (uncapped) and decide the
+    # lane. The size-capped SubmissionEnvelope model is only built on the
+    # small inline OSS path; large transcripts exceed that cap by design
+    # and take the presigned-S3 lane instead.
+    try:
+        redacted_payload = build_redacted_payload(
+            payload=payload, force_unknown_shape=force_unknown_shape
+        )
+    except UnknownTranscriptShapeError as exc:
+        console.print(
+            f"[red]Error:[/red] {exc} "
+            "Inspect the payload with --dry-run-redaction first."
+        )
+        raise typer.Exit(1) from exc
+
+    payload_size = len(
+        json.dumps(
+            redacted_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    )
+    is_large = payload_size > INLINE_PAYLOAD_THRESHOLD_BYTES
+
+    # The provenance surface the inline lane carries on the envelope must
+    # also ride the presigned lane (else large + Teams submissions lose it).
+    provenance: dict[str, object] = {
+        "source_session_id": source_session_id or path.stem,
+    }
+    for key, value in (
+        ("project_reference", project_reference),
+        ("source_report_id", source_report_id),
+        ("agent_id", agent_id),
+        ("model_name", model_name),
+        ("model_version", model_version),
+    ):
+        if value is not None:
+            provenance[key] = value
+    if summary is not None:
+        provenance["signature_summary"] = summary.model_dump(mode="json")
+
+    try:
+        if resolved_tier == "teams":
+            assert teams_api_key is not None
+            result = _teams_presigned(
+                config=TeamsUploadConfig(
+                    intake_url=intake_url, api_key=teams_api_key
+                ),
+                payload=redacted_payload,
+                workflow_reference=resolved_workflow_reference,
+                file_name=path.name,
+                provenance=provenance,
+            )
+        elif is_large:
+            result = _oss_presigned(
+                config=OssUploadConfig(intake_url=intake_url),
+                payload=redacted_payload,
+                workflow_reference=resolved_workflow_reference,
+                file_name=path.name,
+                provenance=provenance,
+            )
+        else:
+            try:
+                submission = build_oss_submission_request(
+                    source_session_id=source_session_id or path.stem,
+                    payload=payload,
+                    workflow_reference=resolved_workflow_reference,
+                    project_reference=project_reference,
+                    source_report_id=source_report_id,
+                    force_unknown_shape=force_unknown_shape,
+                    agent_id=agent_id,
+                    model_name=model_name,
+                    model_version=model_version,
+                    signature_summary=summary,
+                )
+            except UnknownTranscriptShapeError as exc:
+                console.print(
+                    f"[red]Error:[/red] {exc} "
+                    "Inspect the payload with --dry-run-redaction first."
+                )
+                raise typer.Exit(1) from exc
+            submission_config = OssRemoteSubmissionConfig(intake_url=intake_url)
+            result = _post(
+                config=submission_config, submission=submission
+            )
+    except RemoteSubmissionError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    if (
+        result.server_contract_version is not None
+        and result.server_contract_version != SUPPORTED_CONTRACT_VERSION
+    ):
+        console.print(
+            f"[yellow]Deprecation:[/yellow] intake server advertises "
+            f"{result.server_contract_version}; this client is on "
+            f"{SUPPORTED_CONTRACT_VERSION}. The server is in its post-bump "
+            "deprecation window: submissions are still accepted, but the "
+            "server operator should upgrade before the window closes."
+        )
+
+    response = result.response
+    console.print(
+        f"Submitted. submission_id={response.submission_id} status={response.processing_status}"
+    )

--- a/driftshield/src/driftshield/cli/_submit.py
+++ b/driftshield/src/driftshield/cli/_submit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Callable
 
 import typer
 from rich.console import Console
@@ -67,19 +66,8 @@ def run_submit(
     include_analysis: bool,
     tier: str,
     environment: str | None,
-    # Callable overrides — used by tests that monkeypatch via the telemetry
-    # module's namespace.  callers that do not need to swap these out should
-    # leave them as None so the module-level defaults are used.
-    _post_oss_submission: Callable | None = None,
-    _submit_oss_via_presigned_upload: Callable | None = None,
-    _submit_teams_via_presigned_upload: Callable | None = None,
-    _build_signature_summary_from_session: Callable | None = None,
 ) -> None:
     """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL."""
-    _post = _post_oss_submission if _post_oss_submission is not None else post_oss_submission
-    _oss_presigned = _submit_oss_via_presigned_upload if _submit_oss_via_presigned_upload is not None else submit_oss_via_presigned_upload
-    _teams_presigned = _submit_teams_via_presigned_upload if _submit_teams_via_presigned_upload is not None else submit_teams_via_presigned_upload
-    _build_summary = _build_signature_summary_from_session if _build_signature_summary_from_session is not None else build_signature_summary_from_session
 
     try:
         payload = load_session_payload(path)
@@ -173,7 +161,7 @@ def run_submit(
     summary = None
     if include_analysis:
         try:
-            summary = _build_summary(path)
+            summary = build_signature_summary_from_session(path)
         except Exception as exc:  # noqa: BLE001
             typer.echo(
                 "error: --include-analysis specified but "
@@ -270,7 +258,7 @@ def run_submit(
     try:
         if resolved_tier == "teams":
             assert teams_api_key is not None
-            result = _teams_presigned(
+            result = submit_teams_via_presigned_upload(
                 config=TeamsUploadConfig(
                     intake_url=intake_url, api_key=teams_api_key
                 ),
@@ -280,7 +268,7 @@ def run_submit(
                 provenance=provenance,
             )
         elif is_large:
-            result = _oss_presigned(
+            result = submit_oss_via_presigned_upload(
                 config=OssUploadConfig(intake_url=intake_url),
                 payload=redacted_payload,
                 workflow_reference=resolved_workflow_reference,
@@ -308,7 +296,7 @@ def run_submit(
                 )
                 raise typer.Exit(1) from exc
             submission_config = OssRemoteSubmissionConfig(intake_url=intake_url)
-            result = _post(
+            result = post_oss_submission(
                 config=submission_config, submission=submission
             )
     except RemoteSubmissionError as exc:

--- a/driftshield/src/driftshield/cli/_submit.py
+++ b/driftshield/src/driftshield/cli/_submit.py
@@ -67,7 +67,7 @@ def run_submit(
     tier: str,
     environment: str | None,
 ) -> None:
-    """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL."""
+    """Build a phase3g.v1 envelope from a finished session JSON and POST once to the configured intake URL (OSS community lane or authenticated Teams lane)."""
 
     try:
         payload = load_session_payload(path)

--- a/driftshield/src/driftshield/cli/commands/ingest.py
+++ b/driftshield/src/driftshield/cli/commands/ingest.py
@@ -9,7 +9,7 @@ import os
 import uuid
 from pathlib import Path
 from typing import Any
-from urllib import error, parse, request
+from urllib import error, request
 
 import typer
 from rich.console import Console
@@ -19,8 +19,6 @@ from driftshield.cli.parsers import detect_parser
 
 
 console = Console(force_terminal=True)
-
-_VALID_SUBMISSION_TIERS = {"oss", "teams"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,8 +44,6 @@ class SourceConnectorMetadata:
 @dataclass(frozen=True, slots=True)
 class SubmissionContext:
     submission_tier: str
-    tenant_id: str | None = None
-    workspace_id: str | None = None
     workflow_reference: str | None = None
     project_reference: str | None = None
     source_connector: SourceConnectorMetadata | None = None
@@ -75,24 +71,6 @@ def ingest(
         "--parser",
         "-p",
         help="Parser to use (auto, claude_code, claude_desktop, codex_cli, codex_desktop, crewai, langchain, openclaw).",
-    ),
-    submission_tier: str = typer.Option(
-        "oss",
-        "--submission-tier",
-        help="Remote submission tier (oss or teams).",
-        envvar="DRIFTSHIELD_SUBMISSION_TIER",
-    ),
-    tenant_id: str | None = typer.Option(
-        None,
-        "--tenant-id",
-        help="Claimed tenant identifier for Teams submissions.",
-        envvar="DRIFTSHIELD_TENANT_ID",
-    ),
-    workspace_id: str | None = typer.Option(
-        None,
-        "--workspace-id",
-        help="Claimed workspace identifier for Teams submissions.",
-        envvar="DRIFTSHIELD_WORKSPACE_ID",
     ),
     workflow_reference: str | None = typer.Option(
         None,
@@ -140,7 +118,7 @@ def ingest(
         ),
     ),
 ) -> None:
-    """Upload a transcript to the DriftShield ingest API."""
+    """Upload a transcript to a self-hosted DriftShield API (the bundled local app / dashboard feeder). For hosted DriftShield uploads use `driftshield submit`."""
     selected = [bool(path), project, latest]
     if sum(selected) != 1:
         console.print("[red]Error:[/red] Choose exactly one of --path, --project, or --latest.")
@@ -166,11 +144,6 @@ def ingest(
 
     try:
         submission_context = build_submission_context(
-            api_url=api_url,
-            api_key=api_key,
-            submission_tier=submission_tier,
-            tenant_id=tenant_id,
-            workspace_id=workspace_id,
             workflow_reference=workflow_reference,
             project_reference=project_reference,
             source_connector=SourceConnectorMetadata(
@@ -182,13 +155,6 @@ def ingest(
         )
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1) from exc
-    except error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        console.print(f"[red]Error:[/red] Tenant resolution failed with HTTP {exc.code}: {detail}")
-        raise typer.Exit(1) from exc
-    except error.URLError as exc:
-        console.print(f"[red]Error:[/red] Could not reach Teams auth-check endpoint: {exc.reason}")
         raise typer.Exit(1) from exc
 
     if include_analysis:
@@ -216,8 +182,6 @@ def ingest(
             raise typer.Exit(code=2)
         submission_context = SubmissionContext(
             submission_tier=submission_context.submission_tier,
-            tenant_id=submission_context.tenant_id,
-            workspace_id=submission_context.workspace_id,
             workflow_reference=submission_context.workflow_reference,
             project_reference=submission_context.project_reference,
             source_connector=submission_context.source_connector,
@@ -263,43 +227,13 @@ def ingest(
 
 def build_submission_context(
     *,
-    api_url: str,
-    api_key: str,
-    submission_tier: str,
-    tenant_id: str | None,
-    workspace_id: str | None,
     workflow_reference: str | None,
     project_reference: str | None,
     source_connector: SourceConnectorMetadata,
 ) -> SubmissionContext:
-    normalized_tier = submission_tier.strip().lower()
-    if normalized_tier not in _VALID_SUBMISSION_TIERS:
-        valid = ", ".join(sorted(_VALID_SUBMISSION_TIERS))
-        raise ValueError(f"submission tier must be one of: {valid}")
-
     normalized_source_connector = _normalise_source_connector(source_connector)
-    if normalized_tier == "oss":
-        return SubmissionContext(
-            submission_tier=normalized_tier,
-            workflow_reference=_optional_string(workflow_reference),
-            project_reference=_optional_string(project_reference),
-            source_connector=normalized_source_connector,
-        )
-
-    normalized_tenant_id = _required_string(tenant_id, field_name="tenant_id")
-    resolved = resolve_teams_submission_context(
-        api_url=api_url,
-        api_key=api_key,
-        tenant_id=normalized_tenant_id,
-        workspace_id=_optional_string(workspace_id),
-    )
-    resolved_tenant_id = _required_string(resolved.get("tenant_id"), field_name="tenant_id")
-    resolved_workspace_id = _optional_string(resolved.get("workspace_id"))
-
     return SubmissionContext(
-        submission_tier=normalized_tier,
-        tenant_id=resolved_tenant_id,
-        workspace_id=resolved_workspace_id,
+        submission_tier="oss",
         workflow_reference=_optional_string(workflow_reference),
         project_reference=_optional_string(project_reference),
         source_connector=normalized_source_connector,
@@ -360,37 +294,6 @@ def post_ingest(
         return json.loads(resp.read().decode("utf-8"))
 
 
-
-def resolve_teams_submission_context(
-    *,
-    api_url: str,
-    api_key: str,
-    tenant_id: str,
-    workspace_id: str | None,
-) -> dict[str, Any]:
-    query_params = {"tenant_id": tenant_id}
-    if workspace_id is not None:
-        query_params["workspace_id"] = workspace_id
-    auth_url = (
-        os.environ.get("DRIFTSHIELD_TEAMS_AUTH_CHECK_URL")
-        or api_url.rstrip("/") + "/v1/teams/auth-check"
-    )
-    req = request.Request(
-        auth_url + "?" + parse.urlencode(query_params),
-        method="GET",
-        headers={
-            "X-API-Key": api_key,
-            "Accept": "application/json",
-        },
-    )
-
-    with request.urlopen(req) as resp:
-        payload = json.loads(resp.read().decode("utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("Teams auth-check returned an invalid payload")
-    return payload
-
-
 def _build_multipart_body(
     *,
     boundary: str,
@@ -408,19 +311,7 @@ def _build_multipart_body(
         segments,
         boundary=boundary,
         name="submission_tier",
-        value=submission_context.submission_tier,
-    )
-    _append_optional_text_form_field(
-        segments,
-        boundary=boundary,
-        name="tenant_id",
-        value=submission_context.tenant_id,
-    )
-    _append_optional_text_form_field(
-        segments,
-        boundary=boundary,
-        name="workspace_id",
-        value=submission_context.workspace_id,
+        value="oss",
     )
     _append_optional_text_form_field(
         segments,
@@ -502,13 +393,6 @@ def _normalise_source_connector(
         display_name=display_name,
         parser_name=parser_name,
     )
-
-
-def _required_string(value: object, *, field_name: str) -> str:
-    normalized = _optional_string(value)
-    if normalized is None:
-        raise ValueError(f"{field_name} is required for Teams submissions")
-    return normalized
 
 
 def _optional_string(value: object) -> str | None:

--- a/driftshield/src/driftshield/cli/commands/show_result.py
+++ b/driftshield/src/driftshield/cli/commands/show_result.py
@@ -15,7 +15,7 @@ console = Console(force_terminal=True)
 
 
 def show_result(
-    submission_id: str = typer.Argument(..., help="Submission ID returned by `telemetry submit-session`."),
+    submission_id: str = typer.Argument(..., help="Submission ID returned by `driftshield submit`."),
     intake_url: str | None = typer.Option(
         None,
         "--intake-url",
@@ -29,7 +29,7 @@ def show_result(
 ) -> None:
     """Fetch the OSS-safe result triple for a submission from the configured intake URL.
 
-    Zero-config like ``telemetry submit-session --tier oss``: with nothing
+    Zero-config like ``driftshield submit --tier oss``: with nothing
     configured the baked community intake URL is used, so submit followed by
     show-result needs no ``remote-enable``. After ``telemetry remote-disable``
     the baked default does not apply; an explicit ``--intake-url`` always works.

--- a/driftshield/src/driftshield/cli/commands/submit.py
+++ b/driftshield/src/driftshield/cli/commands/submit.py
@@ -1,0 +1,109 @@
+"""Top-level submit command for uploading finished sessions to DriftShield."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from driftshield.cli._submit import run_submit
+
+
+def submit(
+    path: Path = typer.Option(..., "--path", help="JSON file with the finished session payload."),
+    source_session_id: str | None = typer.Option(
+        None,
+        "--source-session-id",
+        help="Override the source_session_id field. Defaults to the JSON file stem.",
+    ),
+    workflow_reference: str | None = typer.Option(
+        None,
+        "--workflow-reference",
+        help=(
+            "Workflow identifier stamped on the envelope. Defaults to the "
+            "value in the session JSON's 'workflow_reference' field, or "
+            "'default' if neither is supplied."
+        ),
+    ),
+    project_reference: str | None = typer.Option(
+        None, "--project-reference", help="Optional project identifier."
+    ),
+    source_report_id: str | None = typer.Option(
+        None, "--source-report-id", help="Optional source report identifier."
+    ),
+    agent_id: str | None = typer.Option(
+        None, "--agent-id", help="Optional agent identifier recorded as run provenance."
+    ),
+    model_name: str | None = typer.Option(
+        None, "--model-name", help="Optional model name recorded as run provenance."
+    ),
+    model_version: str | None = typer.Option(
+        None, "--model-version", help="Optional model version recorded as run provenance."
+    ),
+    dry_run_redaction: bool = typer.Option(
+        False,
+        "--dry-run-redaction",
+        help="Run the recursive redactor, print the redaction entries, exit without submitting.",
+    ),
+    show_manifest: bool = typer.Option(
+        False,
+        "--show-manifest",
+        help="Print the redaction manifest that would accompany the submission, exit without submitting.",
+    ),
+    force_unknown_shape: bool = typer.Option(
+        False,
+        "--force-unknown-shape",
+        help="Submit even if the transcript top-level shape is not recognised by the redactor.",
+    ),
+    include_analysis: bool = typer.Option(
+        False,
+        "--include-analysis",
+        help=(
+            "Run the local deterministic matcher and attach a signature_summary "
+            "block to the envelope. Off by default; no behavioural change vs the "
+            "default submission path when omitted."
+        ),
+    ),
+    tier: str = typer.Option(
+        "oss",
+        "--tier",
+        help=(
+            "Submission tier: 'oss' (unauthenticated community lane) or "
+            "'teams' (authenticated; requires DRIFTSHIELD_API_KEY). Large "
+            "transcripts upload via presigned storage on either tier."
+        ),
+    ),
+    environment: str | None = typer.Option(
+        None,
+        "--environment",
+        help=(
+            "Declared run environment for the community (oss) lane: "
+            "production, staging, test, or demo. Community opt-in declares "
+            "production by default; pass this only for the uncommon "
+            "non-production contribution."
+        ),
+    ),
+) -> None:
+    """Upload a finished session to DriftShield for hosted failure investigation.
+
+    The client redacts the transcript locally before upload. Use --tier teams
+    (with DRIFTSHIELD_API_KEY) for the authenticated hosted Teams lane, or the
+    default --tier oss for the unauthenticated community lane. Pass
+    --include-analysis to attach the local matcher verdict so the hosted
+    investigation matches what you get locally."""
+    run_submit(
+        path=path,
+        source_session_id=source_session_id,
+        workflow_reference=workflow_reference,
+        project_reference=project_reference,
+        source_report_id=source_report_id,
+        agent_id=agent_id,
+        model_name=model_name,
+        model_version=model_version,
+        dry_run_redaction=dry_run_redaction,
+        show_manifest=show_manifest,
+        force_unknown_shape=force_unknown_shape,
+        include_analysis=include_analysis,
+        tier=tier,
+        environment=environment,
+    )

--- a/driftshield/src/driftshield/cli/commands/submit.py
+++ b/driftshield/src/driftshield/cli/commands/submit.py
@@ -91,6 +91,7 @@ def submit(
     default --tier oss for the unauthenticated community lane. Pass
     --include-analysis to attach the local matcher verdict so the hosted
     investigation matches what you get locally."""
+
     run_submit(
         path=path,
         source_session_id=source_session_id,
@@ -107,3 +108,4 @@ def submit(
         tier=tier,
         environment=environment,
     )
+

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -3,42 +3,15 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import typer
 from rich.console import Console
 
-from driftshield.core.canonical_analysis import DECLARED_ENVIRONMENTS
-from driftshield.core.models import EnvironmentClass
-from driftshield.intake_contract import (
-    DEFAULT_WORKFLOW_REFERENCE,
-    REDACTION_MANIFEST_VERSION,
-    REQUIRED_REDACTION_FIELDS,
-    SUPPORTED_CONTRACT_VERSION,
-    RedactionManifest,
-)
-from driftshield.recursive_redactor import (
-    REDACTION_RULESET_VERSION,
-    REDACTOR_VERSION,
-)
-from driftshield.cli._session_payload import load_session_payload
+from driftshield.cli._submit import run_submit
 from driftshield.cli._signature_summary import build_signature_summary_from_session
-from driftshield.remote_submission import (
-    OssRemoteSubmissionConfig,
-    RemoteSubmissionError,
-    UnknownTranscriptShapeError,
-    build_oss_submission_request,
-    build_redacted_payload,
-    derive_openclaw_provenance,
-    detect_shape,
-    post_oss_submission,
-    redact_payload_with_manifest,
-)
+from driftshield.remote_submission import post_oss_submission
 from driftshield.remote_upload import (
-    INLINE_PAYLOAD_THRESHOLD_BYTES,
-    OssUploadConfig,
-    TeamsUploadConfig,
     submit_oss_via_presigned_upload,
     submit_teams_via_presigned_upload,
 )
@@ -217,255 +190,25 @@ def telemetry_submit_session(
     workflow references are what let downstream analysis tell repeat workflows
     apart; leaving every submission on ``"default"`` hides that signal.
     """
-    try:
-        payload = load_session_payload(path)
-    except OSError as exc:
-        console.print(f"[red]Error:[/red] Could not read session file: {exc}")
-        raise typer.Exit(1) from exc
-    except ValueError as exc:
-        console.print(f"[red]Error:[/red] {exc}.")
-        raise typer.Exit(1) from exc
-
-    if dry_run_redaction or show_manifest:
-        redaction_result = redact_payload_with_manifest(payload)
-        shape = detect_shape(payload) or "unknown"
-        if dry_run_redaction:
-            entries = [
-                {
-                    "path": entry.path,
-                    "category": entry.category,
-                    "sample_hash": entry.sample_hash,
-                }
-                for entry in redaction_result.entries
-            ]
-            typer.echo(
-                json.dumps(
-                    {"detected_shape": shape, "entries": entries},
-                    indent=2,
-                )
-            )
-        if show_manifest:
-            manifest = RedactionManifest(
-                manifest_version=REDACTION_MANIFEST_VERSION,
-                redaction_applied=True,
-                redacted_fields=sorted(REQUIRED_REDACTION_FIELDS),
-                redactor_version=REDACTOR_VERSION,
-                redaction_ruleset_version=REDACTION_RULESET_VERSION,
-            )
-            manifest_payload = manifest.model_dump(mode="json")
-            manifest_payload["detected_shape"] = shape
-            manifest_payload["ruleset_entry_count"] = len(redaction_result.entries)
-            typer.echo(json.dumps(manifest_payload, indent=2))
-        return
-
-    resolved_tier = tier.strip().lower()
-    if resolved_tier not in {"oss", "teams"}:
-        console.print("[red]Error:[/red] --tier must be 'oss' or 'teams'.")
-        raise typer.Exit(1)
-
-    resolved_environment: str | None = None
-    if environment is not None:
-        resolved_environment = environment.strip().lower()
-        if resolved_environment not in DECLARED_ENVIRONMENTS:
-            valid = ", ".join(sorted(DECLARED_ENVIRONMENTS))
-            console.print(
-                f"[red]Error:[/red] --environment must be one of: {valid}."
-            )
-            raise typer.Exit(1)
-        if resolved_tier != "oss":
-            console.print(
-                "[red]Error:[/red] --environment applies to the community "
-                "(oss) lane only."
-            )
-            raise typer.Exit(1)
-
-    config = TelemetryService().load_config()
-    if resolved_tier == "oss":
-        intake_url = effective_oss_intake_url(config)
-        if intake_url is None:
-            console.print(
-                "[red]Error:[/red] Remote submission is disabled "
-                "(`telemetry remote-disable`). Run `driftshield telemetry "
-                "remote-enable --intake-url URL` to re-enable."
-            )
-            raise typer.Exit(1)
-    else:
-        intake_url = config.remote_intake_url
-        if intake_url is None:
-            console.print(
-                "[red]Error:[/red] Remote submission is not configured. "
-                "Run `driftshield telemetry remote-enable --intake-url URL` first."
-            )
-            raise typer.Exit(1)
-
-    resolved_workflow_reference = workflow_reference
-    if resolved_workflow_reference is None:
-        payload_workflow = payload.get("workflow_reference")
-        if isinstance(payload_workflow, str) and payload_workflow.strip():
-            resolved_workflow_reference = payload_workflow
-    if resolved_workflow_reference is None:
-        resolved_workflow_reference = DEFAULT_WORKFLOW_REFERENCE
-
-    summary = None
-    if include_analysis:
-        try:
-            summary = build_signature_summary_from_session(path)
-        except Exception as exc:  # noqa: BLE001
-            typer.echo(
-                "error: --include-analysis specified but "
-                f"build_signature_summary_from_session(...) failed: {exc}",
-                err=True,
-            )
-            raise typer.Exit(code=2) from exc
-        if summary is None:
-            typer.echo(
-                "error: --include-analysis specified but "
-                "build_signature_summary_from_session(...) could not produce "
-                "a summary (no parser detected or session yielded no events). "
-                "Re-run without --include-analysis or supply a parseable session.",
-                err=True,
-            )
-            raise typer.Exit(code=2)
-
-    teams_api_key: str | None = None
-    if resolved_tier == "teams":
-        teams_api_key = os.environ.get("DRIFTSHIELD_API_KEY") or os.environ.get(
-            "API_KEY"
-        )
-        if not teams_api_key:
-            console.print(
-                "[red]Error:[/red] --tier teams requires DRIFTSHIELD_API_KEY "
-                "(or API_KEY) in the environment."
-            )
-            raise typer.Exit(1)
-
-    # Real provenance for OpenClaw trajectories: the harness/agent and the
-    # driving provider/model come from the trajectory itself when the caller
-    # did not pass explicit values. Explicit flags always win.
-    derived_provenance = derive_openclaw_provenance(payload)
-    if agent_id is None:
-        agent_id = derived_provenance.get("agent_id")
-    if model_name is None:
-        model_name = derived_provenance.get("model_name")
-
-    # Community opt-in is the production declaration: stamp the declared
-    # environment before redaction so it rides both the inline and the
-    # presigned lanes. An environment already declared in the session JSON
-    # is kept; --environment wins over everything.
-    if resolved_tier == "oss":
-        metadata = payload.get("metadata")
-        if not isinstance(metadata, dict):
-            # The envelope contract expects a metadata mapping; a malformed
-            # value cannot carry the declared environment.
-            metadata = {}
-            payload["metadata"] = metadata
-        if resolved_environment is not None:
-            metadata["environment"] = resolved_environment
-        else:
-            metadata.setdefault("environment", EnvironmentClass.PRODUCTION.value)
-
-    # Redact once to measure the canonical size (uncapped) and decide the
-    # lane. The size-capped SubmissionEnvelope model is only built on the
-    # small inline OSS path; large transcripts exceed that cap by design
-    # and take the presigned-S3 lane instead.
-    try:
-        redacted_payload = build_redacted_payload(
-            payload=payload, force_unknown_shape=force_unknown_shape
-        )
-    except UnknownTranscriptShapeError as exc:
-        console.print(
-            f"[red]Error:[/red] {exc} "
-            "Inspect the payload with --dry-run-redaction first."
-        )
-        raise typer.Exit(1) from exc
-
-    payload_size = len(
-        json.dumps(
-            redacted_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
-    )
-    is_large = payload_size > INLINE_PAYLOAD_THRESHOLD_BYTES
-
-    # The provenance surface the inline lane carries on the envelope must
-    # also ride the presigned lane (else large + Teams submissions lose it).
-    provenance: dict[str, object] = {
-        "source_session_id": source_session_id or path.stem,
-    }
-    for key, value in (
-        ("project_reference", project_reference),
-        ("source_report_id", source_report_id),
-        ("agent_id", agent_id),
-        ("model_name", model_name),
-        ("model_version", model_version),
-    ):
-        if value is not None:
-            provenance[key] = value
-    if summary is not None:
-        provenance["signature_summary"] = summary.model_dump(mode="json")
-
-    try:
-        if resolved_tier == "teams":
-            assert teams_api_key is not None
-            result = submit_teams_via_presigned_upload(
-                config=TeamsUploadConfig(
-                    intake_url=intake_url, api_key=teams_api_key
-                ),
-                payload=redacted_payload,
-                workflow_reference=resolved_workflow_reference,
-                file_name=path.name,
-                provenance=provenance,
-            )
-        elif is_large:
-            result = submit_oss_via_presigned_upload(
-                config=OssUploadConfig(intake_url=intake_url),
-                payload=redacted_payload,
-                workflow_reference=resolved_workflow_reference,
-                file_name=path.name,
-                provenance=provenance,
-            )
-        else:
-            try:
-                submission = build_oss_submission_request(
-                    source_session_id=source_session_id or path.stem,
-                    payload=payload,
-                    workflow_reference=resolved_workflow_reference,
-                    project_reference=project_reference,
-                    source_report_id=source_report_id,
-                    force_unknown_shape=force_unknown_shape,
-                    agent_id=agent_id,
-                    model_name=model_name,
-                    model_version=model_version,
-                    signature_summary=summary,
-                )
-            except UnknownTranscriptShapeError as exc:
-                console.print(
-                    f"[red]Error:[/red] {exc} "
-                    "Inspect the payload with --dry-run-redaction first."
-                )
-                raise typer.Exit(1) from exc
-            submission_config = OssRemoteSubmissionConfig(intake_url=intake_url)
-            result = post_oss_submission(
-                config=submission_config, submission=submission
-            )
-    except RemoteSubmissionError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1) from exc
-
-    if (
-        result.server_contract_version is not None
-        and result.server_contract_version != SUPPORTED_CONTRACT_VERSION
-    ):
-        console.print(
-            f"[yellow]Deprecation:[/yellow] intake server advertises "
-            f"{result.server_contract_version}; this client is on "
-            f"{SUPPORTED_CONTRACT_VERSION}. The server is in its post-bump "
-            "deprecation window: submissions are still accepted, but the "
-            "server operator should upgrade before the window closes."
-        )
-
-    response = result.response
-    console.print(
-        f"Submitted. submission_id={response.submission_id} status={response.processing_status}"
+    run_submit(
+        path=path,
+        source_session_id=source_session_id,
+        workflow_reference=workflow_reference,
+        project_reference=project_reference,
+        source_report_id=source_report_id,
+        agent_id=agent_id,
+        model_name=model_name,
+        model_version=model_version,
+        dry_run_redaction=dry_run_redaction,
+        show_manifest=show_manifest,
+        force_unknown_shape=force_unknown_shape,
+        include_analysis=include_analysis,
+        tier=tier,
+        environment=environment,
+        _post_oss_submission=post_oss_submission,
+        _submit_oss_via_presigned_upload=submit_oss_via_presigned_upload,
+        _submit_teams_via_presigned_upload=submit_teams_via_presigned_upload,
+        _build_signature_summary_from_session=build_signature_summary_from_session,
     )
 
 

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -89,7 +89,7 @@ def telemetry_remote_disable() -> None:
     )
 
 
-@app.command("submit-session")
+@app.command("submit-session", hidden=True)
 def telemetry_submit_session(
     path: Path = typer.Option(..., "--path", help="JSON file with the finished session payload."),
     source_session_id: str | None = typer.Option(
@@ -184,6 +184,11 @@ def telemetry_submit_session(
     workflow references are what let downstream analysis tell repeat workflows
     apart; leaving every submission on ``"default"`` hides that signal.
     """
+    typer.echo(
+        "Deprecated: `telemetry submit-session` is renamed to `driftshield submit`. "
+        "Please use `driftshield submit`.",
+        err=True,
+    )
     run_submit(
         path=path,
         source_session_id=source_session_id,

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -9,12 +9,6 @@ import typer
 from rich.console import Console
 
 from driftshield.cli._submit import run_submit
-from driftshield.cli._signature_summary import build_signature_summary_from_session
-from driftshield.remote_submission import post_oss_submission
-from driftshield.remote_upload import (
-    submit_oss_via_presigned_upload,
-    submit_teams_via_presigned_upload,
-)
 from driftshield.telemetry import (
     TelemetryService,
     effective_oss_intake_url,
@@ -205,10 +199,6 @@ def telemetry_submit_session(
         include_analysis=include_analysis,
         tier=tier,
         environment=environment,
-        _post_oss_submission=post_oss_submission,
-        _submit_oss_via_presigned_upload=submit_oss_via_presigned_upload,
-        _submit_teams_via_presigned_upload=submit_teams_via_presigned_upload,
-        _build_signature_summary_from_session=build_signature_summary_from_session,
     )
 
 

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -165,7 +165,7 @@ def telemetry_submit_session(
         ),
     ),
 ) -> None:
-    """Build a phase3g.v1 envelope from a finished session JSON and POST once to the OSS intake URL.
+    """Build a phase3g.v1 envelope from a finished session JSON and POST once to the configured intake URL (OSS community lane or authenticated Teams lane).
 
     The OSS lane is unauthenticated. No X-API-Key header is sent, no installation_id
     or consent_state is included in the request. The server binds the persisted row

--- a/driftshield/src/driftshield/cli/main.py
+++ b/driftshield/src/driftshield/cli/main.py
@@ -13,6 +13,7 @@ from driftshield.cli.commands.list import list_sessions
 from driftshield.cli.commands.report import report_command
 from driftshield.cli.commands.show_result import show_result
 from driftshield.cli.commands.signatures import app as signatures_app
+from driftshield.cli.commands.submit import submit
 from driftshield.cli.commands.telemetry import app as telemetry_app
 
 app = typer.Typer(
@@ -30,6 +31,7 @@ app.command(name="export-validations")(export_validations)
 app.command(name="generate-fixtures")(generate_fixtures)
 app.command()(ingest)
 app.command(name="show-result")(show_result)
+app.command()(submit)
 app.add_typer(connectors_app, name="connectors")
 app.add_typer(signatures_app, name="signatures")
 app.add_typer(telemetry_app, name="telemetry")

--- a/driftshield/src/driftshield/intake_contract.py
+++ b/driftshield/src/driftshield/intake_contract.py
@@ -1,6 +1,6 @@
 """Intake submission contract (OSS side).
 
-Pydantic models for the request body that ``driftshield submit-session``
+Pydantic models for the request body that ``driftshield submit``
 sends to the configured intake server. The server validates the same
 shape and rejects with HTTP 422 when ``envelope_contract_version`` or
 ``schema_version`` are not in ``ACCEPTED_CONTRACT_VERSIONS``. Keep

--- a/driftshield/tests/cli/test_ingest.py
+++ b/driftshield/tests/cli/test_ingest.py
@@ -199,7 +199,7 @@ def test_build_multipart_body_uses_basename_for_uploaded_filename():
     assert str(transcript) not in decoded
 
 
-def test_build_multipart_body_includes_teams_context_and_source_connector_metadata():
+def test_build_multipart_body_includes_oss_tier_and_source_connector_metadata():
     transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
 
     body = _build_multipart_body(
@@ -207,9 +207,7 @@ def test_build_multipart_body_includes_teams_context_and_source_connector_metada
         file_path=transcript,
         parser="claude_code",
         submission_context=SubmissionContext(
-            submission_tier="teams",
-            tenant_id="tenant-acme",
-            workspace_id="workspace-core",
+            submission_tier="oss",
             workflow_reference="wf-triage",
             project_reference="proj-risk",
             source_connector=SourceConnectorMetadata(
@@ -223,11 +221,9 @@ def test_build_multipart_body_includes_teams_context_and_source_connector_metada
 
     decoded = body.decode("utf-8", errors="ignore")
     assert 'name="submission_tier"' in decoded
-    assert "teams" in decoded
-    assert 'name="tenant_id"' in decoded
-    assert "tenant-acme" in decoded
-    assert 'name="workspace_id"' in decoded
-    assert "workspace-core" in decoded
+    assert "oss" in decoded
+    assert 'name="tenant_id"' not in decoded
+    assert 'name="workspace_id"' not in decoded
     assert 'name="workflow_reference"' in decoded
     assert "wf-triage" in decoded
     assert 'name="project_reference"' in decoded
@@ -237,127 +233,16 @@ def test_build_multipart_body_includes_teams_context_and_source_connector_metada
     assert '"display_name": "Core Claude"' in decoded
 
 
-def test_build_submission_context_rejects_teams_without_tenant_id():
-    with pytest.raises(ValueError, match="tenant_id is required"):
-        build_submission_context(
-            api_url="https://driftshield.example",
-            api_key="secret-key",
-            submission_tier="teams",
-            tenant_id=None,
-            workspace_id=None,
-            workflow_reference=None,
-            project_reference=None,
-            source_connector=SourceConnectorMetadata(),
-        )
+def test_ingest_has_no_teams_options():
+    result = runner.invoke(app, ["ingest", "--help"])
+    assert "--submission-tier" not in result.output
+    assert "--tenant-id" not in result.output
+    assert "--workspace-id" not in result.output
 
 
-def test_build_submission_context_uses_server_resolved_tenant_values(monkeypatch):
-    def fake_resolve(*, api_url: str, api_key: str, tenant_id: str, workspace_id: str | None):
-        assert api_url == "https://driftshield.example"
-        assert api_key == "secret-key"
-        assert tenant_id == "tenant-claimed"
-        assert workspace_id == "workspace-claimed"
-        return {
-            "tenant_id": "tenant-resolved",
-            "workspace_id": "workspace-resolved",
-            "service_identity_id": "svc_123",
-        }
-
-    monkeypatch.setattr(
-        "driftshield.cli.commands.ingest.resolve_teams_submission_context",
-        fake_resolve,
-    )
-
-    context = build_submission_context(
-        api_url="https://driftshield.example",
-        api_key="secret-key",
-        submission_tier="teams",
-        tenant_id="tenant-claimed",
-        workspace_id="workspace-claimed",
-        workflow_reference="wf-1",
-        project_reference="proj-1",
-        source_connector=SourceConnectorMetadata(connector_id="connector-1"),
-    )
-
-    assert context == SubmissionContext(
-        submission_tier="teams",
-        tenant_id="tenant-resolved",
-        workspace_id="workspace-resolved",
-        workflow_reference="wf-1",
-        project_reference="proj-1",
-        source_connector=SourceConnectorMetadata(connector_id="connector-1"),
-    )
-
-
-def test_ingest_teams_submission_uses_server_resolved_context(monkeypatch):
-    captured: dict[str, object] = {}
-
-    def fake_build_submission_context(**kwargs):
-        captured["build_kwargs"] = kwargs
-        return SubmissionContext(
-            submission_tier="teams",
-            tenant_id="tenant-resolved",
-            workspace_id="workspace-resolved",
-        )
-
-    def fake_post_ingest(*, target_url: str, api_key: str, file_path: Path, parser: str, submission_context: SubmissionContext):
-        captured["post"] = {
-            "target_url": target_url,
-            "api_key": api_key,
-            "file_path": file_path,
-            "parser": parser,
-            "submission_context": submission_context,
-        }
-        return DummyResponse()._payload
-
-    monkeypatch.setenv("DRIFTSHIELD_API_URL", "https://driftshield.example")
-    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "secret-key")
-    monkeypatch.setattr("driftshield.cli.commands.ingest.build_submission_context", fake_build_submission_context)
-    monkeypatch.setattr("driftshield.cli.commands.ingest.post_ingest", fake_post_ingest)
-
-    transcript = FIXTURES_DIR / "sample_claude_code_session.jsonl"
-    result = runner.invoke(
-        app,
-        [
-            "ingest",
-            "--path",
-            str(transcript),
-            "--submission-tier",
-            "teams",
-            "--tenant-id",
-            "tenant-claimed",
-            "--workspace-id",
-            "workspace-claimed",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert captured["build_kwargs"] == {
-        "api_url": "https://driftshield.example",
-        "api_key": "secret-key",
-        "submission_tier": "teams",
-        "tenant_id": "tenant-claimed",
-        "workspace_id": "workspace-claimed",
-        "workflow_reference": None,
-        "project_reference": None,
-        "source_connector": SourceConnectorMetadata(
-            connector_id=None,
-            source_type=None,
-            display_name=None,
-            parser_name=None,
-        ),
-    }
-    assert captured["post"] == {
-        "target_url": "https://driftshield.example/api/ingest",
-        "api_key": "secret-key",
-        "file_path": transcript,
-        "parser": "claude_code",
-        "submission_context": SubmissionContext(
-            submission_tier="teams",
-            tenant_id="tenant-resolved",
-            workspace_id="workspace-resolved",
-        ),
-    }
+def test_resolve_teams_submission_context_is_gone():
+    import driftshield.cli.commands.ingest as ingest_mod
+    assert not hasattr(ingest_mod, "resolve_teams_submission_context")
 
 
 # ---------------------------------------------------------------------------

--- a/driftshield/tests/cli/test_show_result.py
+++ b/driftshield/tests/cli/test_show_result.py
@@ -318,7 +318,7 @@ def test_zero_config_submit_then_show_result_roundtrip(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     submit = runner.invoke(

--- a/driftshield/tests/cli/test_submit.py
+++ b/driftshield/tests/cli/test_submit.py
@@ -29,7 +29,7 @@ def test_run_submit_importable_and_callable():
     assert callable(run_submit)
 
 
-_OSS_TEST_INTAKE_URL = "https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/oss/submissions"
+_OSS_TEST_INTAKE_URL = "https://intake.example.test/v1/oss/submissions"
 
 
 def _remote_enable_argv(*, intake_url: str = _OSS_TEST_INTAKE_URL) -> list[str]:

--- a/driftshield/tests/cli/test_submit.py
+++ b/driftshield/tests/cli/test_submit.py
@@ -95,13 +95,19 @@ def test_submit_session_hidden_from_help():
 
 
 def test_submit_session_emits_deprecation(tmp_path, monkeypatch):
+    # Use a local runner so we can inspect separated streams independently.
+    # Click 8.2+ always separates stderr; CliRunner() needs no extra arguments.
+    local_runner = CliRunner()
     monkeypatch.setattr("driftshield.cli._submit.post_oss_submission", _fake_post_ok(monkeypatch))
     monkeypatch.setenv("DRIFTSHIELD_TELEMETRY_HOME", str(tmp_path / "tele"))
     session = _write_session(tmp_path)
-    result = runner.invoke(app, ["telemetry", "submit-session", "--path", str(session)])
+    result = local_runner.invoke(app, ["telemetry", "submit-session", "--path", str(session)])
     assert result.exit_code == 0, result.output
-    assert "deprecated" in result.output.lower()
-    assert "driftshield submit" in result.output
+    # Deprecation notice must appear on stderr.
+    assert "deprecated" in result.stderr.lower()
+    assert "driftshield submit" in result.stderr
+    # Stdout stays clean for scripting — no deprecation text on stdout.
+    assert "deprecated" not in result.stdout.lower()
 
 
 def test_submit_teams_tier_uses_authenticated_presigned_upload(tmp_path, monkeypatch):

--- a/driftshield/tests/cli/test_submit.py
+++ b/driftshield/tests/cli/test_submit.py
@@ -73,6 +73,37 @@ def test_submit_help_has_no_telemetry_framing():
     assert "telemetry" not in result.output.lower()
 
 
+def _fake_post_ok(monkeypatch):
+    """Return a fake_post callable that satisfies driftshield.cli._submit.post_oss_submission."""
+    def fake_post(*, config, submission):
+        class _Resp:
+            submission_id = "sub_test"
+            processing_status = "received"
+
+        class _Result:
+            response = _Resp()
+            server_contract_version = None
+
+        return _Result()
+
+    return fake_post
+
+
+def test_submit_session_hidden_from_help():
+    result = runner.invoke(app, ["telemetry", "--help"])
+    assert "submit-session" not in result.output
+
+
+def test_submit_session_emits_deprecation(tmp_path, monkeypatch):
+    monkeypatch.setattr("driftshield.cli._submit.post_oss_submission", _fake_post_ok(monkeypatch))
+    monkeypatch.setenv("DRIFTSHIELD_TELEMETRY_HOME", str(tmp_path / "tele"))
+    session = _write_session(tmp_path)
+    result = runner.invoke(app, ["telemetry", "submit-session", "--path", str(session)])
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.output.lower()
+    assert "driftshield submit" in result.output
+
+
 def test_submit_teams_tier_uses_authenticated_presigned_upload(tmp_path, monkeypatch):
     captured = {}
 

--- a/driftshield/tests/cli/test_submit.py
+++ b/driftshield/tests/cli/test_submit.py
@@ -27,3 +27,77 @@ def _write_session(tmp_path: Path) -> Path:
 def test_run_submit_importable_and_callable():
     from driftshield.cli._submit import run_submit
     assert callable(run_submit)
+
+
+_OSS_TEST_INTAKE_URL = "https://snidz3uiv5.execute-api.eu-west-2.amazonaws.com/v1/oss/submissions"
+
+
+def _remote_enable_argv(*, intake_url: str = _OSS_TEST_INTAKE_URL) -> list[str]:
+    return ["telemetry", "remote-enable", "--intake-url", intake_url]
+
+
+def test_submit_oss_inline_redacts_and_posts(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_post(*, config, submission):
+        captured["intake_url"] = config.intake_url
+        captured["request"] = submission
+
+        class _Resp:
+            submission_id = "sub_test"
+            processing_status = "received"
+
+        class _Result:
+            response = _Resp()
+            server_contract_version = None
+
+        return _Result()
+
+    monkeypatch.setattr("driftshield.cli._submit.post_oss_submission", fake_post)
+    monkeypatch.setenv("DRIFTSHIELD_TELEMETRY_HOME", str(tmp_path / "tele"))
+    session = _write_session(tmp_path)
+
+    result = runner.invoke(app, ["submit", "--path", str(session)])
+    assert result.exit_code == 0, result.output
+    assert "sub_test" in result.output
+
+
+def test_submit_appears_in_help():
+    result = runner.invoke(app, ["--help"])
+    assert "submit" in result.output
+
+
+def test_submit_help_has_no_telemetry_framing():
+    result = runner.invoke(app, ["submit", "--help"])
+    assert result.exit_code == 0
+    assert "telemetry" not in result.output.lower()
+
+
+def test_submit_teams_tier_uses_authenticated_presigned_upload(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_teams_upload(*, config, payload, workflow_reference, file_name, provenance):
+        captured["api_key"] = config.api_key
+        captured["intake_url"] = config.intake_url
+
+        class _Resp:
+            submission_id = "sub_teams"
+            processing_status = "received"
+
+        class _Result:
+            response = _Resp()
+            server_contract_version = None
+
+        return _Result()
+
+    monkeypatch.setattr(
+        "driftshield.cli._submit.submit_teams_via_presigned_upload", fake_teams_upload
+    )
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "test-key")
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    runner.invoke(app, _remote_enable_argv())
+    session = _write_session(tmp_path)
+    result = runner.invoke(app, ["submit", "--path", str(session), "--tier", "teams"])
+    assert result.exit_code == 0, result.output
+    assert captured["api_key"] == "test-key"
+    assert "sub_teams" in result.output

--- a/driftshield/tests/cli/test_submit.py
+++ b/driftshield/tests/cli/test_submit.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from driftshield.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_session(tmp_path: Path) -> Path:
+    # Minimal OpenClaw-shaped session the redactor recognises.
+    session = {
+        "events": [
+            {"type": "session", "session_id": "s1"},
+            {"type": "message", "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]}},
+        ],
+        "metadata": {},
+    }
+    p = tmp_path / "session.json"
+    p.write_text(json.dumps(session))
+    return p
+
+
+def test_run_submit_importable_and_callable():
+    from driftshield.cli._submit import run_submit
+    assert callable(run_submit)

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -335,7 +335,7 @@ def test_submit_session_happy_path(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission",
+        "driftshield.cli._submit.post_oss_submission",
         fake_post,
     )
 
@@ -368,7 +368,7 @@ def test_submit_session_defaults_workflow_reference_to_default(tmp_path, monkeyp
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -394,7 +394,7 @@ def test_submit_session_prefers_session_json_workflow_reference(tmp_path, monkey
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -420,7 +420,7 @@ def test_submit_session_flag_overrides_session_json_workflow_reference(tmp_path,
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -452,7 +452,7 @@ def test_submit_session_logs_deprecation_warning_when_server_on_phase3f_v1(
         return _ok_result(server_contract_version="phase3f.v1")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -475,7 +475,7 @@ def test_submit_session_no_deprecation_warning_when_server_on_phase3g_v1(
         return _ok_result(server_contract_version="phase3g.v1")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -551,7 +551,7 @@ def test_submit_session_dry_run_redaction_prints_entries_and_does_not_submit(
         called["posted"] = True
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -592,7 +592,7 @@ def test_submit_session_show_manifest_prints_manifest_and_does_not_submit(
         called["posted"] = True
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -624,7 +624,7 @@ def test_submit_session_show_manifest_matches_real_submission_manifest(
     payload = {"session_id": "sess-1", "events": []}
     session_path = _write_session(tmp_path, payload)
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission",
+        "driftshield.cli._submit.post_oss_submission",
         lambda **_: (_ for _ in ()).throw(AssertionError("must not submit")),
     )
 
@@ -668,7 +668,7 @@ def test_submit_session_accepts_unknown_shape_when_forced(tmp_path, monkeypatch)
         return _ok_result(submission_id="sub_forced")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -697,7 +697,7 @@ def test_submit_session_surfaces_remote_error(tmp_path, monkeypatch):
         raise RemoteSubmissionError("intake HTTP 422: invalid_redaction_manifest")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission",
+        "driftshield.cli._submit.post_oss_submission",
         fake_post,
     )
 
@@ -727,7 +727,7 @@ def test_submit_session_default_no_signature_summary(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -774,10 +774,10 @@ def test_submit_session_with_include_analysis_populates_signature_summary(
     )
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.build_signature_summary_from_session",
+        "driftshield.cli._submit.build_signature_summary_from_session",
         lambda _path: fake_summary,
     )
 
@@ -819,10 +819,10 @@ def test_submit_session_include_analysis_strict_fail_on_builder_error(
         raise RuntimeError("matcher exploded")
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.build_signature_summary_from_session", boom
+        "driftshield.cli._submit.build_signature_summary_from_session", boom
     )
 
     result = runner.invoke(
@@ -870,10 +870,10 @@ def test_submit_session_include_analysis_empty_matches_is_valid_success(
     )
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.build_signature_summary_from_session",
+        "driftshield.cli._submit.build_signature_summary_from_session",
         lambda _path: empty_summary,
     )
 
@@ -927,7 +927,7 @@ def test_submit_session_accepts_jsonl_input(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -974,11 +974,11 @@ def test_submit_session_large_oss_routes_to_presigned_upload(tmp_path, monkeypat
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.submit_oss_via_presigned_upload",
+        "driftshield.cli._submit.submit_oss_via_presigned_upload",
         fake_presigned,
     )
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_inline
+        "driftshield.cli._submit.post_oss_submission", fake_inline
     )
 
     result = runner.invoke(
@@ -1005,11 +1005,11 @@ def test_submit_session_small_oss_stays_inline(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.submit_oss_via_presigned_upload",
+        "driftshield.cli._submit.submit_oss_via_presigned_upload",
         fake_presigned,
     )
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_inline
+        "driftshield.cli._submit.post_oss_submission", fake_inline
     )
 
     result = runner.invoke(
@@ -1033,7 +1033,7 @@ def test_submit_session_teams_tier_uses_teams_lane_with_api_key(tmp_path, monkey
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.submit_teams_via_presigned_upload",
+        "driftshield.cli._submit.submit_teams_via_presigned_upload",
         fake_teams,
     )
 
@@ -1079,7 +1079,7 @@ def test_submit_session_oss_defaults_to_community_intake_url(tmp_path, monkeypat
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1108,7 +1108,7 @@ def test_submit_session_oss_default_url_applies_to_presigned_lane(tmp_path, monk
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.submit_oss_via_presigned_upload",
+        "driftshield.cli._submit.submit_oss_via_presigned_upload",
         fake_presigned,
     )
 
@@ -1133,7 +1133,7 @@ def test_submit_session_remote_enable_overrides_default_url(tmp_path, monkeypatc
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1163,7 +1163,7 @@ def test_submit_session_oss_defaults_environment_to_production_inline(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1191,7 +1191,7 @@ def test_submit_session_oss_defaults_environment_to_production_presigned(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.submit_oss_via_presigned_upload",
+        "driftshield.cli._submit.submit_oss_via_presigned_upload",
         fake_presigned,
     )
 
@@ -1216,7 +1216,7 @@ def test_submit_session_environment_flag_overrides_production_default(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1254,7 +1254,7 @@ def test_submit_session_preserves_environment_declared_in_session_json(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1281,7 +1281,7 @@ def test_submit_session_environment_flag_wins_over_session_json_value(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1314,7 +1314,7 @@ def test_submit_session_rejects_invalid_environment(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1377,7 +1377,7 @@ def test_submit_session_teams_tier_does_not_stamp_environment(tmp_path, monkeypa
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.submit_teams_via_presigned_upload",
+        "driftshield.cli._submit.submit_teams_via_presigned_upload",
         fake_teams,
     )
 
@@ -1417,7 +1417,7 @@ def test_community_lane_payload_classifies_production_submitter_declared(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1457,7 +1457,7 @@ def test_remote_disable_blocks_community_default(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1483,7 +1483,7 @@ def test_remote_enable_after_disable_restores_submission(tmp_path, monkeypatch):
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1596,7 +1596,7 @@ def test_submit_session_openclaw_trajectory_stamps_real_provenance(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(
@@ -1636,7 +1636,7 @@ def test_submit_session_explicit_provenance_flags_win_over_derived(
         return _ok_result()
 
     monkeypatch.setattr(
-        "driftshield.cli.commands.telemetry.post_oss_submission", fake_post
+        "driftshield.cli._submit.post_oss_submission", fake_post
     )
 
     result = runner.invoke(


### PR DESCRIPTION
## Summary

- Adds `driftshield submit` as the canonical customer upload command for finished sessions. It redacts the transcript locally before upload, supports the OSS community lane (`--tier oss`, default) and the authenticated Teams lane (`--tier teams`, needs `DRIFTSHIELD_API_KEY`), and accepts `--include-analysis` to attach the local matcher verdict.
- The upload logic is extracted into one shared `run_submit(...)` in `driftshield/cli/_submit.py`. `driftshield submit` and the legacy `telemetry submit-session` both delegate to it, so there is one implementation, not two.
- `telemetry submit-session` becomes a hidden, deprecated alias. It still works and prints a one-line deprecation notice to stderr pointing at `driftshield submit`. The other `telemetry` subcommands (status/enable/disable/heartbeat/remote-enable/remote-disable/emit-analysis) are unchanged.
- `ingest` is now an OSS self-host-only command. Its unused tier branch (the `--submission-tier teams` path with `--tenant-id`/`--workspace-id` and the auth-check tenant resolution) is removed; it uploads to the bundled local `/api/ingest` server as before.
- Docs reframed: README and AGENTS.md present `driftshield submit` as the customer upload command and `ingest` as the self-host feeder. The customer upload is no longer framed as "telemetry".

Why: the customer upload path was buried under the internal term "telemetry" while the README advertised a raw, un-redacted local-API upload as the headline. This makes one clear, redaction-first command the customer path and removes the duplicate/dead surface.

## Verification

- [x] Automated tests run — `pytest tests/cli/` 183 passed, 0 failed
- [ ] Browser flow exercised if UI changed — n/a (CLI only)
- [x] CLI flow exercised if command behavior changed — `driftshield submit` (OSS inline + Teams presigned), deprecation notice on the alias (asserted stderr-only), `ingest` OSS path, and the removal of the Teams flags are all covered by tests

## Links

Closes #

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- Option-schema duplication (drift risk, not a bug here): the 14 `typer.Option` declarations are duplicated between `submit.py` and the hidden `telemetry submit-session` alias. Behaviour is centralised in `run_submit`, but the option signatures are not shared, so a future flag edit could diverge the two surfaces. De-duplicating cleanly needs a small factory/decorator (Typer keeps option defaults in the signature), so it is a separate follow-up rather than part of this PR.
- Minor (non-blocking): `ingest.py` copies `submission_tier` in the include-analysis block where the literal `"oss"` would be clearer now that only the OSS lane remains.

