### PR TITLE
feat(cli): default the teams tier to production env and allow --environment override

### DIFF
--- a/driftshield/src/driftshield/cli/_submit.py
+++ b/driftshield/src/driftshield/cli/_submit.py
@@ -124,12 +124,6 @@ def run_submit(
                 f"[red]Error:[/red] --environment must be one of: {valid}."
             )
             raise typer.Exit(1)
-        if resolved_tier != "oss":
-            console.print(
-                "[red]Error:[/red] --environment applies to the community "
-                "(oss) lane only."
-            )
-            raise typer.Exit(1)
 
     config = TelemetryService().load_config()
     if resolved_tier == "oss":
@@ -200,21 +194,23 @@ def run_submit(
     if model_name is None:
         model_name = derived_provenance.get("model_name")
 
-    # Community opt-in is the production declaration: stamp the declared
-    # environment before redaction so it rides both the inline and the
-    # presigned lanes. An environment already declared in the session JSON
-    # is kept; --environment wins over everything.
-    if resolved_tier == "oss":
-        metadata = payload.get("metadata")
-        if not isinstance(metadata, dict):
-            # The envelope contract expects a metadata mapping; a malformed
-            # value cannot carry the declared environment.
-            metadata = {}
-            payload["metadata"] = metadata
-        if resolved_environment is not None:
-            metadata["environment"] = resolved_environment
-        else:
-            metadata.setdefault("environment", EnvironmentClass.PRODUCTION.value)
+    # Submitting is the production declaration on both lanes: stamp the declared
+    # environment before redaction so it rides both the inline and the presigned
+    # lanes. An environment already declared in the session JSON is kept;
+    # --environment wins over everything. Both tiers default to production (an
+    # explicit non-production contribution is the uncommon case), so the hosted
+    # investigation always lands a declared environment rather than an
+    # undeclared run.
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        # The envelope contract expects a metadata mapping; a malformed
+        # value cannot carry the declared environment.
+        metadata = {}
+        payload["metadata"] = metadata
+    if resolved_environment is not None:
+        metadata["environment"] = resolved_environment
+    else:
+        metadata.setdefault("environment", EnvironmentClass.PRODUCTION.value)
 
     # Redact once to measure the canonical size (uncapped) and decide the
     # lane. The size-capped SubmissionEnvelope model is only built on the

--- a/driftshield/src/driftshield/cli/commands/submit.py
+++ b/driftshield/src/driftshield/cli/commands/submit.py
@@ -77,10 +77,9 @@ def submit(
         None,
         "--environment",
         help=(
-            "Declared run environment for the community (oss) lane: "
-            "production, staging, test, or demo. Community opt-in declares "
-            "production by default; pass this only for the uncommon "
-            "non-production contribution."
+            "Declared run environment: production, staging, test, or demo. "
+            "Both lanes declare production by default; pass this only for the "
+            "uncommon non-production contribution."
         ),
     ),
 ) -> None:

--- a/driftshield/src/driftshield/cli/commands/telemetry.py
+++ b/driftshield/src/driftshield/cli/commands/telemetry.py
@@ -158,10 +158,9 @@ def telemetry_submit_session(
         None,
         "--environment",
         help=(
-            "Declared run environment for the community (oss) lane: "
-            "production, staging, test, or demo. Community opt-in declares "
-            "production by default; pass this only for the uncommon "
-            "non-production contribution."
+            "Declared run environment: production, staging, test, or demo. "
+            "Both lanes declare production by default; pass this only for the "
+            "uncommon non-production contribution."
         ),
     ),
 ) -> None:

--- a/driftshield/tests/cli/test_telemetry.py
+++ b/driftshield/tests/cli/test_telemetry.py
@@ -1336,12 +1336,25 @@ def test_submit_session_rejects_invalid_environment(tmp_path, monkeypatch):
     assert submitted["called"] is False
 
 
-def test_submit_session_environment_flag_rejected_on_teams_tier(tmp_path, monkeypatch):
-    """--environment is a community-lane flag; teams behaviour stays untouched."""
+def test_submit_session_environment_flag_accepted_on_teams_tier(tmp_path, monkeypatch):
+    """--environment now applies to the teams lane too (mirror of the oss lane):
+    an explicit value overrides the production default and is stamped on the
+    payload metadata so the hosted investigation reaches recurrence-eligibility."""
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     monkeypatch.setenv("DRIFTSHIELD_API_KEY", "ds_teams_key")
     runner.invoke(app, _remote_enable_argv())
     session_path = _write_session(tmp_path, {"session_id": "sess-1"})
+
+    captured = {}
+
+    def fake_teams(*, config, payload, workflow_reference, file_name, mode="file", provenance=None, opener=None):  # noqa: ARG001
+        captured["metadata"] = payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli._submit.submit_teams_via_presigned_upload",
+        fake_teams,
+    )
 
     result = runner.invoke(
         app,
@@ -1353,16 +1366,18 @@ def test_submit_session_environment_flag_rejected_on_teams_tier(tmp_path, monkey
             "--tier",
             "teams",
             "--environment",
-            "production",
+            "staging",
         ],
     )
 
-    assert result.exit_code == 1
-    assert "oss" in result.stdout
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "staging"
 
 
-def test_submit_session_teams_tier_does_not_stamp_environment(tmp_path, monkeypatch):
-    """The production default is community-lane only; teams payloads stay as-is."""
+def test_submit_session_teams_tier_defaults_environment_to_production(tmp_path, monkeypatch):
+    """A teams submission with no --environment now defaults to production
+    (mirror of the oss lane), so the hosted investigation lands a declared
+    production environment instead of an undeclared run."""
     monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
     monkeypatch.setenv("DRIFTSHIELD_API_KEY", "ds_teams_key")
     runner.invoke(app, _remote_enable_argv())
@@ -1387,7 +1402,39 @@ def test_submit_session_teams_tier_does_not_stamp_environment(tmp_path, monkeypa
     )
 
     assert result.exit_code == 0
-    assert "environment" not in captured["metadata"]
+    assert captured["metadata"]["environment"] == "production"
+    # Pre-existing metadata is preserved alongside the declared environment.
+    assert captured["metadata"]["foo"] == "bar"
+
+
+def test_submit_session_teams_tier_keeps_environment_declared_in_session(tmp_path, monkeypatch):
+    """An environment already declared in the session JSON is kept; the
+    production default only fills in when none is declared (mirror of oss)."""
+    monkeypatch.setenv("DRIFTSHIELD_HOME", str(tmp_path))
+    monkeypatch.setenv("DRIFTSHIELD_API_KEY", "ds_teams_key")
+    runner.invoke(app, _remote_enable_argv())
+    session_path = _write_session(
+        tmp_path, {"session_id": "sess-1", "metadata": {"environment": "test"}}
+    )
+
+    captured = {}
+
+    def fake_teams(*, config, payload, workflow_reference, file_name, mode="file", provenance=None, opener=None):  # noqa: ARG001
+        captured["metadata"] = payload.get("metadata")
+        return _ok_result()
+
+    monkeypatch.setattr(
+        "driftshield.cli._submit.submit_teams_via_presigned_upload",
+        fake_teams,
+    )
+
+    result = runner.invoke(
+        app,
+        ["telemetry", "submit-session", "--path", str(session_path), "--tier", "teams"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["metadata"]["environment"] == "test"
 
 
 def test_community_lane_payload_classifies_production_submitter_declared(


### PR DESCRIPTION
## Summary

- `driftshield submit --tier teams` now mirrors the community lane for the declared run environment.
- It defaults `--environment` to `production` and accepts `--environment` as an override. Previously `--environment` was rejected on the teams tier and no default was stamped, so a teams submission landed an undeclared environment.
- Submitting is the production declaration on both lanes, so the hosted investigation always lands a declared environment rather than an undeclared run. An environment already declared in the session JSON is kept; `--environment` wins over everything.
- The deprecated `telemetry submit-session` alias delegates to the same `run_submit`, so it inherits the new behaviour automatically.

## Verification

- [x] Automated tests run — full CLI suite green (184 passed). New/updated tests: teams defaults to production, teams accepts `--environment` override, teams keeps a session-declared environment; the OSS lane defaults and override tests are unchanged.
- [ ] Browser flow exercised if UI changed — n/a (CLI only)
- [x] CLI flow exercised if command behavior changed — covered by the CLI test suite above

## Links

- Closes the CLI portion of the Phase 4a hosted-vs-local parity work.

## Workflow

- [x] Linked issue remains `In Progress` until this PR is merged
- [x] Project status and issue checkboxes will be synced when this PR lands
- [x] No references to private DriftShield repos or internal cross-repo planning docs were added to the public tree

## Follow-Ups

- None. This is a self-contained CLI change.
